### PR TITLE
fix: support codex api-key and fake launch preflight

### DIFF
--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -385,7 +384,7 @@ func (s *Service) buildSessionSpec(
 		command,
 		buildBaseArgs(providerItem.CliArgs, providerItem.ModelName),
 		workingDirectory,
-		authConfigEnvironment(providerItem.AuthConfig),
+		provider.AuthConfigEnvironment(providerItem.AuthConfig),
 		nil,
 		systemPrompt,
 		&s.maxTurns,
@@ -628,63 +627,6 @@ func hasModelFlag(args []string) bool {
 		}
 	}
 	return false
-}
-
-func authConfigEnvironment(authConfig map[string]any) []string {
-	if len(authConfig) == 0 {
-		return nil
-	}
-
-	keys := make([]string, 0, len(authConfig))
-	for key := range authConfig {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	env := make([]string, 0, len(keys))
-	for _, key := range keys {
-		value, ok := stringifyEnvValue(authConfig[key])
-		if !ok {
-			continue
-		}
-		env = append(env, normalizeEnvKey(key)+"="+value)
-	}
-	return env
-}
-
-func stringifyEnvValue(value any) (string, bool) {
-	switch typed := value.(type) {
-	case string:
-		return typed, true
-	case bool:
-		return strconv.FormatBool(typed), true
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64), true
-	case int:
-		return strconv.Itoa(typed), true
-	case json.Number:
-		return typed.String(), true
-	default:
-		return "", false
-	}
-}
-
-func normalizeEnvKey(raw string) string {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return ""
-	}
-	normalized := strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r - ('a' - 'A')
-		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			return r
-		default:
-			return '_'
-		}
-	}, trimmed)
-	return strings.Trim(normalized, "_")
 }
 
 func parseSource(raw string) (Source, error) {

--- a/internal/domain/catalog/machine_monitor.go
+++ b/internal/domain/catalog/machine_monitor.go
@@ -52,11 +52,20 @@ const (
 	MachineAgentAuthStatusNotLoggedIn MachineAgentAuthStatus = "not_logged_in"
 )
 
+type MachineAgentAuthMode string
+
+const (
+	MachineAgentAuthModeUnknown MachineAgentAuthMode = "unknown"
+	MachineAgentAuthModeLogin   MachineAgentAuthMode = "login"
+	MachineAgentAuthModeAPIKey  MachineAgentAuthMode = "api_key"
+)
+
 type MachineAgentCLI struct {
 	Name       string
 	Installed  bool
 	Version    string
 	AuthStatus MachineAgentAuthStatus
+	AuthMode   MachineAgentAuthMode
 	Ready      bool
 }
 
@@ -204,8 +213,8 @@ func ParseMachineAgentEnvironment(raw string, collectedAt time.Time) (MachineAge
 
 	parsed := make(map[string]MachineAgentCLI, len(records))
 	for index, record := range records {
-		if len(record) != 4 {
-			return MachineAgentEnvironment{}, fmt.Errorf("agent environment row %d must have 4 columns", index)
+		if len(record) != 4 && len(record) != 5 {
+			return MachineAgentEnvironment{}, fmt.Errorf("agent environment row %d must have 4 or 5 columns", index)
 		}
 
 		name := strings.TrimSpace(record[0])
@@ -224,13 +233,21 @@ func ParseMachineAgentEnvironment(raw string, collectedAt time.Time) (MachineAge
 		if err != nil {
 			return MachineAgentEnvironment{}, fmt.Errorf("parse agent environment auth status on row %d: %w", index, err)
 		}
+		authMode := MachineAgentAuthModeUnknown
+		if len(record) == 5 {
+			authMode, err = parseMachineAgentAuthMode(record[4])
+			if err != nil {
+				return MachineAgentEnvironment{}, fmt.Errorf("parse agent environment auth mode on row %d: %w", index, err)
+			}
+		}
 
 		parsed[name] = MachineAgentCLI{
 			Name:       name,
 			Installed:  installed,
 			Version:    strings.TrimSpace(record[2]),
 			AuthStatus: authStatus,
-			Ready:      installed && authStatus != MachineAgentAuthStatusNotLoggedIn,
+			AuthMode:   authMode,
+			Ready:      installed && (authMode == MachineAgentAuthModeAPIKey || authStatus != MachineAgentAuthStatusNotLoggedIn),
 		}
 	}
 
@@ -410,6 +427,16 @@ func parseMachineAgentAuthStatus(raw string) (MachineAgentAuthStatus, error) {
 		return status, nil
 	default:
 		return "", fmt.Errorf("unsupported auth status %q", strings.TrimSpace(raw))
+	}
+}
+
+func parseMachineAgentAuthMode(raw string) (MachineAgentAuthMode, error) {
+	mode := MachineAgentAuthMode(strings.ToLower(strings.TrimSpace(raw)))
+	switch mode {
+	case MachineAgentAuthModeUnknown, MachineAgentAuthModeLogin, MachineAgentAuthModeAPIKey:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unsupported auth mode %q", strings.TrimSpace(raw))
 	}
 }
 

--- a/internal/domain/catalog/machine_monitor_test.go
+++ b/internal/domain/catalog/machine_monitor_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestParseMachineAgentEnvironment(t *testing.T) {
 	collectedAt := time.Date(2026, 3, 20, 18, 30, 0, 0, time.UTC)
-	raw := "claude_code\tfalse\t\tunknown\n" +
-		"codex\ttrue\t0.0.1\tlogged_in\n" +
-		"gemini\ttrue\t1.2.3\tunknown\n"
+	raw := "claude_code\tfalse\t\tunknown\tunknown\n" +
+		"codex\ttrue\t0.0.1\tunknown\tapi_key\n" +
+		"gemini\ttrue\t1.2.3\tunknown\tunknown\n"
 
 	environment, err := ParseMachineAgentEnvironment(raw, collectedAt)
 	if err != nil {
@@ -21,7 +21,7 @@ func TestParseMachineAgentEnvironment(t *testing.T) {
 	if len(environment.CLIs) != 3 {
 		t.Fatalf("expected three cli snapshots, got %+v", environment.CLIs)
 	}
-	if environment.CLIs[1].Name != "codex" || environment.CLIs[1].Version != "0.0.1" || !environment.CLIs[1].Ready {
+	if environment.CLIs[1].Name != "codex" || environment.CLIs[1].Version != "0.0.1" || environment.CLIs[1].AuthMode != MachineAgentAuthModeAPIKey || !environment.CLIs[1].Ready {
 		t.Fatalf("expected codex snapshot to be parsed, got %+v", environment.CLIs[1])
 	}
 	if environment.CLIs[2].Name != "gemini" || !environment.CLIs[2].Ready {

--- a/internal/infra/ssh/monitor.go
+++ b/internal/infra/ssh/monitor.go
@@ -61,28 +61,34 @@ if command -v claude >/dev/null 2>&1; then
   else
     claude_auth=not_logged_in
   fi
-  printf 'claude_code\ttrue\t%s\t%s\n' "$claude_version" "$claude_auth"
+  printf 'claude_code\ttrue\t%s\t%s\tlogin\n' "$claude_version" "$claude_auth"
 else
-  printf 'claude_code\tfalse\t\tunknown\n'
+  printf 'claude_code\tfalse\t\tunknown\tunknown\n'
 fi
 
 if [ -n "$codex_cmd" ]; then
   codex_version=$(sanitize_field "$("$codex_cmd" --version 2>/dev/null || echo unknown)")
-  if "$codex_cmd" login status 2>/dev/null | grep -q '^Logged in'; then
+  codex_auth_mode=unknown
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    codex_auth=unknown
+    codex_auth_mode=api_key
+  elif "$codex_cmd" login status 2>/dev/null | grep -q '^Logged in'; then
     codex_auth=logged_in
+    codex_auth_mode=login
   else
     codex_auth=not_logged_in
+    codex_auth_mode=login
   fi
-  printf 'codex\ttrue\t%s\t%s\n' "$codex_version" "$codex_auth"
+  printf 'codex\ttrue\t%s\t%s\t%s\n' "$codex_version" "$codex_auth" "$codex_auth_mode"
 else
-  printf 'codex\tfalse\t\tunknown\n'
+  printf 'codex\tfalse\t\tunknown\tunknown\n'
 fi
 
 if command -v gemini >/dev/null 2>&1; then
   gemini_version=$(sanitize_field "$(gemini --version 2>/dev/null || echo unknown)")
-  printf 'gemini\ttrue\t%s\tunknown\n' "$gemini_version"
+  printf 'gemini\ttrue\t%s\tunknown\tunknown\n' "$gemini_version"
 else
-  printf 'gemini\tfalse\t\tunknown\n'
+  printf 'gemini\tfalse\t\tunknown\tunknown\n'
 fi
 `
 	fullAuditScript = `
@@ -223,6 +229,7 @@ func (c *MonitorCollector) CollectFullAudit(ctx context.Context, machine domain.
 }
 
 func (c *MonitorCollector) runScript(ctx context.Context, machine domain.Machine, script string) ([]byte, error) {
+	script = prefixEnvironmentScript(machine.EnvVars, script)
 	if machine.Host == domain.LocalMachineHost {
 		if c == nil || c.runLocal == nil {
 			return nil, fmt.Errorf("local monitor runner unavailable")
@@ -269,4 +276,25 @@ func buildAgentEnvironmentScript(machine domain.Machine) string {
 	}
 
 	return strings.Replace(agentEnvironmentScriptTemplate, "__CODEX_PATH__", shellQuote(codexPath), 1)
+}
+
+func prefixEnvironmentScript(environment []string, script string) string {
+	if len(environment) == 0 {
+		return script
+	}
+
+	var builder strings.Builder
+	for _, entry := range environment {
+		name, value, found := strings.Cut(strings.TrimSpace(entry), "=")
+		if !found || strings.TrimSpace(name) == "" {
+			continue
+		}
+		builder.WriteString("export ")
+		builder.WriteString(name)
+		builder.WriteString("=")
+		builder.WriteString(shellQuote(value))
+		builder.WriteString("\n")
+	}
+	builder.WriteString(script)
+	return builder.String()
 }

--- a/internal/infra/ssh/monitor_test.go
+++ b/internal/infra/ssh/monitor_test.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,5 +58,38 @@ func TestMonitorCollectorCollectReachabilityLocalMachineSkipsPool(t *testing.T) 
 	}
 	if reachability.Transport != "local" || !reachability.Reachable {
 		t.Fatalf("unexpected local reachability result: %+v", reachability)
+	}
+}
+
+func TestMonitorCollectorCollectAgentEnvironmentInjectsMachineEnvVars(t *testing.T) {
+	var capturedScript string
+	collector := &MonitorCollector{
+		now: func() time.Time { return time.Date(2026, 3, 20, 17, 10, 0, 0, time.UTC) },
+		runLocal: func(_ context.Context, script string) ([]byte, error) {
+			capturedScript = script
+			return []byte(
+				"claude_code\tfalse\t\tunknown\tunknown\n" +
+					"codex\ttrue\t0.0.1\tunknown\tapi_key\n" +
+					"gemini\tfalse\t\tunknown\tunknown\n",
+			), nil
+		},
+	}
+
+	environment, err := collector.CollectAgentEnvironment(context.Background(), domain.Machine{
+		Name:    domain.LocalMachineName,
+		Host:    domain.LocalMachineHost,
+		EnvVars: []string{"OPENAI_API_KEY=sk-test", "PATH=/opt/codex/bin:/usr/bin"},
+	})
+	if err != nil {
+		t.Fatalf("collect agent environment: %v", err)
+	}
+	if !strings.Contains(capturedScript, "export OPENAI_API_KEY='sk-test'") {
+		t.Fatalf("expected OPENAI_API_KEY export in monitor script, got %q", capturedScript)
+	}
+	if !strings.Contains(capturedScript, "export PATH='/opt/codex/bin:/usr/bin'") {
+		t.Fatalf("expected PATH export in monitor script, got %q", capturedScript)
+	}
+	if environment.CLIs[1].AuthMode != domain.MachineAgentAuthModeAPIKey || !environment.CLIs[1].Ready {
+		t.Fatalf("expected codex api-key snapshot to be ready, got %+v", environment.CLIs[1])
 	}
 }

--- a/internal/orchestrator/machine_monitor.go
+++ b/internal/orchestrator/machine_monitor.go
@@ -429,6 +429,7 @@ func updateL4Resources(resources map[string]any, agentEnvironment domain.Machine
 			"installed":   cli.Installed,
 			"version":     cli.Version,
 			"auth_status": string(cli.AuthStatus),
+			"auth_mode":   string(cli.AuthMode),
 			"ready":       cli.Ready,
 		}
 		levelMap[cli.Name] = cloneResourceMap(snapshot)

--- a/internal/orchestrator/machine_monitor_test.go
+++ b/internal/orchestrator/machine_monitor_test.go
@@ -295,9 +295,9 @@ func TestMachineMonitorRunTickCapturesL4AndL5WithoutChangingMachineStatus(t *tes
 			CollectedAt:  now,
 			Dispatchable: true,
 			CLIs: []domain.MachineAgentCLI{
-				{Name: "claude_code", Installed: false, AuthStatus: domain.MachineAgentAuthStatusUnknown},
-				{Name: "codex", Installed: true, Version: "0.0.1", AuthStatus: domain.MachineAgentAuthStatusLoggedIn, Ready: true},
-				{Name: "gemini", Installed: true, Version: "1.2.3", AuthStatus: domain.MachineAgentAuthStatusUnknown, Ready: true},
+				{Name: "claude_code", Installed: false, AuthStatus: domain.MachineAgentAuthStatusUnknown, AuthMode: domain.MachineAgentAuthModeUnknown},
+				{Name: "codex", Installed: true, Version: "0.0.1", AuthStatus: domain.MachineAgentAuthStatusLoggedIn, AuthMode: domain.MachineAgentAuthModeLogin, Ready: true},
+				{Name: "gemini", Installed: true, Version: "1.2.3", AuthStatus: domain.MachineAgentAuthStatusUnknown, AuthMode: domain.MachineAgentAuthModeUnknown, Ready: true},
 			},
 		},
 		fullAudit: domain.MachineFullAudit{
@@ -343,7 +343,7 @@ func TestMachineMonitorRunTickCapturesL4AndL5WithoutChangingMachineStatus(t *tes
 	monitorMap := machineAfter.Resources["monitor"].(map[string]any)
 	l4 := monitorMap["l4"].(map[string]any)
 	codex := l4["codex"].(map[string]any)
-	if codex["installed"] != true || codex["auth_status"] != "logged_in" || codex["ready"] != true {
+	if codex["installed"] != true || codex["auth_status"] != "logged_in" || codex["auth_mode"] != "login" || codex["ready"] != true {
 		t.Fatalf("expected codex l4 snapshot, got %+v", codex)
 	}
 

--- a/internal/orchestrator/runtime_launcher.go
+++ b/internal/orchestrator/runtime_launcher.go
@@ -374,7 +374,8 @@ func (l *RuntimeLauncher) startCodexSession(ctx context.Context, agentItem *ent.
 	if err != nil {
 		return nil, fmt.Errorf("parse agent cli command: %w", err)
 	}
-	if requiresMachineCodexReady(command) {
+	environment := buildAgentCLIEnvironment(machine.EnvVars, launchContext.agent.Edges.Provider.AuthConfig)
+	if requiresMachineCodexReady(command, environment) {
 		if ready, reason, ok := machineCodexReady(machine.Resources); ok && !ready {
 			return nil, fmt.Errorf("machine %s codex environment not ready: %s", machine.Name, reason)
 		}
@@ -418,7 +419,7 @@ func (l *RuntimeLauncher) startCodexSession(ctx context.Context, agentItem *ent.
 		command,
 		launchContext.agent.Edges.Provider.CliArgs,
 		&workingDirectory,
-		append([]string(nil), machine.EnvVars...),
+		environment,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build codex process spec: %w", err)
@@ -724,13 +725,65 @@ func machineCodexReady(resources map[string]any) (bool, string, bool) {
 	return false, "codex cli is not ready", true
 }
 
-func requiresMachineCodexReady(command provider.AgentCLICommand) bool {
-	trimmed := strings.TrimSpace(command.String())
-	if trimmed == "" {
+func buildAgentCLIEnvironment(machineEnv []string, authConfig map[string]any) []string {
+	environment := append([]string(nil), machineEnv...)
+	return append(environment, provider.AuthConfigEnvironment(authConfig)...)
+}
+
+func requiresMachineCodexReady(command provider.AgentCLICommand, environment []string) bool {
+	if value, ok := provider.LookupEnvironmentValue(environment, "OPENAI_API_KEY"); ok && strings.TrimSpace(value) != "" {
 		return false
 	}
 
-	base := path.Base(strings.ReplaceAll(trimmed, "\\", "/"))
+	executable := agentCLIExecutable(command)
+	if executable == "" {
+		return false
+	}
+
+	base := path.Base(strings.ReplaceAll(executable, "\\", "/"))
+	return strings.EqualFold(base, "codex") || strings.EqualFold(base, "codex.exe")
+}
+
+func agentCLIExecutable(command provider.AgentCLICommand) string {
+	trimmed := strings.TrimSpace(command.String())
+	if trimmed == "" {
+		return ""
+	}
+
+	if isCodexExecutablePath(trimmed) {
+		return strings.Trim(trimmed, `"'`)
+	}
+
+	token := firstCommandToken(trimmed)
+	if token == "" {
+		return ""
+	}
+	return strings.Trim(token, `"'`)
+}
+
+func firstCommandToken(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if quote := trimmed[0]; quote == '"' || quote == '\'' {
+		for index := 1; index < len(trimmed); index++ {
+			if trimmed[index] == quote {
+				return trimmed[1:index]
+			}
+		}
+		return strings.Trim(trimmed, `"'`)
+	}
+
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func isCodexExecutablePath(raw string) bool {
+	base := path.Base(strings.ReplaceAll(strings.Trim(raw, `"'`), "\\", "/"))
 	return strings.EqualFold(base, "codex") || strings.EqualFold(base, "codex.exe")
 }
 

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -510,17 +510,108 @@ func TestRuntimeLauncherRunTickSkipsMachineCodexPreflightForNonCodexCommand(t *t
 	}
 }
 
+func TestRuntimeLauncherRunTickSkipsMachineCodexPreflightWhenAPIKeyIsConfigured(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	fixture := seedProjectFixture(ctx, t, client)
+
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetAuthConfig(map[string]any{"openai_api_key": "sk-test-runtime"}).
+		Save(ctx); err != nil {
+		t.Fatalf("update provider auth config: %v", err)
+	}
+
+	localMachine, err := client.Machine.Query().
+		Where(
+			entmachine.OrganizationIDEQ(fixture.orgID),
+			entmachine.NameEQ(catalogdomain.LocalMachineName),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("load local machine: %v", err)
+	}
+	if _, err := client.Machine.UpdateOneID(localMachine.ID).
+		SetResources(map[string]any{
+			"monitor": map[string]any{
+				"l4": map[string]any{
+					"codex": map[string]any{
+						"installed":   true,
+						"auth_status": "not_logged_in",
+						"auth_mode":   "login",
+						"ready":       false,
+					},
+				},
+			},
+		}).
+		Save(ctx); err != nil {
+		t.Fatalf("update local machine resources: %v", err)
+	}
+
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(fixture.projectID).
+		SetIdentifier("ASE-404").
+		SetTitle("Launch Codex with API key auth").
+		SetStatusID(fixture.statusIDs["Todo"]).
+		SetPriority(entticket.PriorityHigh).
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+
+	agentItem, err := client.Agent.Create().
+		SetProjectID(fixture.projectID).
+		SetProviderID(fixture.providerID).
+		SetName("codex-api-key-01").
+		SetStatus(entagent.StatusClaimed).
+		SetCurrentTicketID(ticketItem.ID).
+		SetRuntimePhase(entagent.RuntimePhaseNone).
+		SetWorkspacePath("/tmp/openase").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create claimed agent: %v", err)
+	}
+
+	manager := &runtimeFakeProcessManager{}
+	launcher := NewRuntimeLauncher(client, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, manager, nil, nil)
+	t.Cleanup(func() {
+		if err := launcher.Close(context.Background()); err != nil {
+			t.Errorf("close launcher: %v", err)
+		}
+	})
+
+	if err := launcher.RunTick(ctx); err != nil {
+		t.Fatalf("run launcher tick: %v", err)
+	}
+
+	agentAfter, err := client.Agent.Get(ctx, agentItem.ID)
+	if err != nil {
+		t.Fatalf("reload agent: %v", err)
+	}
+	if agentAfter.Status != entagent.StatusRunning || agentAfter.RuntimePhase != entagent.RuntimePhaseReady {
+		t.Fatalf("expected ready runtime state, got %+v", agentAfter)
+	}
+
+	processSpec := manager.capturedProcessSpec()
+	if value, ok := provider.LookupEnvironmentValue(processSpec.Environment, "OPENAI_API_KEY"); !ok || value != "sk-test-runtime" {
+		t.Fatalf("expected OPENAI_API_KEY to be injected into runtime environment, got %+v", processSpec.Environment)
+	}
+}
+
 func TestRequiresMachineCodexReady(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name    string
 		command string
+		env     []string
 		want    bool
 	}{
 		{name: "bare codex", command: "codex", want: true},
 		{name: "absolute codex path", command: "/usr/local/bin/codex", want: true},
+		{name: "quoted codex path with args", command: `"/Applications/Codex/codex" --version`, want: true},
 		{name: "windows codex path", command: `C:\Program Files\Codex\codex.exe`, want: true},
+		{name: "codex with api key", command: "codex", env: []string{"OPENAI_API_KEY=sk-test"}, want: false},
 		{name: "python", command: "python3", want: false},
 		{name: "fake app server wrapper", command: "/usr/bin/python3", want: false},
 	}
@@ -530,9 +621,9 @@ func TestRequiresMachineCodexReady(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := requiresMachineCodexReady(provider.MustParseAgentCLICommand(tc.command))
+			got := requiresMachineCodexReady(provider.MustParseAgentCLICommand(tc.command), tc.env)
 			if got != tc.want {
-				t.Fatalf("requiresMachineCodexReady(%q) = %v, want %v", tc.command, got, tc.want)
+				t.Fatalf("requiresMachineCodexReady(%q, %+v) = %v, want %v", tc.command, tc.env, got, tc.want)
 			}
 		})
 	}
@@ -568,9 +659,15 @@ func decodeLifecycleEnvelope(t *testing.T, payload json.RawMessage) agentLifecyc
 type runtimeFakeProcessManager struct {
 	mu                 sync.Mutex
 	capturedThreadData runtimeThreadStartParams
+	capturedSpec       provider.AgentCLIProcessSpec
 }
 
-func (m *runtimeFakeProcessManager) Start(_ context.Context, _ provider.AgentCLIProcessSpec) (provider.AgentCLIProcess, error) {
+func (m *runtimeFakeProcessManager) Start(_ context.Context, spec provider.AgentCLIProcessSpec) (provider.AgentCLIProcess, error) {
+	if m != nil {
+		m.mu.Lock()
+		m.capturedSpec = spec
+		m.mu.Unlock()
+	}
 	process := newRuntimeFakeProcess()
 	go func() {
 		_ = runRuntimeFakeHandshake(process, m)
@@ -588,6 +685,17 @@ func (m *runtimeFakeProcessManager) capturedThreadStart() runtimeThreadStartPara
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.capturedThreadData
+}
+
+func (m *runtimeFakeProcessManager) capturedProcessSpec() provider.AgentCLIProcessSpec {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return provider.AgentCLIProcessSpec{
+		Command:          m.capturedSpec.Command,
+		Args:             append([]string(nil), m.capturedSpec.Args...),
+		WorkingDirectory: m.capturedSpec.WorkingDirectory,
+		Environment:      append([]string(nil), m.capturedSpec.Environment...),
+	}
 }
 
 type runtimeFakeProcess struct {

--- a/internal/provider/environment.go
+++ b/internal/provider/environment.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func AuthConfigEnvironment(authConfig map[string]any) []string {
+	if len(authConfig) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(authConfig))
+	for key := range authConfig {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value, ok := stringifyEnvValue(authConfig[key])
+		if !ok {
+			continue
+		}
+		normalized := normalizeEnvKey(key)
+		if normalized == "" {
+			continue
+		}
+		env = append(env, normalized+"="+value)
+	}
+	return env
+}
+
+func LookupEnvironmentValue(environment []string, key string) (string, bool) {
+	normalizedKey := normalizeEnvKey(key)
+	if normalizedKey == "" {
+		return "", false
+	}
+
+	for index := len(environment) - 1; index >= 0; index-- {
+		name, value, found := strings.Cut(environment[index], "=")
+		if !found {
+			continue
+		}
+		if normalizeEnvKey(name) == normalizedKey {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func stringifyEnvValue(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return typed, true
+	case bool:
+		return strconv.FormatBool(typed), true
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(typed), true
+	case json.Number:
+		return typed.String(), true
+	default:
+		return "", false
+	}
+}
+
+func normalizeEnvKey(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	normalized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r - ('a' - 'A')
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, trimmed)
+	return strings.Trim(normalized, "_")
+}


### PR DESCRIPTION
## Summary
- keep fake / non-Codex launches off the machine-level Codex login preflight by classifying the effective executable instead of the adapter type alone
- inject normalized `provider.auth_config` into runtime launch environments so Codex can launch through `OPENAI_API_KEY` as well as interactive login
- make machine monitoring evaluate `machine.env_vars` and record Codex `auth_mode`, which improves diagnostics for `systemd` and other service-managed environments

## Validation
- PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/domain/catalog ./internal/infra/ssh ./internal/orchestrator -run 'Test(ParseMachineAgentEnvironment|MonitorCollectorCollectAgentEnvironmentInjectsMachineEnvVars|MachineMonitorRunTickCapturesL4AndL5WithoutChangingMachineStatus|RuntimeLauncherRunTickFailsWhenRemoteCodexEnvironmentIsNotReady|RuntimeLauncherRunTickSkipsMachineCodexPreflightForNonCodexCommand|RuntimeLauncherRunTickSkipsMachineCodexPreflightWhenAPIKeyIsConfigured|RequiresMachineCodexReady)' -count=1
- PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh

## Risks / Follow-up
- command classification still keys off the effective executable name (`codex` / `codex.exe`); wrapper commands that eventually shell out to Codex remain a follow-up if we need richer launch-mode modeling
- machine snapshots only reflect auth material visible to the monitor process (`machine.env_vars` or service env); provider `auth_config` is intentionally injected only at launch time

Closes #146
