### PR TITLE
fix(board): wire board frontend views and agent data

### DIFF
--- a/web/src/lib/features/board/components/board-list-view.svelte
+++ b/web/src/lib/features/board/components/board-list-view.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { Badge } from '$ui/badge'
+  import { cn, formatRelativeTime } from '$lib/utils'
+  import type { BoardColumn, BoardTicket } from '../types'
+
+  let {
+    columns,
+    class: className = '',
+    onticketclick,
+  }: {
+    columns: BoardColumn[]
+    class?: string
+    onticketclick?: (ticket: BoardTicket) => void
+  } = $props()
+
+  const rows = $derived(
+    columns.flatMap((column) =>
+      column.tickets.map((ticket) => ({
+        ticket,
+        statusName: column.name,
+        statusColor: column.color,
+      })),
+    ),
+  )
+
+  const priorityColors: Record<BoardTicket['priority'], string> = {
+    urgent: 'bg-red-500',
+    high: 'bg-orange-500',
+    medium: 'bg-blue-500',
+    low: 'bg-zinc-400',
+  }
+</script>
+
+<div class={cn('flex-1 overflow-x-auto', className)}>
+  {#if rows.length === 0}
+    <div
+      class="text-muted-foreground flex h-full items-center justify-center rounded-md border px-4 py-10 text-sm"
+    >
+      No tickets match the current filters.
+    </div>
+  {:else}
+    <div class="border-border rounded-md border">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-border text-muted-foreground border-b text-left text-xs">
+            <th class="px-4 py-2.5 font-medium">Ticket</th>
+            <th class="px-4 py-2.5 font-medium">Status</th>
+            <th class="px-4 py-2.5 font-medium">Priority</th>
+            <th class="px-4 py-2.5 font-medium">Workflow</th>
+            <th class="px-4 py-2.5 font-medium">Agent</th>
+            <th class="px-4 py-2.5 text-right font-medium">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each rows as row (row.ticket.id)}
+            <tr
+              class="border-border hover:bg-muted/50 cursor-pointer border-b transition-colors last:border-0"
+              onclick={() => onticketclick?.(row.ticket)}
+            >
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-2">
+                  <span class="text-muted-foreground font-mono text-xs"
+                    >{row.ticket.identifier}</span
+                  >
+                  <span class="text-foreground">{row.ticket.title}</span>
+                </div>
+              </td>
+              <td class="px-4 py-3">
+                <Badge variant="outline" class="gap-1.5 text-xs">
+                  <span class="size-2 rounded-full" style="background-color: {row.statusColor}"
+                  ></span>
+                  {row.statusName}
+                </Badge>
+              </td>
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-1.5">
+                  <span class={cn('size-2 rounded-full', priorityColors[row.ticket.priority])}
+                  ></span>
+                  <span class="text-muted-foreground text-xs capitalize">{row.ticket.priority}</span
+                  >
+                </div>
+              </td>
+              <td class="px-4 py-3">
+                <span class="text-muted-foreground text-xs">
+                  {row.ticket.workflowType ?? 'Unassigned'}
+                </span>
+              </td>
+              <td class="px-4 py-3">
+                <span class="text-muted-foreground text-xs"
+                  >{row.ticket.agentName ?? 'Unassigned'}</span
+                >
+              </td>
+              <td class="px-4 py-3 text-right">
+                <span class="text-muted-foreground text-xs">
+                  {formatRelativeTime(row.ticket.updatedAt)}
+                </span>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/features/board/components/board-page.svelte
+++ b/web/src/lib/features/board/components/board-page.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
   import { appStore } from '$lib/stores/app.svelte'
   import { connectEventStream } from '$lib/api/sse'
-  import { listStatuses, listTickets, listWorkflows, updateTicket } from '$lib/api/openase'
+  import {
+    listActivity,
+    listAgents,
+    listStatuses,
+    listTickets,
+    listWorkflows,
+    updateTicket,
+  } from '$lib/api/openase'
   import { ApiError } from '$lib/api/client'
   import { statusSync } from '$lib/features/statuses/public'
   import type { BoardColumn, BoardFilter, BoardTicket } from '../types'
   import {
-    buildBoardColumns,
+    buildBoardData,
     filterBoardColumns,
     findTicketLocation,
     patchTicket,
     relocateTicket,
     type PendingTicketMove,
   } from '../model'
+  import BoardListView from './board-list-view.svelte'
   import BoardToolbar from './board-toolbar.svelte'
   import BoardView from './board-view.svelte'
 
@@ -23,6 +31,7 @@
   let mutationError = $state('')
   let allColumns = $state<BoardColumn[]>([])
   let workflows = $state<string[]>([])
+  let agentOptions = $state<string[]>([])
   let draggingTicketId = $state<string | null>(null)
   let dropColumnId = $state<string | null>(null)
 
@@ -63,11 +72,14 @@
     beginLoad(mode)
 
     try {
-      const [statusPayload, ticketPayload, workflowPayload] = await Promise.all([
-        listStatuses(projectId),
-        listTickets(projectId),
-        listWorkflows(projectId),
-      ])
+      const [statusPayload, ticketPayload, workflowPayload, agentPayload, activityPayload] =
+        await Promise.all([
+          listStatuses(projectId),
+          listTickets(projectId),
+          listWorkflows(projectId),
+          listAgents(projectId),
+          listActivity(projectId, { limit: 200 }),
+        ])
       if (isStaleLoad(projectId, requestVersion)) {
         return
       }
@@ -76,13 +88,16 @@
         return
       }
 
-      const nextBoard = buildBoardColumns(
+      const nextBoard = buildBoardData(
         statusPayload.statuses,
         ticketPayload.tickets,
         workflowPayload.workflows,
+        agentPayload.agents,
+        activityPayload.events,
       )
 
       workflows = nextBoard.workflowTypes
+      agentOptions = nextBoard.agentOptions
       allColumns = nextBoard.columns
 
       mutationError = ''
@@ -135,6 +150,7 @@
     if (!projectId) {
       allColumns = []
       workflows = []
+      agentOptions = []
       error = ''
       loading = false
       return
@@ -231,7 +247,7 @@
 </script>
 
 <div class="flex h-full flex-col gap-4">
-  <BoardToolbar bind:filter bind:view {workflows} agents={[]} listEnabled={false} />
+  <BoardToolbar bind:filter bind:view {workflows} agents={agentOptions} listEnabled={true} />
   {#if error}
     <div
       class="border-destructive/40 bg-destructive/10 text-destructive rounded-md border px-4 py-3 text-sm"
@@ -250,7 +266,7 @@
     <div class="text-muted-foreground flex flex-1 items-center justify-center text-sm">
       Loading board…
     </div>
-  {:else}
+  {:else if view === 'board'}
     <BoardView
       columns={filteredColumns}
       onticketclick={handleTicketClick}
@@ -261,5 +277,7 @@
       {draggingTicketId}
       {dropColumnId}
     />
+  {:else}
+    <BoardListView columns={filteredColumns} onticketclick={handleTicketClick} />
   {/if}
 </div>

--- a/web/src/lib/features/board/components/board-page.test.ts
+++ b/web/src/lib/features/board/components/board-page.test.ts
@@ -1,0 +1,201 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ActivityPayload,
+  AgentPayload,
+  Project,
+  StatusPayload,
+  TicketPayload,
+  WorkflowListPayload,
+} from '$lib/api/contracts'
+import { appStore } from '$lib/stores/app.svelte'
+import BoardPage from './board-page.svelte'
+
+const {
+  listActivity,
+  listAgents,
+  listStatuses,
+  listTickets,
+  listWorkflows,
+  updateTicket,
+  connectEventStream,
+} = vi.hoisted(() => ({
+  listActivity: vi.fn(),
+  listAgents: vi.fn(),
+  listStatuses: vi.fn(),
+  listTickets: vi.fn(),
+  listWorkflows: vi.fn(),
+  updateTicket: vi.fn(),
+  connectEventStream: vi.fn(),
+}))
+
+vi.mock('$lib/api/openase', () => ({
+  listActivity,
+  listAgents,
+  listStatuses,
+  listTickets,
+  listWorkflows,
+  updateTicket,
+}))
+
+vi.mock('$lib/api/sse', () => ({
+  connectEventStream,
+}))
+
+const projectFixture: Project = {
+  id: 'project-1',
+  organization_id: 'org-1',
+  name: 'OpenASE',
+  slug: 'openase',
+  description: '',
+  status: 'active',
+  default_workflow_id: null,
+  default_agent_provider_id: null,
+  accessible_machine_ids: [],
+  max_concurrent_agents: 4,
+}
+
+const statusesFixture: StatusPayload = {
+  statuses: [
+    {
+      id: 'status-1',
+      project_id: 'project-1',
+      name: 'Todo',
+      color: '#2563eb',
+      icon: '',
+      is_default: true,
+      description: '',
+      position: 1,
+    },
+  ],
+}
+
+const ticketsFixture: TicketPayload = {
+  tickets: [
+    {
+      id: 'ticket-1',
+      project_id: 'project-1',
+      identifier: 'ASE-202',
+      title: 'Wire board page to runtime data',
+      description: '',
+      status_id: 'status-1',
+      status_name: 'Todo',
+      priority: 'high',
+      type: 'feature',
+      workflow_id: 'workflow-1',
+      target_machine_id: null,
+      created_by: 'codex',
+      parent: null,
+      children: [],
+      dependencies: [],
+      external_links: [],
+      external_ref: '',
+      budget_usd: 0,
+      cost_tokens_input: 0,
+      cost_tokens_output: 0,
+      cost_amount: 0,
+      attempt_count: 0,
+      consecutive_errors: 0,
+      next_retry_at: null,
+      retry_paused: false,
+      pause_reason: '',
+      created_at: '2026-03-21T12:00:00Z',
+    },
+  ],
+}
+
+const workflowsFixture: WorkflowListPayload = {
+  workflows: [
+    {
+      id: 'workflow-1',
+      project_id: 'project-1',
+      name: 'Coding',
+      type: 'coding',
+      harness_path: '.openase/harnesses/coding.md',
+      harness_content: null,
+      hooks: {},
+      required_machine_labels: [],
+      max_concurrent: 1,
+      max_retry_attempts: 0,
+      timeout_minutes: 30,
+      stall_timeout_minutes: 10,
+      version: 1,
+      is_active: true,
+      pickup_status_id: 'status-1',
+      finish_status_id: null,
+    },
+  ],
+}
+
+const agentsFixture: AgentPayload = {
+  agents: [
+    {
+      id: 'agent-1',
+      provider_id: 'provider-1',
+      project_id: 'project-1',
+      name: 'Codex Worker',
+      status: 'running',
+      current_ticket_id: 'ticket-1',
+      session_id: 'session-1',
+      runtime_phase: 'ready',
+      runtime_control_state: 'active',
+      runtime_started_at: null,
+      last_error: '',
+      workspace_path: '/tmp/agent-1',
+      capabilities: ['code'],
+      total_tokens_used: 0,
+      total_tickets_completed: 0,
+      last_heartbeat_at: null,
+    },
+  ],
+}
+
+const activityFixture: ActivityPayload = {
+  events: [
+    {
+      id: 'activity-1',
+      project_id: 'project-1',
+      ticket_id: 'ticket-1',
+      agent_id: 'agent-1',
+      event_type: 'agent_started',
+      message: 'Agent started work.',
+      metadata: {
+        agent_name: 'Codex Worker',
+      },
+      created_at: '2026-03-22T09:30:00Z',
+    },
+  ],
+}
+
+describe('BoardPage', () => {
+  afterEach(() => {
+    cleanup()
+    appStore.currentProject = null
+    vi.clearAllMocks()
+  })
+
+  it('renders mapped agent metadata, exposes the agent filter, and switches into list view', async () => {
+    appStore.currentProject = projectFixture
+
+    listStatuses.mockResolvedValue(statusesFixture)
+    listTickets.mockResolvedValue(ticketsFixture)
+    listWorkflows.mockResolvedValue(workflowsFixture)
+    listAgents.mockResolvedValue(agentsFixture)
+    listActivity.mockResolvedValue(activityFixture)
+    updateTicket.mockResolvedValue({ ticket: ticketsFixture.tickets[0] })
+    connectEventStream.mockReturnValue(() => {})
+
+    const { findByRole, findByText, queryByRole } = render(BoardPage)
+
+    expect(await findByText('ASE-202')).toBeTruthy()
+    expect(await findByText('Codex Worker')).toBeTruthy()
+    expect(await findByRole('button', { name: 'Agent' })).toBeTruthy()
+    expect(queryByRole('table')).toBeNull()
+
+    await fireEvent.click(await findByRole('button', { name: 'List view' }))
+
+    expect(await findByRole('table')).toBeTruthy()
+    expect(await findByText('Updated')).toBeTruthy()
+  })
+})

--- a/web/src/lib/features/board/components/board-toolbar.svelte
+++ b/web/src/lib/features/board/components/board-toolbar.svelte
@@ -112,6 +112,7 @@
       variant={view === 'board' ? 'secondary' : 'ghost'}
       size="sm"
       class="h-7 rounded-r-none px-2"
+      aria-label="Board view"
       onclick={() => {
         view = 'board'
       }}
@@ -123,6 +124,7 @@
       size="sm"
       class="h-7 rounded-l-none px-2"
       disabled={!listEnabled}
+      aria-label="List view"
       title={listEnabled ? 'Switch to list view' : 'List view is not implemented yet'}
       onclick={() => {
         view = 'list'

--- a/web/src/lib/features/board/components/ticket-card.svelte
+++ b/web/src/lib/features/board/components/ticket-card.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
   import { cn, formatRelativeTime, truncate } from '$lib/utils'
   import { Badge } from '$ui/badge'
-  import {
-    GitPullRequest,
-    Bot,
-    AlertTriangle,
-    RotateCcw,
-    ShieldAlert,
-    Wallet,
-    GripVertical,
-  } from '@lucide/svelte'
+  import { Bot, AlertTriangle, RotateCcw, ShieldAlert, Wallet, GripVertical } from '@lucide/svelte'
   import type { BoardTicket } from '../types'
 
   let {
@@ -143,16 +135,6 @@
       <span class="text-muted-foreground inline-flex items-center gap-0.5 text-[10px]">
         <Bot class="size-3" />
         {ticket.agentName}
-      </span>
-    {/if}
-
-    {#if ticket.prCount && ticket.prCount > 0}
-      <span class="text-muted-foreground inline-flex items-center gap-0.5 text-[10px]">
-        <GitPullRequest class="size-3" />
-        {ticket.prCount}
-        {#if ticket.prStatus}
-          <span class="text-muted-foreground/70">· {ticket.prStatus}</span>
-        {/if}
       </span>
     {/if}
   </div>

--- a/web/src/lib/features/board/model.test.ts
+++ b/web/src/lib/features/board/model.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ActivityEvent, Agent, Ticket, TicketStatus, Workflow } from '$lib/api/contracts'
+import { buildBoardData } from './model'
+
+const statusesFixture: TicketStatus[] = [
+  {
+    id: 'status-1',
+    project_id: 'project-1',
+    name: 'Todo',
+    color: '#2563eb',
+    icon: '',
+    is_default: true,
+    description: '',
+    position: 1,
+  },
+]
+
+const workflowsFixture: Workflow[] = [
+  {
+    id: 'workflow-1',
+    project_id: 'project-1',
+    name: 'Coding',
+    type: 'coding',
+    harness_path: '.openase/harnesses/coding.md',
+    harness_content: null,
+    hooks: {},
+    required_machine_labels: [],
+    max_concurrent: 1,
+    max_retry_attempts: 0,
+    timeout_minutes: 30,
+    stall_timeout_minutes: 10,
+    version: 1,
+    is_active: true,
+    pickup_status_id: 'status-1',
+    finish_status_id: null,
+  },
+]
+
+const ticketsFixture: Ticket[] = [
+  {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    identifier: 'ASE-202',
+    title: 'Wire board page to runtime data',
+    description: '',
+    status_id: 'status-1',
+    status_name: 'Todo',
+    priority: 'high',
+    type: 'feature',
+    workflow_id: 'workflow-1',
+    target_machine_id: null,
+    created_by: 'codex',
+    parent: null,
+    children: [],
+    dependencies: [],
+    external_links: [],
+    external_ref: '',
+    budget_usd: 0,
+    cost_tokens_input: 0,
+    cost_tokens_output: 0,
+    cost_amount: 0,
+    attempt_count: 0,
+    consecutive_errors: 0,
+    next_retry_at: null,
+    retry_paused: false,
+    pause_reason: '',
+    created_at: '2026-03-21T12:00:00Z',
+  },
+]
+
+const agentsFixture: Agent[] = [
+  {
+    id: 'agent-1',
+    provider_id: 'provider-1',
+    project_id: 'project-1',
+    name: 'Codex Worker',
+    status: 'running',
+    current_ticket_id: 'ticket-1',
+    session_id: 'session-1',
+    runtime_phase: 'ready',
+    runtime_control_state: 'active',
+    runtime_started_at: null,
+    last_error: '',
+    workspace_path: '/tmp/agent-1',
+    capabilities: ['code'],
+    total_tokens_used: 0,
+    total_tickets_completed: 0,
+    last_heartbeat_at: null,
+  },
+]
+
+const activityFixture: ActivityEvent[] = [
+  {
+    id: 'activity-1',
+    project_id: 'project-1',
+    ticket_id: 'ticket-1',
+    agent_id: 'agent-1',
+    event_type: 'agent_started',
+    message: 'Agent started work.',
+    metadata: {},
+    created_at: '2026-03-22T09:30:00Z',
+  },
+]
+
+describe('board model', () => {
+  it('maps runtime agent names and exposes matching agent filter options', () => {
+    const board = buildBoardData(
+      statusesFixture,
+      ticketsFixture,
+      workflowsFixture,
+      agentsFixture,
+      activityFixture,
+    )
+
+    expect(board.workflowTypes).toEqual(['coding'])
+    expect(board.agentOptions).toEqual(['Codex Worker'])
+    expect(board.columns).toHaveLength(1)
+    expect(board.columns[0]?.tickets[0]).toMatchObject({
+      id: 'ticket-1',
+      workflowType: 'coding',
+      agentName: 'Codex Worker',
+      updatedAt: '2026-03-22T09:30:00Z',
+    })
+    expect('prCount' in (board.columns[0]?.tickets[0] ?? {})).toBe(false)
+    expect('prStatus' in (board.columns[0]?.tickets[0] ?? {})).toBe(false)
+  })
+})

--- a/web/src/lib/features/board/model.ts
+++ b/web/src/lib/features/board/model.ts
@@ -1,9 +1,15 @@
-import type { Ticket, TicketStatus, Workflow } from '$lib/api/contracts'
+import type { ActivityEvent, Agent, Ticket, TicketStatus, Workflow } from '$lib/api/contracts'
 import type { BoardColumn, BoardFilter, BoardTicket } from './types'
 
 export type PendingTicketMove = {
   fromColumnId: string
   fromIndex: number
+}
+
+export type BoardData = {
+  columns: BoardColumn[]
+  workflowTypes: string[]
+  agentOptions: string[]
 }
 
 export function filterBoardColumns(columns: BoardColumn[], filter: BoardFilter): BoardColumn[] {
@@ -41,25 +47,29 @@ function matchesAnomalyFilter(ticket: BoardTicket, anomalyOnly: boolean | undefi
   return !anomalyOnly || !!ticket.anomaly
 }
 
-export function buildBoardColumns(
+export function buildBoardData(
   statuses: TicketStatus[],
   tickets: Ticket[],
   workflows: Workflow[],
-) {
+  agents: Agent[],
+  activity: ActivityEvent[],
+): BoardData {
   const workflowTypeById = new Map(workflows.map((workflow) => [workflow.id, workflow.type]))
+  const runtimeByTicketId = buildTicketRuntimeById(agents, activity)
 
-  return {
-    workflowTypes: Array.from(new Set(workflows.map((workflow) => workflow.type))),
-    columns: statuses
-      .slice()
-      .sort((left, right) => left.position - right.position)
-      .map((status) => ({
-        id: status.id,
-        name: status.name,
-        color: status.color || '#94a3b8',
-        tickets: tickets
-          .filter((ticket) => ticket.status_id === status.id)
-          .map((ticket) => ({
+  const columns = statuses
+    .slice()
+    .sort((left, right) => left.position - right.position)
+    .map((status) => ({
+      id: status.id,
+      name: status.name,
+      color: status.color || '#94a3b8',
+      tickets: tickets
+        .filter((ticket) => ticket.status_id === status.id)
+        .map((ticket) => {
+          const runtime = runtimeByTicketId.get(ticket.id)
+
+          return {
             id: ticket.id,
             statusId: ticket.status_id,
             identifier: ticket.identifier,
@@ -68,11 +78,24 @@ export function buildBoardColumns(
             workflowType: ticket.workflow_id
               ? (workflowTypeById.get(ticket.workflow_id) ?? undefined)
               : undefined,
-            updatedAt: ticket.created_at,
+            agentName: runtime?.agentName,
+            updatedAt: runtime?.updatedAt ?? ticket.created_at,
             labels: [],
             anomaly: inferAnomaly(ticket),
-          })),
-      })),
+          }
+        }),
+    }))
+
+  return {
+    workflowTypes: Array.from(new Set(workflows.map((workflow) => workflow.type))),
+    agentOptions: Array.from(
+      new Set(
+        columns.flatMap((column) =>
+          column.tickets.map((ticket) => ticket.agentName).filter(isDefined),
+        ),
+      ),
+    ).sort((left, right) => left.localeCompare(right)),
+    columns,
   }
 }
 
@@ -169,6 +192,47 @@ function clampIndex(index: number, length: number) {
   return Math.max(0, Math.min(index, length))
 }
 
+function buildTicketRuntimeById(agents: Agent[], activity: ActivityEvent[]) {
+  const agentNameById = new Map(agents.map((agent) => [agent.id, agent.name]))
+  const runtimeByTicketId = new Map<
+    string,
+    { agentName: string; updatedAt: string; timestamp: number }
+  >()
+
+  for (const event of activity) {
+    if (!event.ticket_id) continue
+
+    const agentName = getActivityAgentName(event, agentNameById)
+    if (!agentName) continue
+
+    const timestamp = Date.parse(event.created_at)
+    const current = runtimeByTicketId.get(event.ticket_id)
+    if (current && !Number.isNaN(timestamp) && current.timestamp > timestamp) {
+      continue
+    }
+
+    runtimeByTicketId.set(event.ticket_id, {
+      agentName,
+      updatedAt: event.created_at,
+      timestamp: Number.isNaN(timestamp) ? 0 : timestamp,
+    })
+  }
+
+  return runtimeByTicketId
+}
+
+function getActivityAgentName(
+  event: Pick<ActivityEvent, 'agent_id' | 'metadata'>,
+  agentNameById: Map<string, string>,
+) {
+  const metadataAgentName = event.metadata.agent_name
+  if (typeof metadataAgentName === 'string' && metadataAgentName.trim() !== '') {
+    return metadataAgentName
+  }
+
+  return event.agent_id ? agentNameById.get(event.agent_id) : undefined
+}
+
 function normalizePriority(priority: string): BoardTicket['priority'] {
   if (priority === 'urgent' || priority === 'high' || priority === 'medium' || priority === 'low') {
     return priority
@@ -184,4 +248,8 @@ function inferAnomaly(
   if (ticket.consecutive_errors > 0) return 'hook_failed'
   if (ticket.budget_usd > 0 && ticket.cost_amount >= ticket.budget_usd) return 'budget_exhausted'
   return undefined
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined
 }

--- a/web/src/lib/features/board/types.ts
+++ b/web/src/lib/features/board/types.ts
@@ -15,8 +15,6 @@ export type BoardTicket = {
   priority: 'urgent' | 'high' | 'medium' | 'low'
   workflowType?: string
   agentName?: string
-  prCount?: number
-  prStatus?: string
   anomaly?: 'retry' | 'hook_failed' | 'awaiting_approval' | 'budget_exhausted'
   updatedAt: string
   isMoving?: boolean


### PR DESCRIPTION
## Summary
- add a real board/list render switch on the board page instead of keeping `view` as dead toolbar state
- derive board agent names and agent filter options from project activity plus agent catalog data
- remove unsupported board PR summary fields from the board ticket contract and cover the wiring with focused tests

Closes #202.

## Validation
- `pnpm exec vitest run src/lib/features/board/model.test.ts src/lib/features/board/components/board-page.test.ts`
- `pnpm check`
- `pnpm exec eslint src/lib/features/board/components/board-page.svelte src/lib/features/board/components/board-toolbar.svelte src/lib/features/board/components/ticket-card.svelte src/lib/features/board/components/board-list-view.svelte src/lib/features/board/model.ts src/lib/features/board/types.ts src/lib/features/board/model.test.ts src/lib/features/board/components/board-page.test.ts`
- `pnpm exec prettier --check src/lib/features/board/components/board-page.svelte src/lib/features/board/components/board-toolbar.svelte src/lib/features/board/components/ticket-card.svelte src/lib/features/board/components/board-list-view.svelte src/lib/features/board/model.ts src/lib/features/board/types.ts src/lib/features/board/model.test.ts src/lib/features/board/components/board-page.test.ts`
- `PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- Board cards still do not show PR summary data because the ticket list API does not expose a board-level PR contract yet.
