### PR TITLE
Bind agent providers to machine execution targets

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4186,6 +4186,26 @@
                           "id": {
                             "type": "string"
                           },
+                          "machine_host": {
+                            "type": "string"
+                          },
+                          "machine_id": {
+                            "type": "string"
+                          },
+                          "machine_name": {
+                            "type": "string"
+                          },
+                          "machine_ssh_user": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "machine_status": {
+                            "type": "string"
+                          },
+                          "machine_workspace_root": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "model_max_tokens": {
                             "type": "integer"
                           },
@@ -4319,6 +4339,9 @@
                     "nullable": true,
                     "type": "number"
                   },
+                  "machine_id": {
+                    "type": "string"
+                  },
                   "model_max_tokens": {
                     "nullable": true,
                     "type": "integer"
@@ -4378,6 +4401,26 @@
                           "type": "number"
                         },
                         "id": {
+                          "type": "string"
+                        },
+                        "machine_host": {
+                          "type": "string"
+                        },
+                        "machine_id": {
+                          "type": "string"
+                        },
+                        "machine_name": {
+                          "type": "string"
+                        },
+                        "machine_ssh_user": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "machine_status": {
+                          "type": "string"
+                        },
+                        "machine_workspace_root": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "model_max_tokens": {
@@ -10380,6 +10423,10 @@
                     "nullable": true,
                     "type": "number"
                   },
+                  "machine_id": {
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "model_max_tokens": {
                     "nullable": true,
                     "type": "integer"
@@ -10441,6 +10488,26 @@
                           "type": "number"
                         },
                         "id": {
+                          "type": "string"
+                        },
+                        "machine_host": {
+                          "type": "string"
+                        },
+                        "machine_id": {
+                          "type": "string"
+                        },
+                        "machine_name": {
+                          "type": "string"
+                        },
+                        "machine_ssh_user": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "machine_status": {
+                          "type": "string"
+                        },
+                        "machine_workspace_root": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "model_max_tokens": {

--- a/ent/agentprovider.go
+++ b/ent/agentprovider.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/BetterAndBetterII/openase/ent/agentprovider"
+	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/internal/types/pgarray"
 	"github.com/google/uuid"
@@ -22,6 +23,8 @@ type AgentProvider struct {
 	ID uuid.UUID `json:"id,omitempty"`
 	// OrganizationID holds the value of the "organization_id" field.
 	OrganizationID uuid.UUID `json:"organization_id,omitempty"`
+	// MachineID holds the value of the "machine_id" field.
+	MachineID uuid.UUID `json:"machine_id,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// AdapterType holds the value of the "adapter_type" field.
@@ -52,13 +55,15 @@ type AgentProvider struct {
 type AgentProviderEdges struct {
 	// Organization holds the value of the organization edge.
 	Organization *Organization `json:"organization,omitempty"`
+	// Machine holds the value of the machine edge.
+	Machine *Machine `json:"machine,omitempty"`
 	// Agents holds the value of the agents edge.
 	Agents []*Agent `json:"agents,omitempty"`
 	// AgentRuns holds the value of the agent_runs edge.
 	AgentRuns []*AgentRun `json:"agent_runs,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [4]bool
 }
 
 // OrganizationOrErr returns the Organization value or an error if the edge
@@ -72,10 +77,21 @@ func (e AgentProviderEdges) OrganizationOrErr() (*Organization, error) {
 	return nil, &NotLoadedError{edge: "organization"}
 }
 
+// MachineOrErr returns the Machine value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e AgentProviderEdges) MachineOrErr() (*Machine, error) {
+	if e.Machine != nil {
+		return e.Machine, nil
+	} else if e.loadedTypes[1] {
+		return nil, &NotFoundError{label: machine.Label}
+	}
+	return nil, &NotLoadedError{edge: "machine"}
+}
+
 // AgentsOrErr returns the Agents value or an error if the edge
 // was not loaded in eager-loading.
 func (e AgentProviderEdges) AgentsOrErr() ([]*Agent, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[2] {
 		return e.Agents, nil
 	}
 	return nil, &NotLoadedError{edge: "agents"}
@@ -84,7 +100,7 @@ func (e AgentProviderEdges) AgentsOrErr() ([]*Agent, error) {
 // AgentRunsOrErr returns the AgentRuns value or an error if the edge
 // was not loaded in eager-loading.
 func (e AgentProviderEdges) AgentRunsOrErr() ([]*AgentRun, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[3] {
 		return e.AgentRuns, nil
 	}
 	return nil, &NotLoadedError{edge: "agent_runs"}
@@ -105,7 +121,7 @@ func (*AgentProvider) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case agentprovider.FieldName, agentprovider.FieldAdapterType, agentprovider.FieldCliCommand, agentprovider.FieldModelName:
 			values[i] = new(sql.NullString)
-		case agentprovider.FieldID, agentprovider.FieldOrganizationID:
+		case agentprovider.FieldID, agentprovider.FieldOrganizationID, agentprovider.FieldMachineID:
 			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -133,6 +149,12 @@ func (_m *AgentProvider) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field organization_id", values[i])
 			} else if value != nil {
 				_m.OrganizationID = *value
+			}
+		case agentprovider.FieldMachineID:
+			if value, ok := values[i].(*uuid.UUID); !ok {
+				return fmt.Errorf("unexpected type %T for field machine_id", values[i])
+			} else if value != nil {
+				_m.MachineID = *value
 			}
 		case agentprovider.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -214,6 +236,11 @@ func (_m *AgentProvider) QueryOrganization() *OrganizationQuery {
 	return NewAgentProviderClient(_m.config).QueryOrganization(_m)
 }
 
+// QueryMachine queries the "machine" edge of the AgentProvider entity.
+func (_m *AgentProvider) QueryMachine() *MachineQuery {
+	return NewAgentProviderClient(_m.config).QueryMachine(_m)
+}
+
 // QueryAgents queries the "agents" edge of the AgentProvider entity.
 func (_m *AgentProvider) QueryAgents() *AgentQuery {
 	return NewAgentProviderClient(_m.config).QueryAgents(_m)
@@ -249,6 +276,9 @@ func (_m *AgentProvider) String() string {
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
 	builder.WriteString("organization_id=")
 	builder.WriteString(fmt.Sprintf("%v", _m.OrganizationID))
+	builder.WriteString(", ")
+	builder.WriteString("machine_id=")
+	builder.WriteString(fmt.Sprintf("%v", _m.MachineID))
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(_m.Name)

--- a/ent/agentprovider/agentprovider.go
+++ b/ent/agentprovider/agentprovider.go
@@ -17,6 +17,8 @@ const (
 	FieldID = "id"
 	// FieldOrganizationID holds the string denoting the organization_id field in the database.
 	FieldOrganizationID = "organization_id"
+	// FieldMachineID holds the string denoting the machine_id field in the database.
+	FieldMachineID = "machine_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldAdapterType holds the string denoting the adapter_type field in the database.
@@ -39,6 +41,8 @@ const (
 	FieldCostPerOutputToken = "cost_per_output_token"
 	// EdgeOrganization holds the string denoting the organization edge name in mutations.
 	EdgeOrganization = "organization"
+	// EdgeMachine holds the string denoting the machine edge name in mutations.
+	EdgeMachine = "machine"
 	// EdgeAgents holds the string denoting the agents edge name in mutations.
 	EdgeAgents = "agents"
 	// EdgeAgentRuns holds the string denoting the agent_runs edge name in mutations.
@@ -52,6 +56,13 @@ const (
 	OrganizationInverseTable = "organizations"
 	// OrganizationColumn is the table column denoting the organization relation/edge.
 	OrganizationColumn = "organization_id"
+	// MachineTable is the table that holds the machine relation/edge.
+	MachineTable = "agent_providers"
+	// MachineInverseTable is the table name for the Machine entity.
+	// It exists in this package in order to avoid circular dependency with the "machine" package.
+	MachineInverseTable = "machines"
+	// MachineColumn is the table column denoting the machine relation/edge.
+	MachineColumn = "machine_id"
 	// AgentsTable is the table that holds the agents relation/edge.
 	AgentsTable = "agents"
 	// AgentsInverseTable is the table name for the Agent entity.
@@ -72,6 +83,7 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldOrganizationID,
+	FieldMachineID,
 	FieldName,
 	FieldAdapterType,
 	FieldCliCommand,
@@ -153,6 +165,11 @@ func ByOrganizationID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOrganizationID, opts...).ToFunc()
 }
 
+// ByMachineID orders the results by the machine_id field.
+func ByMachineID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldMachineID, opts...).ToFunc()
+}
+
 // ByName orders the results by the name field.
 func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
@@ -205,6 +222,13 @@ func ByOrganizationField(field string, opts ...sql.OrderTermOption) OrderOption 
 	}
 }
 
+// ByMachineField orders the results by machine field.
+func ByMachineField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newMachineStep(), sql.OrderByField(field, opts...))
+	}
+}
+
 // ByAgentsCount orders the results by agents count.
 func ByAgentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -237,6 +261,13 @@ func newOrganizationStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(OrganizationInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, OrganizationTable, OrganizationColumn),
+	)
+}
+func newMachineStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(MachineInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, MachineTable, MachineColumn),
 	)
 }
 func newAgentsStep() *sqlgraph.Step {

--- a/ent/agentprovider/where.go
+++ b/ent/agentprovider/where.go
@@ -60,6 +60,11 @@ func OrganizationID(v uuid.UUID) predicate.AgentProvider {
 	return predicate.AgentProvider(sql.FieldEQ(FieldOrganizationID, v))
 }
 
+// MachineID applies equality check predicate on the "machine_id" field. It's identical to MachineIDEQ.
+func MachineID(v uuid.UUID) predicate.AgentProvider {
+	return predicate.AgentProvider(sql.FieldEQ(FieldMachineID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.AgentProvider {
 	return predicate.AgentProvider(sql.FieldEQ(FieldName, v))
@@ -118,6 +123,26 @@ func OrganizationIDIn(vs ...uuid.UUID) predicate.AgentProvider {
 // OrganizationIDNotIn applies the NotIn predicate on the "organization_id" field.
 func OrganizationIDNotIn(vs ...uuid.UUID) predicate.AgentProvider {
 	return predicate.AgentProvider(sql.FieldNotIn(FieldOrganizationID, vs...))
+}
+
+// MachineIDEQ applies the EQ predicate on the "machine_id" field.
+func MachineIDEQ(v uuid.UUID) predicate.AgentProvider {
+	return predicate.AgentProvider(sql.FieldEQ(FieldMachineID, v))
+}
+
+// MachineIDNEQ applies the NEQ predicate on the "machine_id" field.
+func MachineIDNEQ(v uuid.UUID) predicate.AgentProvider {
+	return predicate.AgentProvider(sql.FieldNEQ(FieldMachineID, v))
+}
+
+// MachineIDIn applies the In predicate on the "machine_id" field.
+func MachineIDIn(vs ...uuid.UUID) predicate.AgentProvider {
+	return predicate.AgentProvider(sql.FieldIn(FieldMachineID, vs...))
+}
+
+// MachineIDNotIn applies the NotIn predicate on the "machine_id" field.
+func MachineIDNotIn(vs ...uuid.UUID) predicate.AgentProvider {
+	return predicate.AgentProvider(sql.FieldNotIn(FieldMachineID, vs...))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -560,6 +585,29 @@ func HasOrganization() predicate.AgentProvider {
 func HasOrganizationWith(preds ...predicate.Organization) predicate.AgentProvider {
 	return predicate.AgentProvider(func(s *sql.Selector) {
 		step := newOrganizationStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasMachine applies the HasEdge predicate on the "machine" edge.
+func HasMachine() predicate.AgentProvider {
+	return predicate.AgentProvider(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, MachineTable, MachineColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasMachineWith applies the HasEdge predicate on the "machine" edge with a given conditions (other predicates).
+func HasMachineWith(preds ...predicate.Machine) predicate.AgentProvider {
+	return predicate.AgentProvider(func(s *sql.Selector) {
+		step := newMachineStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/ent/agentprovider_create.go
+++ b/ent/agentprovider_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BetterAndBetterII/openase/ent/agent"
 	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/agentrun"
+	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/internal/types/pgarray"
 	"github.com/google/uuid"
@@ -27,6 +28,12 @@ type AgentProviderCreate struct {
 // SetOrganizationID sets the "organization_id" field.
 func (_c *AgentProviderCreate) SetOrganizationID(v uuid.UUID) *AgentProviderCreate {
 	_c.mutation.SetOrganizationID(v)
+	return _c
+}
+
+// SetMachineID sets the "machine_id" field.
+func (_c *AgentProviderCreate) SetMachineID(v uuid.UUID) *AgentProviderCreate {
+	_c.mutation.SetMachineID(v)
 	return _c
 }
 
@@ -141,6 +148,11 @@ func (_c *AgentProviderCreate) SetOrganization(v *Organization) *AgentProviderCr
 	return _c.SetOrganizationID(v.ID)
 }
 
+// SetMachine sets the "machine" edge to the Machine entity.
+func (_c *AgentProviderCreate) SetMachine(v *Machine) *AgentProviderCreate {
+	return _c.SetMachineID(v.ID)
+}
+
 // AddAgentIDs adds the "agents" edge to the Agent entity by IDs.
 func (_c *AgentProviderCreate) AddAgentIDs(ids ...uuid.UUID) *AgentProviderCreate {
 	_c.mutation.AddAgentIDs(ids...)
@@ -237,6 +249,9 @@ func (_c *AgentProviderCreate) check() error {
 	if _, ok := _c.mutation.OrganizationID(); !ok {
 		return &ValidationError{Name: "organization_id", err: errors.New(`ent: missing required field "AgentProvider.organization_id"`)}
 	}
+	if _, ok := _c.mutation.MachineID(); !ok {
+		return &ValidationError{Name: "machine_id", err: errors.New(`ent: missing required field "AgentProvider.machine_id"`)}
+	}
 	if _, ok := _c.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required field "AgentProvider.name"`)}
 	}
@@ -286,6 +301,9 @@ func (_c *AgentProviderCreate) check() error {
 	}
 	if len(_c.mutation.OrganizationIDs()) == 0 {
 		return &ValidationError{Name: "organization", err: errors.New(`ent: missing required edge "AgentProvider.organization"`)}
+	}
+	if len(_c.mutation.MachineIDs()) == 0 {
+		return &ValidationError{Name: "machine", err: errors.New(`ent: missing required edge "AgentProvider.machine"`)}
 	}
 	return nil
 }
@@ -377,6 +395,23 @@ func (_c *AgentProviderCreate) createSpec() (*AgentProvider, *sqlgraph.CreateSpe
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.OrganizationID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.MachineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   agentprovider.MachineTable,
+			Columns: []string{agentprovider.MachineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(machine.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.MachineID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.AgentsIDs(); len(nodes) > 0 {

--- a/ent/agentprovider_query.go
+++ b/ent/agentprovider_query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BetterAndBetterII/openase/ent/agent"
 	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/agentrun"
+	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/ent/predicate"
 	"github.com/google/uuid"
@@ -28,6 +29,7 @@ type AgentProviderQuery struct {
 	inters           []Interceptor
 	predicates       []predicate.AgentProvider
 	withOrganization *OrganizationQuery
+	withMachine      *MachineQuery
 	withAgents       *AgentQuery
 	withAgentRuns    *AgentRunQuery
 	// intermediate query (i.e. traversal path).
@@ -81,6 +83,28 @@ func (_q *AgentProviderQuery) QueryOrganization() *OrganizationQuery {
 			sqlgraph.From(agentprovider.Table, agentprovider.FieldID, selector),
 			sqlgraph.To(organization.Table, organization.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, agentprovider.OrganizationTable, agentprovider.OrganizationColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryMachine chains the current query on the "machine" edge.
+func (_q *AgentProviderQuery) QueryMachine() *MachineQuery {
+	query := (&MachineClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(agentprovider.Table, agentprovider.FieldID, selector),
+			sqlgraph.To(machine.Table, machine.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, agentprovider.MachineTable, agentprovider.MachineColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -325,6 +349,7 @@ func (_q *AgentProviderQuery) Clone() *AgentProviderQuery {
 		inters:           append([]Interceptor{}, _q.inters...),
 		predicates:       append([]predicate.AgentProvider{}, _q.predicates...),
 		withOrganization: _q.withOrganization.Clone(),
+		withMachine:      _q.withMachine.Clone(),
 		withAgents:       _q.withAgents.Clone(),
 		withAgentRuns:    _q.withAgentRuns.Clone(),
 		// clone intermediate query.
@@ -341,6 +366,17 @@ func (_q *AgentProviderQuery) WithOrganization(opts ...func(*OrganizationQuery))
 		opt(query)
 	}
 	_q.withOrganization = query
+	return _q
+}
+
+// WithMachine tells the query-builder to eager-load the nodes that are connected to
+// the "machine" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *AgentProviderQuery) WithMachine(opts ...func(*MachineQuery)) *AgentProviderQuery {
+	query := (&MachineClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withMachine = query
 	return _q
 }
 
@@ -444,8 +480,9 @@ func (_q *AgentProviderQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([
 	var (
 		nodes       = []*AgentProvider{}
 		_spec       = _q.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [4]bool{
 			_q.withOrganization != nil,
+			_q.withMachine != nil,
 			_q.withAgents != nil,
 			_q.withAgentRuns != nil,
 		}
@@ -471,6 +508,12 @@ func (_q *AgentProviderQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([
 	if query := _q.withOrganization; query != nil {
 		if err := _q.loadOrganization(ctx, query, nodes, nil,
 			func(n *AgentProvider, e *Organization) { n.Edges.Organization = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withMachine; query != nil {
+		if err := _q.loadMachine(ctx, query, nodes, nil,
+			func(n *AgentProvider, e *Machine) { n.Edges.Machine = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -513,6 +556,35 @@ func (_q *AgentProviderQuery) loadOrganization(ctx context.Context, query *Organ
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "organization_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *AgentProviderQuery) loadMachine(ctx context.Context, query *MachineQuery, nodes []*AgentProvider, init func(*AgentProvider), assign func(*AgentProvider, *Machine)) error {
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*AgentProvider)
+	for i := range nodes {
+		fk := nodes[i].MachineID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(machine.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "machine_id" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
@@ -608,6 +680,9 @@ func (_q *AgentProviderQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if _q.withOrganization != nil {
 			_spec.Node.AddColumnOnce(agentprovider.FieldOrganizationID)
+		}
+		if _q.withMachine != nil {
+			_spec.Node.AddColumnOnce(agentprovider.FieldMachineID)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/ent/agentprovider_update.go
+++ b/ent/agentprovider_update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BetterAndBetterII/openase/ent/agent"
 	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/agentrun"
+	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/ent/predicate"
 	"github.com/BetterAndBetterII/openase/internal/types/pgarray"
@@ -42,6 +43,20 @@ func (_u *AgentProviderUpdate) SetOrganizationID(v uuid.UUID) *AgentProviderUpda
 func (_u *AgentProviderUpdate) SetNillableOrganizationID(v *uuid.UUID) *AgentProviderUpdate {
 	if v != nil {
 		_u.SetOrganizationID(*v)
+	}
+	return _u
+}
+
+// SetMachineID sets the "machine_id" field.
+func (_u *AgentProviderUpdate) SetMachineID(v uuid.UUID) *AgentProviderUpdate {
+	_u.mutation.SetMachineID(v)
+	return _u
+}
+
+// SetNillableMachineID sets the "machine_id" field if the given value is not nil.
+func (_u *AgentProviderUpdate) SetNillableMachineID(v *uuid.UUID) *AgentProviderUpdate {
+	if v != nil {
+		_u.SetMachineID(*v)
 	}
 	return _u
 }
@@ -209,6 +224,11 @@ func (_u *AgentProviderUpdate) SetOrganization(v *Organization) *AgentProviderUp
 	return _u.SetOrganizationID(v.ID)
 }
 
+// SetMachine sets the "machine" edge to the Machine entity.
+func (_u *AgentProviderUpdate) SetMachine(v *Machine) *AgentProviderUpdate {
+	return _u.SetMachineID(v.ID)
+}
+
 // AddAgentIDs adds the "agents" edge to the Agent entity by IDs.
 func (_u *AgentProviderUpdate) AddAgentIDs(ids ...uuid.UUID) *AgentProviderUpdate {
 	_u.mutation.AddAgentIDs(ids...)
@@ -247,6 +267,12 @@ func (_u *AgentProviderUpdate) Mutation() *AgentProviderMutation {
 // ClearOrganization clears the "organization" edge to the Organization entity.
 func (_u *AgentProviderUpdate) ClearOrganization() *AgentProviderUpdate {
 	_u.mutation.ClearOrganization()
+	return _u
+}
+
+// ClearMachine clears the "machine" edge to the Machine entity.
+func (_u *AgentProviderUpdate) ClearMachine() *AgentProviderUpdate {
+	_u.mutation.ClearMachine()
 	return _u
 }
 
@@ -344,6 +370,9 @@ func (_u *AgentProviderUpdate) check() error {
 	if _u.mutation.OrganizationCleared() && len(_u.mutation.OrganizationIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "AgentProvider.organization"`)
 	}
+	if _u.mutation.MachineCleared() && len(_u.mutation.MachineIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "AgentProvider.machine"`)
+	}
 	return nil
 }
 
@@ -426,6 +455,35 @@ func (_u *AgentProviderUpdate) sqlSave(ctx context.Context) (_node int, err erro
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.MachineCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   agentprovider.MachineTable,
+			Columns: []string{agentprovider.MachineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(machine.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.MachineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   agentprovider.MachineTable,
+			Columns: []string{agentprovider.MachineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(machine.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -553,6 +611,20 @@ func (_u *AgentProviderUpdateOne) SetOrganizationID(v uuid.UUID) *AgentProviderU
 func (_u *AgentProviderUpdateOne) SetNillableOrganizationID(v *uuid.UUID) *AgentProviderUpdateOne {
 	if v != nil {
 		_u.SetOrganizationID(*v)
+	}
+	return _u
+}
+
+// SetMachineID sets the "machine_id" field.
+func (_u *AgentProviderUpdateOne) SetMachineID(v uuid.UUID) *AgentProviderUpdateOne {
+	_u.mutation.SetMachineID(v)
+	return _u
+}
+
+// SetNillableMachineID sets the "machine_id" field if the given value is not nil.
+func (_u *AgentProviderUpdateOne) SetNillableMachineID(v *uuid.UUID) *AgentProviderUpdateOne {
+	if v != nil {
+		_u.SetMachineID(*v)
 	}
 	return _u
 }
@@ -720,6 +792,11 @@ func (_u *AgentProviderUpdateOne) SetOrganization(v *Organization) *AgentProvide
 	return _u.SetOrganizationID(v.ID)
 }
 
+// SetMachine sets the "machine" edge to the Machine entity.
+func (_u *AgentProviderUpdateOne) SetMachine(v *Machine) *AgentProviderUpdateOne {
+	return _u.SetMachineID(v.ID)
+}
+
 // AddAgentIDs adds the "agents" edge to the Agent entity by IDs.
 func (_u *AgentProviderUpdateOne) AddAgentIDs(ids ...uuid.UUID) *AgentProviderUpdateOne {
 	_u.mutation.AddAgentIDs(ids...)
@@ -758,6 +835,12 @@ func (_u *AgentProviderUpdateOne) Mutation() *AgentProviderMutation {
 // ClearOrganization clears the "organization" edge to the Organization entity.
 func (_u *AgentProviderUpdateOne) ClearOrganization() *AgentProviderUpdateOne {
 	_u.mutation.ClearOrganization()
+	return _u
+}
+
+// ClearMachine clears the "machine" edge to the Machine entity.
+func (_u *AgentProviderUpdateOne) ClearMachine() *AgentProviderUpdateOne {
+	_u.mutation.ClearMachine()
 	return _u
 }
 
@@ -868,6 +951,9 @@ func (_u *AgentProviderUpdateOne) check() error {
 	if _u.mutation.OrganizationCleared() && len(_u.mutation.OrganizationIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "AgentProvider.organization"`)
 	}
+	if _u.mutation.MachineCleared() && len(_u.mutation.MachineIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "AgentProvider.machine"`)
+	}
 	return nil
 }
 
@@ -967,6 +1053,35 @@ func (_u *AgentProviderUpdateOne) sqlSave(ctx context.Context) (_node *AgentProv
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.MachineCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   agentprovider.MachineTable,
+			Columns: []string{agentprovider.MachineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(machine.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.MachineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   agentprovider.MachineTable,
+			Columns: []string{agentprovider.MachineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(machine.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/client.go
+++ b/ent/client.go
@@ -890,6 +890,22 @@ func (c *AgentProviderClient) QueryOrganization(_m *AgentProvider) *Organization
 	return query
 }
 
+// QueryMachine queries the machine edge of a AgentProvider.
+func (c *AgentProviderClient) QueryMachine(_m *AgentProvider) *MachineQuery {
+	query := (&MachineClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(agentprovider.Table, agentprovider.FieldID, id),
+			sqlgraph.To(machine.Table, machine.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, agentprovider.MachineTable, agentprovider.MachineColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryAgents queries the agents edge of a AgentProvider.
 func (c *AgentProviderClient) QueryAgents(_m *AgentProvider) *AgentQuery {
 	query := (&AgentClient{config: c.config}).Query()
@@ -1458,6 +1474,22 @@ func (c *MachineClient) QueryOrganization(_m *Machine) *OrganizationQuery {
 			sqlgraph.From(machine.Table, machine.FieldID, id),
 			sqlgraph.To(organization.Table, organization.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, machine.OrganizationTable, machine.OrganizationColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryProviders queries the providers edge of a Machine.
+func (c *MachineClient) QueryProviders(_m *Machine) *AgentProviderQuery {
+	query := (&AgentProviderClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(machine.Table, machine.FieldID, id),
+			sqlgraph.To(agentprovider.Table, agentprovider.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, machine.ProvidersTable, machine.ProvidersColumn),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil

--- a/ent/machine.go
+++ b/ent/machine.go
@@ -59,11 +59,13 @@ type Machine struct {
 type MachineEdges struct {
 	// Organization holds the value of the organization edge.
 	Organization *Organization `json:"organization,omitempty"`
+	// Providers holds the value of the providers edge.
+	Providers []*AgentProvider `json:"providers,omitempty"`
 	// TargetTickets holds the value of the target_tickets edge.
 	TargetTickets []*Ticket `json:"target_tickets,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [3]bool
 }
 
 // OrganizationOrErr returns the Organization value or an error if the edge
@@ -77,10 +79,19 @@ func (e MachineEdges) OrganizationOrErr() (*Organization, error) {
 	return nil, &NotLoadedError{edge: "organization"}
 }
 
+// ProvidersOrErr returns the Providers value or an error if the edge
+// was not loaded in eager-loading.
+func (e MachineEdges) ProvidersOrErr() ([]*AgentProvider, error) {
+	if e.loadedTypes[1] {
+		return e.Providers, nil
+	}
+	return nil, &NotLoadedError{edge: "providers"}
+}
+
 // TargetTicketsOrErr returns the TargetTickets value or an error if the edge
 // was not loaded in eager-loading.
 func (e MachineEdges) TargetTicketsOrErr() ([]*Ticket, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[2] {
 		return e.TargetTickets, nil
 	}
 	return nil, &NotLoadedError{edge: "target_tickets"}
@@ -227,6 +238,11 @@ func (_m *Machine) Value(name string) (ent.Value, error) {
 // QueryOrganization queries the "organization" edge of the Machine entity.
 func (_m *Machine) QueryOrganization() *OrganizationQuery {
 	return NewMachineClient(_m.config).QueryOrganization(_m)
+}
+
+// QueryProviders queries the "providers" edge of the Machine entity.
+func (_m *Machine) QueryProviders() *AgentProviderQuery {
+	return NewMachineClient(_m.config).QueryProviders(_m)
 }
 
 // QueryTargetTickets queries the "target_tickets" edge of the Machine entity.

--- a/ent/machine/machine.go
+++ b/ent/machine/machine.go
@@ -45,6 +45,8 @@ const (
 	FieldResources = "resources"
 	// EdgeOrganization holds the string denoting the organization edge name in mutations.
 	EdgeOrganization = "organization"
+	// EdgeProviders holds the string denoting the providers edge name in mutations.
+	EdgeProviders = "providers"
 	// EdgeTargetTickets holds the string denoting the target_tickets edge name in mutations.
 	EdgeTargetTickets = "target_tickets"
 	// Table holds the table name of the machine in the database.
@@ -56,6 +58,13 @@ const (
 	OrganizationInverseTable = "organizations"
 	// OrganizationColumn is the table column denoting the organization relation/edge.
 	OrganizationColumn = "organization_id"
+	// ProvidersTable is the table that holds the providers relation/edge.
+	ProvidersTable = "agent_providers"
+	// ProvidersInverseTable is the table name for the AgentProvider entity.
+	// It exists in this package in order to avoid circular dependency with the "agentprovider" package.
+	ProvidersInverseTable = "agent_providers"
+	// ProvidersColumn is the table column denoting the providers relation/edge.
+	ProvidersColumn = "machine_id"
 	// TargetTicketsTable is the table that holds the target_tickets relation/edge.
 	TargetTicketsTable = "tickets"
 	// TargetTicketsInverseTable is the table name for the Ticket entity.
@@ -215,6 +224,20 @@ func ByOrganizationField(field string, opts ...sql.OrderTermOption) OrderOption 
 	}
 }
 
+// ByProvidersCount orders the results by providers count.
+func ByProvidersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newProvidersStep(), opts...)
+	}
+}
+
+// ByProviders orders the results by providers terms.
+func ByProviders(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newProvidersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByTargetTicketsCount orders the results by target_tickets count.
 func ByTargetTicketsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -233,6 +256,13 @@ func newOrganizationStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(OrganizationInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, OrganizationTable, OrganizationColumn),
+	)
+}
+func newProvidersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ProvidersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ProvidersTable, ProvidersColumn),
 	)
 }
 func newTargetTicketsStep() *sqlgraph.Step {

--- a/ent/machine/where.go
+++ b/ent/machine/where.go
@@ -875,6 +875,29 @@ func HasOrganizationWith(preds ...predicate.Organization) predicate.Machine {
 	})
 }
 
+// HasProviders applies the HasEdge predicate on the "providers" edge.
+func HasProviders() predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, ProvidersTable, ProvidersColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasProvidersWith applies the HasEdge predicate on the "providers" edge with a given conditions (other predicates).
+func HasProvidersWith(preds ...predicate.AgentProvider) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		step := newProvidersStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasTargetTickets applies the HasEdge predicate on the "target_tickets" edge.
 func HasTargetTickets() predicate.Machine {
 	return predicate.Machine(func(s *sql.Selector) {

--- a/ent/machine_create.go
+++ b/ent/machine_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/ent/ticket"
@@ -189,6 +190,21 @@ func (_c *MachineCreate) SetNillableID(v *uuid.UUID) *MachineCreate {
 // SetOrganization sets the "organization" edge to the Organization entity.
 func (_c *MachineCreate) SetOrganization(v *Organization) *MachineCreate {
 	return _c.SetOrganizationID(v.ID)
+}
+
+// AddProviderIDs adds the "providers" edge to the AgentProvider entity by IDs.
+func (_c *MachineCreate) AddProviderIDs(ids ...uuid.UUID) *MachineCreate {
+	_c.mutation.AddProviderIDs(ids...)
+	return _c
+}
+
+// AddProviders adds the "providers" edges to the AgentProvider entity.
+func (_c *MachineCreate) AddProviders(v ...*AgentProvider) *MachineCreate {
+	ids := make([]uuid.UUID, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddProviderIDs(ids...)
 }
 
 // AddTargetTicketIDs adds the "target_tickets" edge to the Ticket entity by IDs.
@@ -399,6 +415,22 @@ func (_c *MachineCreate) createSpec() (*Machine, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.OrganizationID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ProvidersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.TargetTicketsIDs(); len(nodes) > 0 {

--- a/ent/machine_query.go
+++ b/ent/machine_query.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/ent/predicate"
@@ -27,6 +28,7 @@ type MachineQuery struct {
 	inters            []Interceptor
 	predicates        []predicate.Machine
 	withOrganization  *OrganizationQuery
+	withProviders     *AgentProviderQuery
 	withTargetTickets *TicketQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -79,6 +81,28 @@ func (_q *MachineQuery) QueryOrganization() *OrganizationQuery {
 			sqlgraph.From(machine.Table, machine.FieldID, selector),
 			sqlgraph.To(organization.Table, organization.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, machine.OrganizationTable, machine.OrganizationColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryProviders chains the current query on the "providers" edge.
+func (_q *MachineQuery) QueryProviders() *AgentProviderQuery {
+	query := (&AgentProviderClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(machine.Table, machine.FieldID, selector),
+			sqlgraph.To(agentprovider.Table, agentprovider.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, machine.ProvidersTable, machine.ProvidersColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -301,6 +325,7 @@ func (_q *MachineQuery) Clone() *MachineQuery {
 		inters:            append([]Interceptor{}, _q.inters...),
 		predicates:        append([]predicate.Machine{}, _q.predicates...),
 		withOrganization:  _q.withOrganization.Clone(),
+		withProviders:     _q.withProviders.Clone(),
 		withTargetTickets: _q.withTargetTickets.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
@@ -316,6 +341,17 @@ func (_q *MachineQuery) WithOrganization(opts ...func(*OrganizationQuery)) *Mach
 		opt(query)
 	}
 	_q.withOrganization = query
+	return _q
+}
+
+// WithProviders tells the query-builder to eager-load the nodes that are connected to
+// the "providers" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *MachineQuery) WithProviders(opts ...func(*AgentProviderQuery)) *MachineQuery {
+	query := (&AgentProviderClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withProviders = query
 	return _q
 }
 
@@ -408,8 +444,9 @@ func (_q *MachineQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Mach
 	var (
 		nodes       = []*Machine{}
 		_spec       = _q.querySpec()
-		loadedTypes = [2]bool{
+		loadedTypes = [3]bool{
 			_q.withOrganization != nil,
+			_q.withProviders != nil,
 			_q.withTargetTickets != nil,
 		}
 	)
@@ -434,6 +471,13 @@ func (_q *MachineQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Mach
 	if query := _q.withOrganization; query != nil {
 		if err := _q.loadOrganization(ctx, query, nodes, nil,
 			func(n *Machine, e *Organization) { n.Edges.Organization = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withProviders; query != nil {
+		if err := _q.loadProviders(ctx, query, nodes,
+			func(n *Machine) { n.Edges.Providers = []*AgentProvider{} },
+			func(n *Machine, e *AgentProvider) { n.Edges.Providers = append(n.Edges.Providers, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -473,6 +517,36 @@ func (_q *MachineQuery) loadOrganization(ctx context.Context, query *Organizatio
 		for i := range nodes {
 			assign(nodes[i], n)
 		}
+	}
+	return nil
+}
+func (_q *MachineQuery) loadProviders(ctx context.Context, query *AgentProviderQuery, nodes []*Machine, init func(*Machine), assign func(*Machine, *AgentProvider)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[uuid.UUID]*Machine)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(agentprovider.FieldMachineID)
+	}
+	query.Where(predicate.AgentProvider(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(machine.ProvidersColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.MachineID
+		node, ok := nodeids[fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "machine_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
 	}
 	return nil
 }

--- a/ent/machine_update.go
+++ b/ent/machine_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/BetterAndBetterII/openase/ent/agentprovider"
 	"github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/ent/organization"
 	"github.com/BetterAndBetterII/openase/ent/predicate"
@@ -264,6 +265,21 @@ func (_u *MachineUpdate) SetOrganization(v *Organization) *MachineUpdate {
 	return _u.SetOrganizationID(v.ID)
 }
 
+// AddProviderIDs adds the "providers" edge to the AgentProvider entity by IDs.
+func (_u *MachineUpdate) AddProviderIDs(ids ...uuid.UUID) *MachineUpdate {
+	_u.mutation.AddProviderIDs(ids...)
+	return _u
+}
+
+// AddProviders adds the "providers" edges to the AgentProvider entity.
+func (_u *MachineUpdate) AddProviders(v ...*AgentProvider) *MachineUpdate {
+	ids := make([]uuid.UUID, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddProviderIDs(ids...)
+}
+
 // AddTargetTicketIDs adds the "target_tickets" edge to the Ticket entity by IDs.
 func (_u *MachineUpdate) AddTargetTicketIDs(ids ...uuid.UUID) *MachineUpdate {
 	_u.mutation.AddTargetTicketIDs(ids...)
@@ -288,6 +304,27 @@ func (_u *MachineUpdate) Mutation() *MachineMutation {
 func (_u *MachineUpdate) ClearOrganization() *MachineUpdate {
 	_u.mutation.ClearOrganization()
 	return _u
+}
+
+// ClearProviders clears all "providers" edges to the AgentProvider entity.
+func (_u *MachineUpdate) ClearProviders() *MachineUpdate {
+	_u.mutation.ClearProviders()
+	return _u
+}
+
+// RemoveProviderIDs removes the "providers" edge to AgentProvider entities by IDs.
+func (_u *MachineUpdate) RemoveProviderIDs(ids ...uuid.UUID) *MachineUpdate {
+	_u.mutation.RemoveProviderIDs(ids...)
+	return _u
+}
+
+// RemoveProviders removes "providers" edges to AgentProvider entities.
+func (_u *MachineUpdate) RemoveProviders(v ...*AgentProvider) *MachineUpdate {
+	ids := make([]uuid.UUID, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveProviderIDs(ids...)
 }
 
 // ClearTargetTickets clears all "target_tickets" edges to the Ticket entity.
@@ -461,6 +498,51 @@ func (_u *MachineUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ProvidersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedProvidersIDs(); len(nodes) > 0 && !_u.mutation.ProvidersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ProvidersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -765,6 +847,21 @@ func (_u *MachineUpdateOne) SetOrganization(v *Organization) *MachineUpdateOne {
 	return _u.SetOrganizationID(v.ID)
 }
 
+// AddProviderIDs adds the "providers" edge to the AgentProvider entity by IDs.
+func (_u *MachineUpdateOne) AddProviderIDs(ids ...uuid.UUID) *MachineUpdateOne {
+	_u.mutation.AddProviderIDs(ids...)
+	return _u
+}
+
+// AddProviders adds the "providers" edges to the AgentProvider entity.
+func (_u *MachineUpdateOne) AddProviders(v ...*AgentProvider) *MachineUpdateOne {
+	ids := make([]uuid.UUID, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddProviderIDs(ids...)
+}
+
 // AddTargetTicketIDs adds the "target_tickets" edge to the Ticket entity by IDs.
 func (_u *MachineUpdateOne) AddTargetTicketIDs(ids ...uuid.UUID) *MachineUpdateOne {
 	_u.mutation.AddTargetTicketIDs(ids...)
@@ -789,6 +886,27 @@ func (_u *MachineUpdateOne) Mutation() *MachineMutation {
 func (_u *MachineUpdateOne) ClearOrganization() *MachineUpdateOne {
 	_u.mutation.ClearOrganization()
 	return _u
+}
+
+// ClearProviders clears all "providers" edges to the AgentProvider entity.
+func (_u *MachineUpdateOne) ClearProviders() *MachineUpdateOne {
+	_u.mutation.ClearProviders()
+	return _u
+}
+
+// RemoveProviderIDs removes the "providers" edge to AgentProvider entities by IDs.
+func (_u *MachineUpdateOne) RemoveProviderIDs(ids ...uuid.UUID) *MachineUpdateOne {
+	_u.mutation.RemoveProviderIDs(ids...)
+	return _u
+}
+
+// RemoveProviders removes "providers" edges to AgentProvider entities.
+func (_u *MachineUpdateOne) RemoveProviders(v ...*AgentProvider) *MachineUpdateOne {
+	ids := make([]uuid.UUID, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveProviderIDs(ids...)
 }
 
 // ClearTargetTickets clears all "target_tickets" edges to the Ticket entity.
@@ -992,6 +1110,51 @@ func (_u *MachineUpdateOne) sqlSave(ctx context.Context) (_node *Machine, err er
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ProvidersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedProvidersIDs(); len(nodes) > 0 && !_u.mutation.ProvidersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ProvidersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   machine.ProvidersTable,
+			Columns: []string{machine.ProvidersColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(agentprovider.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/migrate/migrations/20260319170201_202603190001_bootstrap_schema.sql
+++ b/ent/migrate/migrations/20260319170201_202603190001_bootstrap_schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE "agent_providers" (
   "model_max_tokens" bigint NOT NULL DEFAULT 16384,
   "cost_per_input_token" numeric(18,8) NOT NULL DEFAULT 0,
   "cost_per_output_token" numeric(18,8) NOT NULL DEFAULT 0,
+  "machine_id" uuid NOT NULL,
   "organization_id" uuid NOT NULL,
   PRIMARY KEY ("id")
 );
@@ -243,7 +244,7 @@ CREATE UNIQUE INDEX "workflow_project_id_name" ON "workflows" ("project_id", "na
 -- Modify "activity_events" table
 ALTER TABLE "activity_events" ADD CONSTRAINT "activity_events_agents_activity_events" FOREIGN KEY ("agent_id") REFERENCES "agents" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "activity_events_projects_activity_events" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION, ADD CONSTRAINT "activity_events_tickets_activity_events" FOREIGN KEY ("ticket_id") REFERENCES "tickets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
 -- Modify "agent_providers" table
-ALTER TABLE "agent_providers" ADD CONSTRAINT "agent_providers_organizations_providers" FOREIGN KEY ("organization_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+ALTER TABLE "agent_providers" ADD CONSTRAINT "agent_providers_machines_providers" FOREIGN KEY ("machine_id") REFERENCES "machines" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION, ADD CONSTRAINT "agent_providers_organizations_providers" FOREIGN KEY ("organization_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
 -- Modify "agents" table
 ALTER TABLE "agents" ADD CONSTRAINT "agents_agent_providers_agents" FOREIGN KEY ("provider_id") REFERENCES "agent_providers" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION, ADD CONSTRAINT "agents_projects_agents" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION, ADD CONSTRAINT "agents_tickets_current_ticket" FOREIGN KEY ("current_ticket_id") REFERENCES "tickets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
 -- Modify "organizations" table

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -114,6 +114,7 @@ var (
 		{Name: "model_max_tokens", Type: field.TypeInt, Default: 16384},
 		{Name: "cost_per_input_token", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "numeric(18,8)"}},
 		{Name: "cost_per_output_token", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "numeric(18,8)"}},
+		{Name: "machine_id", Type: field.TypeUUID},
 		{Name: "organization_id", Type: field.TypeUUID},
 	}
 	// AgentProvidersTable holds the schema information for the "agent_providers" table.
@@ -123,8 +124,14 @@ var (
 		PrimaryKey: []*schema.Column{AgentProvidersColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "agent_providers_organizations_providers",
+				Symbol:     "agent_providers_machines_providers",
 				Columns:    []*schema.Column{AgentProvidersColumns[11]},
+				RefColumns: []*schema.Column{MachinesColumns[0]},
+				OnDelete:   schema.NoAction,
+			},
+			{
+				Symbol:     "agent_providers_organizations_providers",
+				Columns:    []*schema.Column{AgentProvidersColumns[12]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -133,7 +140,7 @@ var (
 			{
 				Name:    "agentprovider_organization_id_name",
 				Unique:  true,
-				Columns: []*schema.Column{AgentProvidersColumns[11], AgentProvidersColumns[1]},
+				Columns: []*schema.Column{AgentProvidersColumns[12], AgentProvidersColumns[1]},
 			},
 		},
 	}
@@ -943,7 +950,8 @@ func init() {
 	ActivityEventsTable.ForeignKeys[2].RefTable = TicketsTable
 	AgentsTable.ForeignKeys[0].RefTable = AgentProvidersTable
 	AgentsTable.ForeignKeys[1].RefTable = ProjectsTable
-	AgentProvidersTable.ForeignKeys[0].RefTable = OrganizationsTable
+	AgentProvidersTable.ForeignKeys[0].RefTable = MachinesTable
+	AgentProvidersTable.ForeignKeys[1].RefTable = OrganizationsTable
 	AgentRunsTable.ForeignKeys[0].RefTable = AgentsTable
 	AgentRunsTable.ForeignKeys[1].RefTable = AgentProvidersTable
 	AgentRunsTable.ForeignKeys[2].RefTable = TicketsTable

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -2131,6 +2131,8 @@ type AgentProviderMutation struct {
 	clearedFields            map[string]struct{}
 	organization             *uuid.UUID
 	clearedorganization      bool
+	machine                  *uuid.UUID
+	clearedmachine           bool
 	agents                   map[uuid.UUID]struct{}
 	removedagents            map[uuid.UUID]struct{}
 	clearedagents            bool
@@ -2280,6 +2282,42 @@ func (m *AgentProviderMutation) OldOrganizationID(ctx context.Context) (v uuid.U
 // ResetOrganizationID resets all changes to the "organization_id" field.
 func (m *AgentProviderMutation) ResetOrganizationID() {
 	m.organization = nil
+}
+
+// SetMachineID sets the "machine_id" field.
+func (m *AgentProviderMutation) SetMachineID(u uuid.UUID) {
+	m.machine = &u
+}
+
+// MachineID returns the value of the "machine_id" field in the mutation.
+func (m *AgentProviderMutation) MachineID() (r uuid.UUID, exists bool) {
+	v := m.machine
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMachineID returns the old "machine_id" field's value of the AgentProvider entity.
+// If the AgentProvider object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentProviderMutation) OldMachineID(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMachineID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMachineID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMachineID: %w", err)
+	}
+	return oldValue.MachineID, nil
+}
+
+// ResetMachineID resets all changes to the "machine_id" field.
+func (m *AgentProviderMutation) ResetMachineID() {
+	m.machine = nil
 }
 
 // SetName sets the "name" field.
@@ -2762,6 +2800,33 @@ func (m *AgentProviderMutation) ResetOrganization() {
 	m.clearedorganization = false
 }
 
+// ClearMachine clears the "machine" edge to the Machine entity.
+func (m *AgentProviderMutation) ClearMachine() {
+	m.clearedmachine = true
+	m.clearedFields[agentprovider.FieldMachineID] = struct{}{}
+}
+
+// MachineCleared reports if the "machine" edge to the Machine entity was cleared.
+func (m *AgentProviderMutation) MachineCleared() bool {
+	return m.clearedmachine
+}
+
+// MachineIDs returns the "machine" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// MachineID instead. It exists only for internal usage by the builders.
+func (m *AgentProviderMutation) MachineIDs() (ids []uuid.UUID) {
+	if id := m.machine; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetMachine resets all changes to the "machine" edge.
+func (m *AgentProviderMutation) ResetMachine() {
+	m.machine = nil
+	m.clearedmachine = false
+}
+
 // AddAgentIDs adds the "agents" edge to the Agent entity by ids.
 func (m *AgentProviderMutation) AddAgentIDs(ids ...uuid.UUID) {
 	if m.agents == nil {
@@ -2904,9 +2969,12 @@ func (m *AgentProviderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentProviderMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.organization != nil {
 		fields = append(fields, agentprovider.FieldOrganizationID)
+	}
+	if m.machine != nil {
+		fields = append(fields, agentprovider.FieldMachineID)
 	}
 	if m.name != nil {
 		fields = append(fields, agentprovider.FieldName)
@@ -2948,6 +3016,8 @@ func (m *AgentProviderMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case agentprovider.FieldOrganizationID:
 		return m.OrganizationID()
+	case agentprovider.FieldMachineID:
+		return m.MachineID()
 	case agentprovider.FieldName:
 		return m.Name()
 	case agentprovider.FieldAdapterType:
@@ -2979,6 +3049,8 @@ func (m *AgentProviderMutation) OldField(ctx context.Context, name string) (ent.
 	switch name {
 	case agentprovider.FieldOrganizationID:
 		return m.OldOrganizationID(ctx)
+	case agentprovider.FieldMachineID:
+		return m.OldMachineID(ctx)
 	case agentprovider.FieldName:
 		return m.OldName(ctx)
 	case agentprovider.FieldAdapterType:
@@ -3014,6 +3086,13 @@ func (m *AgentProviderMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetOrganizationID(v)
+		return nil
+	case agentprovider.FieldMachineID:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMachineID(v)
 		return nil
 	case agentprovider.FieldName:
 		v, ok := value.(string)
@@ -3197,6 +3276,9 @@ func (m *AgentProviderMutation) ResetField(name string) error {
 	case agentprovider.FieldOrganizationID:
 		m.ResetOrganizationID()
 		return nil
+	case agentprovider.FieldMachineID:
+		m.ResetMachineID()
+		return nil
 	case agentprovider.FieldName:
 		m.ResetName()
 		return nil
@@ -3233,9 +3315,12 @@ func (m *AgentProviderMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *AgentProviderMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.organization != nil {
 		edges = append(edges, agentprovider.EdgeOrganization)
+	}
+	if m.machine != nil {
+		edges = append(edges, agentprovider.EdgeMachine)
 	}
 	if m.agents != nil {
 		edges = append(edges, agentprovider.EdgeAgents)
@@ -3252,6 +3337,10 @@ func (m *AgentProviderMutation) AddedIDs(name string) []ent.Value {
 	switch name {
 	case agentprovider.EdgeOrganization:
 		if id := m.organization; id != nil {
+			return []ent.Value{*id}
+		}
+	case agentprovider.EdgeMachine:
+		if id := m.machine; id != nil {
 			return []ent.Value{*id}
 		}
 	case agentprovider.EdgeAgents:
@@ -3272,7 +3361,7 @@ func (m *AgentProviderMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *AgentProviderMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.removedagents != nil {
 		edges = append(edges, agentprovider.EdgeAgents)
 	}
@@ -3304,9 +3393,12 @@ func (m *AgentProviderMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *AgentProviderMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.clearedorganization {
 		edges = append(edges, agentprovider.EdgeOrganization)
+	}
+	if m.clearedmachine {
+		edges = append(edges, agentprovider.EdgeMachine)
 	}
 	if m.clearedagents {
 		edges = append(edges, agentprovider.EdgeAgents)
@@ -3323,6 +3415,8 @@ func (m *AgentProviderMutation) EdgeCleared(name string) bool {
 	switch name {
 	case agentprovider.EdgeOrganization:
 		return m.clearedorganization
+	case agentprovider.EdgeMachine:
+		return m.clearedmachine
 	case agentprovider.EdgeAgents:
 		return m.clearedagents
 	case agentprovider.EdgeAgentRuns:
@@ -3338,6 +3432,9 @@ func (m *AgentProviderMutation) ClearEdge(name string) error {
 	case agentprovider.EdgeOrganization:
 		m.ClearOrganization()
 		return nil
+	case agentprovider.EdgeMachine:
+		m.ClearMachine()
+		return nil
 	}
 	return fmt.Errorf("unknown AgentProvider unique edge %s", name)
 }
@@ -3348,6 +3445,9 @@ func (m *AgentProviderMutation) ResetEdge(name string) error {
 	switch name {
 	case agentprovider.EdgeOrganization:
 		m.ResetOrganization()
+		return nil
+	case agentprovider.EdgeMachine:
+		m.ResetMachine()
 		return nil
 	case agentprovider.EdgeAgents:
 		m.ResetAgents()
@@ -5450,6 +5550,9 @@ type MachineMutation struct {
 	clearedFields         map[string]struct{}
 	organization          *uuid.UUID
 	clearedorganization   bool
+	providers             map[uuid.UUID]struct{}
+	removedproviders      map[uuid.UUID]struct{}
+	clearedproviders      bool
 	target_tickets        map[uuid.UUID]struct{}
 	removedtarget_tickets map[uuid.UUID]struct{}
 	clearedtarget_tickets bool
@@ -6217,6 +6320,60 @@ func (m *MachineMutation) ResetOrganization() {
 	m.clearedorganization = false
 }
 
+// AddProviderIDs adds the "providers" edge to the AgentProvider entity by ids.
+func (m *MachineMutation) AddProviderIDs(ids ...uuid.UUID) {
+	if m.providers == nil {
+		m.providers = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.providers[ids[i]] = struct{}{}
+	}
+}
+
+// ClearProviders clears the "providers" edge to the AgentProvider entity.
+func (m *MachineMutation) ClearProviders() {
+	m.clearedproviders = true
+}
+
+// ProvidersCleared reports if the "providers" edge to the AgentProvider entity was cleared.
+func (m *MachineMutation) ProvidersCleared() bool {
+	return m.clearedproviders
+}
+
+// RemoveProviderIDs removes the "providers" edge to the AgentProvider entity by IDs.
+func (m *MachineMutation) RemoveProviderIDs(ids ...uuid.UUID) {
+	if m.removedproviders == nil {
+		m.removedproviders = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.providers, ids[i])
+		m.removedproviders[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedProviders returns the removed IDs of the "providers" edge to the AgentProvider entity.
+func (m *MachineMutation) RemovedProvidersIDs() (ids []uuid.UUID) {
+	for id := range m.removedproviders {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ProvidersIDs returns the "providers" edge IDs in the mutation.
+func (m *MachineMutation) ProvidersIDs() (ids []uuid.UUID) {
+	for id := range m.providers {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetProviders resets all changes to the "providers" edge.
+func (m *MachineMutation) ResetProviders() {
+	m.providers = nil
+	m.clearedproviders = false
+	m.removedproviders = nil
+}
+
 // AddTargetTicketIDs adds the "target_tickets" edge to the Ticket entity by ids.
 func (m *MachineMutation) AddTargetTicketIDs(ids ...uuid.UUID) {
 	if m.target_tickets == nil {
@@ -6691,9 +6848,12 @@ func (m *MachineMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *MachineMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.organization != nil {
 		edges = append(edges, machine.EdgeOrganization)
+	}
+	if m.providers != nil {
+		edges = append(edges, machine.EdgeProviders)
 	}
 	if m.target_tickets != nil {
 		edges = append(edges, machine.EdgeTargetTickets)
@@ -6709,6 +6869,12 @@ func (m *MachineMutation) AddedIDs(name string) []ent.Value {
 		if id := m.organization; id != nil {
 			return []ent.Value{*id}
 		}
+	case machine.EdgeProviders:
+		ids := make([]ent.Value, 0, len(m.providers))
+		for id := range m.providers {
+			ids = append(ids, id)
+		}
+		return ids
 	case machine.EdgeTargetTickets:
 		ids := make([]ent.Value, 0, len(m.target_tickets))
 		for id := range m.target_tickets {
@@ -6721,7 +6887,10 @@ func (m *MachineMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *MachineMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
+	if m.removedproviders != nil {
+		edges = append(edges, machine.EdgeProviders)
+	}
 	if m.removedtarget_tickets != nil {
 		edges = append(edges, machine.EdgeTargetTickets)
 	}
@@ -6732,6 +6901,12 @@ func (m *MachineMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *MachineMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case machine.EdgeProviders:
+		ids := make([]ent.Value, 0, len(m.removedproviders))
+		for id := range m.removedproviders {
+			ids = append(ids, id)
+		}
+		return ids
 	case machine.EdgeTargetTickets:
 		ids := make([]ent.Value, 0, len(m.removedtarget_tickets))
 		for id := range m.removedtarget_tickets {
@@ -6744,9 +6919,12 @@ func (m *MachineMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *MachineMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.clearedorganization {
 		edges = append(edges, machine.EdgeOrganization)
+	}
+	if m.clearedproviders {
+		edges = append(edges, machine.EdgeProviders)
 	}
 	if m.clearedtarget_tickets {
 		edges = append(edges, machine.EdgeTargetTickets)
@@ -6760,6 +6938,8 @@ func (m *MachineMutation) EdgeCleared(name string) bool {
 	switch name {
 	case machine.EdgeOrganization:
 		return m.clearedorganization
+	case machine.EdgeProviders:
+		return m.clearedproviders
 	case machine.EdgeTargetTickets:
 		return m.clearedtarget_tickets
 	}
@@ -6783,6 +6963,9 @@ func (m *MachineMutation) ResetEdge(name string) error {
 	switch name {
 	case machine.EdgeOrganization:
 		m.ResetOrganization()
+		return nil
+	case machine.EdgeProviders:
+		m.ResetProviders()
 		return nil
 	case machine.EdgeTargetTickets:
 		m.ResetTargetTickets()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -71,35 +71,35 @@ func init() {
 	agentproviderFields := schema.AgentProvider{}.Fields()
 	_ = agentproviderFields
 	// agentproviderDescName is the schema descriptor for name field.
-	agentproviderDescName := agentproviderFields[2].Descriptor()
+	agentproviderDescName := agentproviderFields[3].Descriptor()
 	// agentprovider.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	agentprovider.NameValidator = agentproviderDescName.Validators[0].(func(string) error)
 	// agentproviderDescCliCommand is the schema descriptor for cli_command field.
-	agentproviderDescCliCommand := agentproviderFields[4].Descriptor()
+	agentproviderDescCliCommand := agentproviderFields[5].Descriptor()
 	// agentprovider.CliCommandValidator is a validator for the "cli_command" field. It is called by the builders before save.
 	agentprovider.CliCommandValidator = agentproviderDescCliCommand.Validators[0].(func(string) error)
 	// agentproviderDescAuthConfig is the schema descriptor for auth_config field.
-	agentproviderDescAuthConfig := agentproviderFields[6].Descriptor()
+	agentproviderDescAuthConfig := agentproviderFields[7].Descriptor()
 	// agentprovider.DefaultAuthConfig holds the default value on creation for the auth_config field.
 	agentprovider.DefaultAuthConfig = agentproviderDescAuthConfig.Default.(func() map[string]interface{})
 	// agentproviderDescModelName is the schema descriptor for model_name field.
-	agentproviderDescModelName := agentproviderFields[7].Descriptor()
+	agentproviderDescModelName := agentproviderFields[8].Descriptor()
 	// agentprovider.ModelNameValidator is a validator for the "model_name" field. It is called by the builders before save.
 	agentprovider.ModelNameValidator = agentproviderDescModelName.Validators[0].(func(string) error)
 	// agentproviderDescModelTemperature is the schema descriptor for model_temperature field.
-	agentproviderDescModelTemperature := agentproviderFields[8].Descriptor()
+	agentproviderDescModelTemperature := agentproviderFields[9].Descriptor()
 	// agentprovider.DefaultModelTemperature holds the default value on creation for the model_temperature field.
 	agentprovider.DefaultModelTemperature = agentproviderDescModelTemperature.Default.(float64)
 	// agentproviderDescModelMaxTokens is the schema descriptor for model_max_tokens field.
-	agentproviderDescModelMaxTokens := agentproviderFields[9].Descriptor()
+	agentproviderDescModelMaxTokens := agentproviderFields[10].Descriptor()
 	// agentprovider.DefaultModelMaxTokens holds the default value on creation for the model_max_tokens field.
 	agentprovider.DefaultModelMaxTokens = agentproviderDescModelMaxTokens.Default.(int)
 	// agentproviderDescCostPerInputToken is the schema descriptor for cost_per_input_token field.
-	agentproviderDescCostPerInputToken := agentproviderFields[10].Descriptor()
+	agentproviderDescCostPerInputToken := agentproviderFields[11].Descriptor()
 	// agentprovider.DefaultCostPerInputToken holds the default value on creation for the cost_per_input_token field.
 	agentprovider.DefaultCostPerInputToken = agentproviderDescCostPerInputToken.Default.(float64)
 	// agentproviderDescCostPerOutputToken is the schema descriptor for cost_per_output_token field.
-	agentproviderDescCostPerOutputToken := agentproviderFields[11].Descriptor()
+	agentproviderDescCostPerOutputToken := agentproviderFields[12].Descriptor()
 	// agentprovider.DefaultCostPerOutputToken holds the default value on creation for the cost_per_output_token field.
 	agentprovider.DefaultCostPerOutputToken = agentproviderDescCostPerOutputToken.Default.(float64)
 	// agentproviderDescID is the schema descriptor for id field.

--- a/ent/schema/agentprovider.go
+++ b/ent/schema/agentprovider.go
@@ -15,6 +15,7 @@ func (AgentProvider) Fields() []ent.Field {
 	return []ent.Field{
 		uuidField(),
 		field.UUID("organization_id", uuidZero()),
+		field.UUID("machine_id", uuidZero()),
 		field.String("name").NotEmpty(),
 		field.Enum("adapter_type").
 			Values("claude-code-cli", "codex-app-server", "gemini-cli", "custom"),
@@ -38,6 +39,11 @@ func (AgentProvider) Edges() []ent.Edge {
 		edge.From("organization", Organization.Type).
 			Ref("providers").
 			Field("organization_id").
+			Unique().
+			Required(),
+		edge.From("machine", Machine.Type).
+			Ref("providers").
+			Field("machine_id").
 			Unique().
 			Required(),
 		edge.To("agents", Agent.Type),

--- a/ent/schema/machine.go
+++ b/ent/schema/machine.go
@@ -44,6 +44,7 @@ func (Machine) Edges() []ent.Edge {
 			Field("organization_id").
 			Unique().
 			Required(),
+		edge.To("providers", AgentProvider.Type),
 		edge.To("target_tickets", Ticket.Type),
 	}
 }

--- a/internal/agentplatform/service_test.go
+++ b/internal/agentplatform/service_test.go
@@ -239,6 +239,16 @@ func seedAgentPlatformFixture(ctx context.Context, t *testing.T, client *ent.Cli
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -249,6 +259,7 @@ func seedAgentPlatformFixture(ctx context.Context, t *testing.T, client *ent.Cli
 	}
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/cli/issue_agent_token_test.go
+++ b/internal/cli/issue_agent_token_test.go
@@ -172,6 +172,16 @@ func seedCLIPlatformFixture(ctx context.Context, t *testing.T, client *ent.Clien
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("CLI OpenASE").
@@ -182,6 +192,7 @@ func seedCLIPlatformFixture(ctx context.Context, t *testing.T, client *ent.Clien
 	}
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/domain/catalog/agent_catalog.go
+++ b/internal/domain/catalog/agent_catalog.go
@@ -9,19 +9,27 @@ import (
 )
 
 type AgentProvider struct {
-	ID                 uuid.UUID
-	OrganizationID     uuid.UUID
-	Name               string
-	AdapterType        AgentProviderAdapterType
-	Available          bool
-	CliCommand         string
-	CliArgs            []string
-	AuthConfig         map[string]any
-	ModelName          string
-	ModelTemperature   float64
-	ModelMaxTokens     int
-	CostPerInputToken  float64
-	CostPerOutputToken float64
+	ID                   uuid.UUID
+	OrganizationID       uuid.UUID
+	MachineID            uuid.UUID
+	MachineName          string
+	MachineHost          string
+	MachineStatus        MachineStatus
+	MachineSSHUser       *string
+	MachineWorkspaceRoot *string
+	MachineAgentCLIPath  *string
+	MachineResources     map[string]any
+	Name                 string
+	AdapterType          AgentProviderAdapterType
+	Available            bool
+	CliCommand           string
+	CliArgs              []string
+	AuthConfig           map[string]any
+	ModelName            string
+	ModelTemperature     float64
+	ModelMaxTokens       int
+	CostPerInputToken    float64
+	CostPerOutputToken   float64
 }
 
 type Agent struct {
@@ -62,6 +70,7 @@ type AgentRun struct {
 }
 
 type AgentProviderInput struct {
+	MachineID          string         `json:"machine_id"`
 	Name               string         `json:"name"`
 	AdapterType        string         `json:"adapter_type"`
 	CliCommand         string         `json:"cli_command"`
@@ -82,6 +91,7 @@ type AgentInput struct {
 
 type CreateAgentProvider struct {
 	OrganizationID     uuid.UUID
+	MachineID          uuid.UUID
 	Name               string
 	AdapterType        AgentProviderAdapterType
 	CliCommand         string
@@ -97,6 +107,7 @@ type CreateAgentProvider struct {
 type UpdateAgentProvider struct {
 	ID                 uuid.UUID
 	OrganizationID     uuid.UUID
+	MachineID          uuid.UUID
 	Name               string
 	AdapterType        AgentProviderAdapterType
 	CliCommand         string
@@ -120,6 +131,11 @@ type CreateAgent struct {
 }
 
 func ParseCreateAgentProvider(organizationID uuid.UUID, raw AgentProviderInput) (CreateAgentProvider, error) {
+	machineID, err := parseRequiredUUID("machine_id", raw.MachineID)
+	if err != nil {
+		return CreateAgentProvider{}, err
+	}
+
 	name, err := parseName("name", raw.Name)
 	if err != nil {
 		return CreateAgentProvider{}, err
@@ -162,6 +178,7 @@ func ParseCreateAgentProvider(organizationID uuid.UUID, raw AgentProviderInput) 
 
 	return CreateAgentProvider{
 		OrganizationID:     organizationID,
+		MachineID:          machineID,
 		Name:               name,
 		AdapterType:        adapterType,
 		CliCommand:         strings.TrimSpace(raw.CliCommand),
@@ -184,6 +201,7 @@ func ParseUpdateAgentProvider(id uuid.UUID, organizationID uuid.UUID, raw AgentP
 	return UpdateAgentProvider{
 		ID:                 id,
 		OrganizationID:     input.OrganizationID,
+		MachineID:          input.MachineID,
 		Name:               input.Name,
 		AdapterType:        input.AdapterType,
 		CliCommand:         input.CliCommand,

--- a/internal/domain/catalog/agent_catalog_test.go
+++ b/internal/domain/catalog/agent_catalog_test.go
@@ -1,0 +1,35 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestParseCreateAgentProviderRequiresMachineID(t *testing.T) {
+	_, err := ParseCreateAgentProvider(uuid.New(), AgentProviderInput{
+		Name:        "Codex",
+		AdapterType: "codex-app-server",
+		ModelName:   "gpt-5.4",
+	})
+	if err == nil || err.Error() != "machine_id must not be empty" {
+		t.Fatalf("expected machine_id validation error, got %v", err)
+	}
+}
+
+func TestParseCreateAgentProviderParsesMachineID(t *testing.T) {
+	machineID := uuid.New()
+	input, err := ParseCreateAgentProvider(uuid.New(), AgentProviderInput{
+		MachineID:   machineID.String(),
+		Name:        "Codex",
+		AdapterType: "codex-app-server",
+		CliCommand:  "codex",
+		ModelName:   "gpt-5.4",
+	})
+	if err != nil {
+		t.Fatalf("ParseCreateAgentProvider returned error: %v", err)
+	}
+	if input.MachineID != machineID {
+		t.Fatalf("expected machine_id %s, got %s", machineID, input.MachineID)
+	}
+}

--- a/internal/httpapi/agent_catalog.go
+++ b/internal/httpapi/agent_catalog.go
@@ -11,19 +11,25 @@ import (
 )
 
 type agentProviderResponse struct {
-	ID                 string         `json:"id"`
-	OrganizationID     string         `json:"organization_id"`
-	Name               string         `json:"name"`
-	AdapterType        string         `json:"adapter_type"`
-	Available          bool           `json:"available"`
-	CliCommand         string         `json:"cli_command"`
-	CliArgs            []string       `json:"cli_args"`
-	AuthConfig         map[string]any `json:"auth_config"`
-	ModelName          string         `json:"model_name"`
-	ModelTemperature   float64        `json:"model_temperature"`
-	ModelMaxTokens     int            `json:"model_max_tokens"`
-	CostPerInputToken  float64        `json:"cost_per_input_token"`
-	CostPerOutputToken float64        `json:"cost_per_output_token"`
+	ID                   string         `json:"id"`
+	OrganizationID       string         `json:"organization_id"`
+	MachineID            string         `json:"machine_id"`
+	MachineName          string         `json:"machine_name"`
+	MachineHost          string         `json:"machine_host"`
+	MachineStatus        string         `json:"machine_status"`
+	MachineSSHUser       *string        `json:"machine_ssh_user,omitempty"`
+	MachineWorkspaceRoot *string        `json:"machine_workspace_root,omitempty"`
+	Name                 string         `json:"name"`
+	AdapterType          string         `json:"adapter_type"`
+	Available            bool           `json:"available"`
+	CliCommand           string         `json:"cli_command"`
+	CliArgs              []string       `json:"cli_args"`
+	AuthConfig           map[string]any `json:"auth_config"`
+	ModelName            string         `json:"model_name"`
+	ModelTemperature     float64        `json:"model_temperature"`
+	ModelMaxTokens       int            `json:"model_max_tokens"`
+	CostPerInputToken    float64        `json:"cost_per_input_token"`
+	CostPerOutputToken   float64        `json:"cost_per_output_token"`
 }
 
 type agentResponse struct {
@@ -50,6 +56,7 @@ type agentRuntimeResponse struct {
 }
 
 type agentProviderPatchRequest struct {
+	MachineID          *string         `json:"machine_id"`
 	Name               *string         `json:"name"`
 	AdapterType        *string         `json:"adapter_type"`
 	CliCommand         *string         `json:"cli_command"`
@@ -121,6 +128,7 @@ func (s *Server) patchAgentProvider(c echo.Context) error {
 	}
 
 	request := domain.AgentProviderInput{
+		MachineID:          current.MachineID.String(),
 		Name:               current.Name,
 		AdapterType:        current.AdapterType.String(),
 		CliCommand:         current.CliCommand,
@@ -131,6 +139,9 @@ func (s *Server) patchAgentProvider(c echo.Context) error {
 		ModelMaxTokens:     intPointer(current.ModelMaxTokens),
 		CostPerInputToken:  floatPointer(current.CostPerInputToken),
 		CostPerOutputToken: floatPointer(current.CostPerOutputToken),
+	}
+	if patch.MachineID != nil {
+		request.MachineID = *patch.MachineID
 	}
 	if patch.Name != nil {
 		request.Name = *patch.Name
@@ -317,20 +328,34 @@ func mapAgentProviderResponses(items []domain.AgentProvider) []agentProviderResp
 
 func mapAgentProviderResponse(item domain.AgentProvider) agentProviderResponse {
 	return agentProviderResponse{
-		ID:                 item.ID.String(),
-		OrganizationID:     item.OrganizationID.String(),
-		Name:               item.Name,
-		AdapterType:        item.AdapterType.String(),
-		Available:          item.Available,
-		CliCommand:         item.CliCommand,
-		CliArgs:            cloneStringSlice(item.CliArgs),
-		AuthConfig:         cloneMap(item.AuthConfig),
-		ModelName:          item.ModelName,
-		ModelTemperature:   item.ModelTemperature,
-		ModelMaxTokens:     item.ModelMaxTokens,
-		CostPerInputToken:  item.CostPerInputToken,
-		CostPerOutputToken: item.CostPerOutputToken,
+		ID:                   item.ID.String(),
+		OrganizationID:       item.OrganizationID.String(),
+		MachineID:            item.MachineID.String(),
+		MachineName:          item.MachineName,
+		MachineHost:          item.MachineHost,
+		MachineStatus:        item.MachineStatus.String(),
+		MachineSSHUser:       stringPointerValue(item.MachineSSHUser),
+		MachineWorkspaceRoot: stringPointerValue(item.MachineWorkspaceRoot),
+		Name:                 item.Name,
+		AdapterType:          item.AdapterType.String(),
+		Available:            item.Available,
+		CliCommand:           item.CliCommand,
+		CliArgs:              cloneStringSlice(item.CliArgs),
+		AuthConfig:           cloneMap(item.AuthConfig),
+		ModelName:            item.ModelName,
+		ModelTemperature:     item.ModelTemperature,
+		ModelMaxTokens:       item.ModelMaxTokens,
+		CostPerInputToken:    item.CostPerInputToken,
+		CostPerOutputToken:   item.CostPerOutputToken,
 	}
+}
+
+func stringPointerValue(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
 }
 
 func mapAgentResponses(items []domain.Agent) []agentResponse {

--- a/internal/httpapi/agent_catalog_test.go
+++ b/internal/httpapi/agent_catalog_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BetterAndBetterII/openase/ent"
+	entmachine "github.com/BetterAndBetterII/openase/ent/machine"
 	"github.com/BetterAndBetterII/openase/internal/config"
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	eventinfra "github.com/BetterAndBetterII/openase/internal/infra/event"
@@ -49,7 +51,7 @@ func TestAgentProviderAndAgentRoutes(t *testing.T) {
 		server,
 		http.MethodPost,
 		"/api/v1/orgs/"+orgPayload.Organization.ID+"/providers",
-		`{"name":"Codex","adapter_type":"codex-app-server","cli_command":"codex","cli_args":["app-server","--listen","stdio://"],"auth_config":{"token":"secret"},"model_name":"gpt-5.3-codex","model_temperature":0.1,"model_max_tokens":32000,"cost_per_input_token":0.001,"cost_per_output_token":0.002}`,
+		`{"machine_id":"`+findLocalMachineID(t, server.catalog.(*fakeCatalogService), orgPayload.Organization.ID)+`","name":"Codex","adapter_type":"codex-app-server","cli_command":"codex","cli_args":["app-server","--listen","stdio://"],"auth_config":{"token":"secret"},"model_name":"gpt-5.3-codex","model_temperature":0.1,"model_max_tokens":32000,"cost_per_input_token":0.001,"cost_per_output_token":0.002}`,
 	)
 	if providerRec.Code != http.StatusCreated {
 		t.Fatalf("expected provider create 201, got %d: %s", providerRec.Code, providerRec.Body.String())
@@ -61,6 +63,9 @@ func TestAgentProviderAndAgentRoutes(t *testing.T) {
 	decodeResponse(t, providerRec, &providerPayload)
 	if providerPayload.Provider.CliCommand != "codex" {
 		t.Fatalf("expected provider cli_command to round-trip, got %+v", providerPayload.Provider)
+	}
+	if providerPayload.Provider.MachineName != domain.LocalMachineName {
+		t.Fatalf("expected provider machine metadata to round-trip, got %+v", providerPayload.Provider)
 	}
 
 	listProviderRec := performJSONRequest(t, server, http.MethodGet, "/api/v1/orgs/"+orgPayload.Organization.ID+"/providers", "")
@@ -159,7 +164,7 @@ func TestAgentProviderAndAgentRoutesWithEntRepository(t *testing.T) {
 		server,
 		http.MethodPost,
 		"/api/v1/orgs/"+orgPayload.Organization.ID+"/providers",
-		`{"name":"Codex","adapter_type":"codex-app-server","cli_command":"codex","cli_args":["app-server","--listen","stdio://"],"auth_config":{"token":"secret"},"model_name":"gpt-5.4"}`,
+		`{"machine_id":"`+loadEntLocalMachineID(t, client, orgPayload.Organization.ID)+`","name":"Codex","adapter_type":"codex-app-server","cli_command":"codex","cli_args":["app-server","--listen","stdio://"],"auth_config":{"token":"secret"},"model_name":"gpt-5.4"}`,
 	)
 	if providerRec.Code != http.StatusCreated {
 		t.Fatalf("expected provider create 201, got %d: %s", providerRec.Code, providerRec.Body.String())
@@ -256,7 +261,7 @@ func TestAgentProviderRoutesRejectInvalidInput(t *testing.T) {
 		server,
 		http.MethodPost,
 		"/api/v1/orgs/"+orgPayload.Organization.ID+"/providers",
-		`{"name":"Custom","adapter_type":"custom","model_name":"manual"}`,
+		`{"machine_id":"`+findLocalMachineID(t, server.catalog.(*fakeCatalogService), orgPayload.Organization.ID)+`","name":"Custom","adapter_type":"custom","model_name":"manual"}`,
 	)
 	if providerRec.Code != http.StatusBadRequest {
 		t.Fatalf("expected provider create 400, got %d: %s", providerRec.Code, providerRec.Body.String())
@@ -326,7 +331,7 @@ func TestListAgentsRouteOmitsCapabilitiesField(t *testing.T) {
 	agentID := uuid.New()
 	service.organizations[orgID] = domain.Organization{ID: orgID, Name: "Acme", Slug: "acme"}
 	service.projects[projectID] = domain.Project{ID: projectID, OrganizationID: orgID, Name: "OpenASE", Slug: "openase"}
-	service.providers[providerID] = domain.AgentProvider{ID: providerID, OrganizationID: orgID, Name: "Codex"}
+	service.providers[providerID] = domain.AgentProvider{ID: providerID, OrganizationID: orgID, MachineID: uuid.New(), Name: "Codex"}
 	service.agents[agentID] = domain.Agent{
 		ID:                  agentID,
 		ProviderID:          providerID,
@@ -377,7 +382,7 @@ func TestPauseAndResumeAgentRoutes(t *testing.T) {
 	ticketID := uuid.New()
 	service.organizations[orgID] = domain.Organization{ID: orgID, Name: "Acme", Slug: "acme"}
 	service.projects[projectID] = domain.Project{ID: projectID, OrganizationID: orgID, Name: "OpenASE", Slug: "openase"}
-	service.providers[providerID] = domain.AgentProvider{ID: providerID, OrganizationID: orgID, Name: "Codex"}
+	service.providers[providerID] = domain.AgentProvider{ID: providerID, OrganizationID: orgID, MachineID: uuid.New(), Name: "Codex"}
 	service.agents[agentID] = domain.Agent{
 		ID:                  agentID,
 		ProviderID:          providerID,
@@ -461,20 +466,33 @@ func (f *fakeCatalogService) CreateAgentProvider(_ context.Context, input domain
 	if input.CliCommand == "" {
 		return domain.AgentProvider{}, fmt.Errorf("%w: cli_command must not be empty", catalogservice.ErrInvalidInput)
 	}
+	if _, ok := f.machines[input.MachineID]; !ok {
+		return domain.AgentProvider{}, fmt.Errorf("%w: machine_id must reference an existing machine", catalogservice.ErrInvalidInput)
+	}
+
+	machine := f.machines[input.MachineID]
 
 	provider := domain.AgentProvider{
-		ID:                 uuid.New(),
-		OrganizationID:     input.OrganizationID,
-		Name:               input.Name,
-		AdapterType:        input.AdapterType,
-		CliCommand:         input.CliCommand,
-		CliArgs:            append([]string(nil), input.CliArgs...),
-		AuthConfig:         cloneMap(input.AuthConfig),
-		ModelName:          input.ModelName,
-		ModelTemperature:   input.ModelTemperature,
-		ModelMaxTokens:     input.ModelMaxTokens,
-		CostPerInputToken:  input.CostPerInputToken,
-		CostPerOutputToken: input.CostPerOutputToken,
+		ID:                   uuid.New(),
+		OrganizationID:       input.OrganizationID,
+		MachineID:            input.MachineID,
+		MachineName:          machine.Name,
+		MachineHost:          machine.Host,
+		MachineStatus:        machine.Status,
+		MachineSSHUser:       cloneStringPointer(machine.SSHUser),
+		MachineWorkspaceRoot: cloneStringPointer(machine.WorkspaceRoot),
+		MachineAgentCLIPath:  cloneStringPointer(machine.AgentCLIPath),
+		MachineResources:     cloneMap(machine.Resources),
+		Name:                 input.Name,
+		AdapterType:          input.AdapterType,
+		CliCommand:           input.CliCommand,
+		CliArgs:              append([]string(nil), input.CliArgs...),
+		AuthConfig:           cloneMap(input.AuthConfig),
+		ModelName:            input.ModelName,
+		ModelTemperature:     input.ModelTemperature,
+		ModelMaxTokens:       input.ModelMaxTokens,
+		CostPerInputToken:    input.CostPerInputToken,
+		CostPerOutputToken:   input.CostPerOutputToken,
 	}
 	f.providers[provider.ID] = provider
 
@@ -497,20 +515,33 @@ func (f *fakeCatalogService) UpdateAgentProvider(_ context.Context, input domain
 	if input.CliCommand == "" {
 		return domain.AgentProvider{}, fmt.Errorf("%w: cli_command must not be empty", catalogservice.ErrInvalidInput)
 	}
+	if _, ok := f.machines[input.MachineID]; !ok {
+		return domain.AgentProvider{}, fmt.Errorf("%w: machine_id must reference an existing machine", catalogservice.ErrInvalidInput)
+	}
+
+	machine := f.machines[input.MachineID]
 
 	item := domain.AgentProvider{
-		ID:                 input.ID,
-		OrganizationID:     input.OrganizationID,
-		Name:               input.Name,
-		AdapterType:        input.AdapterType,
-		CliCommand:         input.CliCommand,
-		CliArgs:            append([]string(nil), input.CliArgs...),
-		AuthConfig:         cloneMap(input.AuthConfig),
-		ModelName:          input.ModelName,
-		ModelTemperature:   input.ModelTemperature,
-		ModelMaxTokens:     input.ModelMaxTokens,
-		CostPerInputToken:  input.CostPerInputToken,
-		CostPerOutputToken: input.CostPerOutputToken,
+		ID:                   input.ID,
+		OrganizationID:       input.OrganizationID,
+		MachineID:            input.MachineID,
+		MachineName:          machine.Name,
+		MachineHost:          machine.Host,
+		MachineStatus:        machine.Status,
+		MachineSSHUser:       cloneStringPointer(machine.SSHUser),
+		MachineWorkspaceRoot: cloneStringPointer(machine.WorkspaceRoot),
+		MachineAgentCLIPath:  cloneStringPointer(machine.AgentCLIPath),
+		MachineResources:     cloneMap(machine.Resources),
+		Name:                 input.Name,
+		AdapterType:          input.AdapterType,
+		CliCommand:           input.CliCommand,
+		CliArgs:              append([]string(nil), input.CliArgs...),
+		AuthConfig:           cloneMap(input.AuthConfig),
+		ModelName:            input.ModelName,
+		ModelTemperature:     input.ModelTemperature,
+		ModelMaxTokens:       input.ModelMaxTokens,
+		CostPerInputToken:    input.CostPerInputToken,
+		CostPerOutputToken:   input.CostPerOutputToken,
 	}
 	f.providers[input.ID] = item
 
@@ -724,4 +755,45 @@ func cloneTimePointer(value *time.Time) *time.Time {
 
 	cloned := value.UTC()
 	return &cloned
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+func findLocalMachineID(t *testing.T, service *fakeCatalogService, organizationID string) string {
+	t.Helper()
+	orgID, err := uuid.Parse(organizationID)
+	if err != nil {
+		t.Fatalf("parse organization id: %v", err)
+	}
+	for _, machine := range service.machines {
+		if machine.OrganizationID == orgID && machine.Name == domain.LocalMachineName {
+			return machine.ID.String()
+		}
+	}
+	t.Fatalf("local machine not found for organization %s", organizationID)
+	return ""
+}
+
+func loadEntLocalMachineID(t *testing.T, client *ent.Client, organizationID string) string {
+	t.Helper()
+	orgID, err := uuid.Parse(organizationID)
+	if err != nil {
+		t.Fatalf("parse organization id: %v", err)
+	}
+	machine, err := client.Machine.Query().
+		Where(
+			entmachine.OrganizationIDEQ(orgID),
+			entmachine.NameEQ(domain.LocalMachineName),
+		).
+		Only(context.Background())
+	if err != nil {
+		t.Fatalf("load local machine: %v", err)
+	}
+	return machine.ID.String()
 }

--- a/internal/httpapi/agent_platform_api_test.go
+++ b/internal/httpapi/agent_platform_api_test.go
@@ -393,6 +393,16 @@ func seedAgentPlatformHTTPFixture(ctx context.Context, t *testing.T, client *ent
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -403,6 +413,7 @@ func seedAgentPlatformHTTPFixture(ctx context.Context, t *testing.T, client *ent
 	}
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/httpapi/catalog_test.go
+++ b/internal/httpapi/catalog_test.go
@@ -921,6 +921,10 @@ func (f *fakeCatalogService) CreateOrganization(_ context.Context, input domain.
 		f.providers[providerID] = domain.AgentProvider{
 			ID:             providerID,
 			OrganizationID: item.ID,
+			MachineID:      localID,
+			MachineName:    domain.LocalMachineName,
+			MachineHost:    domain.LocalMachineHost,
+			MachineStatus:  domain.MachineStatusOnline,
 			Name:           template.Name,
 			AdapterType:    template.AdapterType,
 			CliCommand:     template.Command,

--- a/internal/httpapi/chat_api_test.go
+++ b/internal/httpapi/chat_api_test.go
@@ -37,6 +37,18 @@ func TestChatRouteStreamsTicketDetailContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName(catalogdomain.LocalMachineName).
+		SetHost(catalogdomain.LocalMachineHost).
+		SetPort(22).
+		SetDescription("Control-plane local execution host.").
+		SetStatus("online").
+		SetResources(map[string]any{"transport": "local", "last_success": true}).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -98,6 +110,7 @@ func TestChatRouteStreamsTicketDetailContext(t *testing.T) {
 
 	catalogSvc := catalogservice.New(catalogrepo.NewEntRepository(client), executable.NewPathResolver(), nil)
 	providerInput, err := catalogdomain.ParseCreateAgentProvider(org.ID, catalogdomain.AgentProviderInput{
+		MachineID:   localMachine.ID.String(),
 		Name:        "Claude Code",
 		AdapterType: "claude-code-cli",
 		CliCommand:  "claude",

--- a/internal/httpapi/github_webhook_test.go
+++ b/internal/httpapi/github_webhook_test.go
@@ -426,6 +426,16 @@ func newGitHubWebhookLifecycleFixture(
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -443,6 +453,7 @@ func newGitHubWebhookLifecycleFixture(
 
 	providerItem, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/httpapi/hr_advisor_api_test.go
+++ b/internal/httpapi/hr_advisor_api_test.go
@@ -72,6 +72,16 @@ func TestHRAdvisorRouteReturnsRecommendationsAndActivationState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 
 	statuses, err := ticketstatus.NewService(client).ResetToDefaultTemplate(ctx, project.ID)
 	if err != nil {
@@ -87,6 +97,7 @@ func TestHRAdvisorRouteReturnsRecommendationsAndActivationState(t *testing.T) {
 
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCustom).
 		SetCliCommand("codex").

--- a/internal/httpapi/openapi.go
+++ b/internal/httpapi/openapi.go
@@ -78,19 +78,25 @@ type OpenAPIProjectRepo struct {
 }
 
 type OpenAPIAgentProvider struct {
-	ID                 string         `json:"id"`
-	OrganizationID     string         `json:"organization_id"`
-	Name               string         `json:"name"`
-	AdapterType        string         `json:"adapter_type"`
-	Available          bool           `json:"available"`
-	CliCommand         string         `json:"cli_command"`
-	CliArgs            []string       `json:"cli_args"`
-	AuthConfig         map[string]any `json:"auth_config"`
-	ModelName          string         `json:"model_name"`
-	ModelTemperature   float64        `json:"model_temperature"`
-	ModelMaxTokens     int            `json:"model_max_tokens"`
-	CostPerInputToken  float64        `json:"cost_per_input_token"`
-	CostPerOutputToken float64        `json:"cost_per_output_token"`
+	ID                   string         `json:"id"`
+	OrganizationID       string         `json:"organization_id"`
+	MachineID            string         `json:"machine_id"`
+	MachineName          string         `json:"machine_name"`
+	MachineHost          string         `json:"machine_host"`
+	MachineStatus        string         `json:"machine_status"`
+	MachineSSHUser       *string        `json:"machine_ssh_user,omitempty"`
+	MachineWorkspaceRoot *string        `json:"machine_workspace_root,omitempty"`
+	Name                 string         `json:"name"`
+	AdapterType          string         `json:"adapter_type"`
+	Available            bool           `json:"available"`
+	CliCommand           string         `json:"cli_command"`
+	CliArgs              []string       `json:"cli_args"`
+	AuthConfig           map[string]any `json:"auth_config"`
+	ModelName            string         `json:"model_name"`
+	ModelTemperature     float64        `json:"model_temperature"`
+	ModelMaxTokens       int            `json:"model_max_tokens"`
+	CostPerInputToken    float64        `json:"cost_per_input_token"`
+	CostPerOutputToken   float64        `json:"cost_per_output_token"`
 }
 
 type OpenAPIAgent struct {

--- a/internal/httpapi/skills_api_test.go
+++ b/internal/httpapi/skills_api_test.go
@@ -62,6 +62,16 @@ func TestSkillRoutesRefreshHarvestBindAndUnbind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 
 	statuses, err := ticketstatus.NewService(client).ResetToDefaultTemplate(ctx, project.ID)
 	if err != nil {
@@ -71,6 +81,7 @@ func TestSkillRoutesRefreshHarvestBindAndUnbind(t *testing.T) {
 	doneID := findStatusIDByName(t, statuses, "Done")
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").
@@ -354,6 +365,16 @@ func TestSkillBindRouteRejectsMissingSkill(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	statuses, err := ticketstatus.NewService(client).ResetToDefaultTemplate(ctx, project.ID)
 	if err != nil {
 		t.Fatalf("reset ticket statuses: %v", err)
@@ -362,6 +383,7 @@ func TestSkillBindRouteRejectsMissingSkill(t *testing.T) {
 	doneID := findStatusIDByName(t, statuses, "Done")
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/httpapi/ticket_api_test.go
+++ b/internal/httpapi/ticket_api_test.go
@@ -742,6 +742,16 @@ func TestTicketRoutesCreateFirstTicketPerProjectAfterWorkflowCreate(t *testing.T
 		if err != nil {
 			t.Fatalf("create project %d: %v", index+1, err)
 		}
+		localMachine, err := client.Machine.Create().
+			SetOrganizationID(org.ID).
+			SetName(fmt.Sprintf("local-%d", index+1)).
+			SetHost("local").
+			SetPort(22).
+			SetStatus("online").
+			Save(ctx)
+		if err != nil {
+			t.Fatalf("create local machine %d: %v", index+1, err)
+		}
 
 		statuses := struct {
 			Statuses []ticketstatus.Status `json:"statuses"`
@@ -759,6 +769,7 @@ func TestTicketRoutesCreateFirstTicketPerProjectAfterWorkflowCreate(t *testing.T
 		doneID := findStatusIDByName(t, statuses.Statuses, "Done")
 		provider, err := client.AgentProvider.Create().
 			SetOrganizationID(org.ID).
+			SetMachineID(localMachine.ID).
 			SetName(fmt.Sprintf("Codex %d", index+1)).
 			SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 			SetCliCommand("codex").
@@ -1136,6 +1147,16 @@ func TestTicketRouteStatusChangeClearsAssignmentAndReleasesAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -1146,6 +1167,7 @@ func TestTicketRouteStatusChangeClearsAssignmentAndReleasesAgent(t *testing.T) {
 	}
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/internal/httpapi/workflow_api_test.go
+++ b/internal/httpapi/workflow_api_test.go
@@ -60,6 +60,16 @@ func TestWorkflowRoutesCRUDHarnessStorageAndHotReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -80,6 +90,7 @@ func TestWorkflowRoutesCRUDHarnessStorageAndHotReload(t *testing.T) {
 	reloadMarkerPath := filepath.Join(repoRoot, "reload.marker")
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").
@@ -469,6 +480,16 @@ func TestBuildHarnessTemplateDataAndRenderBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -489,6 +510,7 @@ func TestBuildHarnessTemplateDataAndRenderBody(t *testing.T) {
 	doneID := findStatusIDByName(t, statuses, "Done")
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Claude Code").
 		SetAdapterType(entagentprovider.AdapterTypeClaudeCodeCli).
 		SetCliCommand("claude").

--- a/internal/orchestrator/runtime_launcher.go
+++ b/internal/orchestrator/runtime_launcher.go
@@ -706,33 +706,19 @@ func (l *RuntimeLauncher) resolveLaunchMachine(ctx context.Context, launchContex
 		return catalogdomain.Machine{}, false, fmt.Errorf("list machines for runtime launch: %w", err)
 	}
 
-	workspacePath := strings.TrimSpace(launchContext.agent.WorkspacePath)
-	var matched *ent.Machine
-	for _, machineItem := range machines {
-		if machineItem.Host == catalogdomain.LocalMachineHost || strings.TrimSpace(machineItem.WorkspaceRoot) == "" {
-			continue
-		}
-		if pathWithinRoot(workspacePath, machineItem.WorkspaceRoot) {
-			if matched != nil {
-				return catalogdomain.Machine{}, false, fmt.Errorf("workspace path %q matches multiple remote machines", workspacePath)
-			}
-			matched = machineItem
-		}
-	}
-	if matched != nil {
-		return mapRuntimeMachine(matched), true, nil
+	providerItem := launchContext.agent.Edges.Provider
+	if providerItem == nil {
+		return catalogdomain.Machine{}, false, fmt.Errorf("agent provider must be loaded")
 	}
 
 	for _, machineItem := range machines {
-		if machineItem.Host == catalogdomain.LocalMachineHost {
-			return mapRuntimeMachine(machineItem), false, nil
+		if machineItem.ID == providerItem.MachineID {
+			mapped := mapRuntimeMachine(machineItem)
+			return mapped, mapped.Host != catalogdomain.LocalMachineHost, nil
 		}
 	}
 
-	return catalogdomain.Machine{
-		Name: catalogdomain.LocalMachineName,
-		Host: catalogdomain.LocalMachineHost,
-	}, false, nil
+	return catalogdomain.Machine{}, false, fmt.Errorf("provider %s bound machine %s not found", providerItem.ID, providerItem.MachineID)
 }
 
 func buildRemoteWorkspaceRequest(launchContext runtimeLaunchContext, machine catalogdomain.Machine) (workspaceinfra.SetupRequest, error) {
@@ -798,23 +784,6 @@ func buildWorkspaceRepoInputs(projectRepos []*ent.ProjectRepo, ticketScopes []*e
 	}
 
 	return inputs
-}
-
-func pathWithinRoot(path string, root string) bool {
-	trimmedPath := strings.TrimSpace(path)
-	trimmedRoot := strings.TrimSpace(root)
-	if trimmedPath == "" || trimmedRoot == "" {
-		return false
-	}
-
-	cleanPath := filepath.Clean(trimmedPath)
-	cleanRoot := filepath.Clean(trimmedRoot)
-	if cleanPath == cleanRoot {
-		return true
-	}
-
-	relative, err := filepath.Rel(cleanRoot, cleanPath)
-	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func mapRuntimeMachine(item *ent.Machine) catalogdomain.Machine {

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -771,6 +771,20 @@ func TestRuntimeLauncherRunTickPreparesRemoteWorkspaceAndLaunchesOverSSH(t *test
 		Save(ctx); err != nil {
 		t.Fatalf("create machine: %v", err)
 	}
+	remoteMachine, err := client.Machine.Query().
+		Where(
+			entmachine.OrganizationIDEQ(fixture.orgID),
+			entmachine.NameEQ("gpu-01"),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("load remote machine: %v", err)
+	}
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetMachineID(remoteMachine.ID).
+		Save(ctx); err != nil {
+		t.Fatalf("bind provider machine: %v", err)
+	}
 
 	agentItem, err := client.Agent.Create().
 		SetProjectID(fixture.projectID).
@@ -878,6 +892,20 @@ func TestRuntimeLauncherRunTickFailsWhenRemoteCodexEnvironmentIsNotReady(t *test
 		}).
 		Save(ctx); err != nil {
 		t.Fatalf("create machine: %v", err)
+	}
+	remoteMachine, err := client.Machine.Query().
+		Where(
+			entmachine.OrganizationIDEQ(fixture.orgID),
+			entmachine.NameEQ("gpu-02"),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("load remote machine: %v", err)
+	}
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetMachineID(remoteMachine.ID).
+		Save(ctx); err != nil {
+		t.Fatalf("bind provider machine: %v", err)
 	}
 
 	agentItem, err := client.Agent.Create().

--- a/internal/orchestrator/scheduler.go
+++ b/internal/orchestrator/scheduler.go
@@ -16,7 +16,6 @@ import (
 	entticket "github.com/BetterAndBetterII/openase/ent/ticket"
 	entticketdependency "github.com/BetterAndBetterII/openase/ent/ticketdependency"
 	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
-	domaincatalog "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/BetterAndBetterII/openase/internal/provider"
 	scheduledjobservice "github.com/BetterAndBetterII/openase/internal/scheduledjob"
 	ticketservice "github.com/BetterAndBetterII/openase/internal/ticket"
@@ -174,9 +173,9 @@ func (s *Scheduler) tryDispatch(ctx context.Context, workflow *ent.Workflow, tic
 	if agent == nil {
 		return false, skipReasonNoAgent, nil
 	}
-	machine, err := s.selectMachine(ctx, project.OrganizationID, workflow, ticket)
+	machine, err := s.resolveExecutionMachine(ctx, project.OrganizationID, agent)
 	if err != nil {
-		return false, "", fmt.Errorf("select machine: %w", err)
+		return false, "", fmt.Errorf("resolve execution machine: %w", err)
 	}
 	if machine == nil {
 		return false, skipReasonNoMachine, nil
@@ -221,76 +220,41 @@ func (s *Scheduler) resolveWorkflowAgent(ctx context.Context, workflow *ent.Work
 	return agentItem, nil
 }
 
-func (s *Scheduler) selectMachine(
+func (s *Scheduler) resolveExecutionMachine(
 	ctx context.Context,
 	organizationID uuid.UUID,
-	workflow *ent.Workflow,
-	ticket *ent.Ticket,
+	agent *ent.Agent,
 ) (*ent.Machine, error) {
-	if ticket != nil && ticket.TargetMachineID != nil {
-		machine, err := s.client.Machine.Query().
-			Where(
-				entmachine.IDEQ(*ticket.TargetMachineID),
-				entmachine.OrganizationIDEQ(organizationID),
-			).
-			Only(ctx)
-		if err != nil {
-			if ent.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		if machine.Status != entmachine.StatusOnline {
+	providerItem, err := s.client.AgentProvider.Get(ctx, agent.ProviderID)
+	if err != nil {
+		if ent.IsNotFound(err) {
 			return nil, nil
 		}
-		return machine, nil
-	}
-
-	if len(workflow.RequiredMachineLabels) == 0 {
-		machine, err := s.client.Machine.Query().
-			Where(
-				entmachine.OrganizationIDEQ(organizationID),
-				entmachine.NameEQ(domaincatalog.LocalMachineName),
-				entmachine.StatusEQ(entmachine.StatusOnline),
-			).
-			Only(ctx)
-		if err != nil {
-			if ent.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return machine, nil
-	}
-
-	machines, err := s.client.Machine.Query().
-		Where(
-			entmachine.OrganizationIDEQ(organizationID),
-			entmachine.StatusEQ(entmachine.StatusOnline),
-		).
-		Order(ent.Asc(entmachine.FieldName)).
-		All(ctx)
-	if err != nil {
 		return nil, err
 	}
-	for _, machine := range machines {
-		if machineHasAllLabels(machine.Labels, workflow.RequiredMachineLabels) {
-			return machine, nil
-		}
+	if providerItem.OrganizationID != organizationID {
+		return nil, nil
 	}
 
-	return nil, nil
+	machine, err := s.client.Machine.Query().
+		Where(
+			entmachine.OrganizationIDEQ(organizationID),
+			entmachine.IDEQ(providerItem.MachineID),
+		).
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if machine.Status != entmachine.StatusOnline {
+		return nil, nil
+	}
+	return machine, nil
 }
 
-func (s *Scheduler) claimTicketWithAgent(
-	ctx context.Context,
-	workflow *ent.Workflow,
-	ticket *ent.Ticket,
-	machine *ent.Machine,
-	agent *ent.Agent,
-	projectMaxConcurrent int,
-	now time.Time,
-) (string, error) {
+func (s *Scheduler) claimTicketWithAgent(ctx context.Context, workflow *ent.Workflow, ticket *ent.Ticket, machine *ent.Machine, agent *ent.Agent, projectMaxConcurrent int, now time.Time) (string, error) {
 	tx, err := s.client.Tx(ctx)
 	if err != nil {
 		return "", fmt.Errorf("start dispatch tx: %w", err)

--- a/internal/orchestrator/scheduler_test.go
+++ b/internal/orchestrator/scheduler_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/BetterAndBetterII/openase/internal/provider"
 	catalogrepo "github.com/BetterAndBetterII/openase/internal/repo/catalog"
 	"github.com/BetterAndBetterII/openase/internal/ticketstatus"
-	"github.com/BetterAndBetterII/openase/internal/types/pgarray"
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/google/uuid"
 )
@@ -419,7 +418,7 @@ func TestSchedulerRunTickPublishesClaimedLifecycleAndClearsRuntimeState(t *testi
 	}
 }
 
-func TestSchedulerRunTickMatchesRequiredMachineLabelsAndBindsTicket(t *testing.T) {
+func TestSchedulerRunTickResolvesExecutionMachineFromBoundProvider(t *testing.T) {
 	ctx := context.Background()
 	client := openTestEntClient(t)
 	fixture := seedProjectFixture(ctx, t, client)
@@ -443,12 +442,17 @@ func TestSchedulerRunTickMatchesRequiredMachineLabelsAndBindsTicket(t *testing.T
 		t.Fatalf("create remote machine: %v", err)
 	}
 
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetMachineID(remoteMachine.ID).
+		Save(ctx); err != nil {
+		t.Fatalf("bind provider machine: %v", err)
+	}
+
 	workflow, err := client.Workflow.Create().
 		SetProjectID(fixture.projectID).
 		SetName("Training").
 		SetType(entworkflow.TypeCustom).
 		SetHarnessPath(".openase/harnesses/training.md").
-		SetRequiredMachineLabels(pgarray.StringArray{"gpu"}).
 		SetMaxConcurrent(1).
 		SetPickupStatusID(fixture.statusIDs["Todo"]).
 		SetFinishStatusID(fixture.statusIDs["Done"]).
@@ -502,7 +506,7 @@ func TestSchedulerRunTickMatchesRequiredMachineLabelsAndBindsTicket(t *testing.T
 	}
 }
 
-func TestSchedulerRunTickHonorsExplicitTargetMachineBinding(t *testing.T) {
+func TestSchedulerRunTickIgnoresTicketTargetMachineAndUsesProviderBinding(t *testing.T) {
 	ctx := context.Background()
 	client := openTestEntClient(t)
 	fixture := seedProjectFixture(ctx, t, client)
@@ -526,12 +530,17 @@ func TestSchedulerRunTickHonorsExplicitTargetMachineBinding(t *testing.T) {
 		t.Fatalf("create explicit machine: %v", err)
 	}
 
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetMachineID(fixture.localMachineID).
+		Save(ctx); err != nil {
+		t.Fatalf("bind provider machine: %v", err)
+	}
+
 	if _, err := client.Workflow.Create().
 		SetProjectID(fixture.projectID).
 		SetName("Coding").
 		SetType(entworkflow.TypeCoding).
 		SetHarnessPath(".openase/harnesses/coding.md").
-		SetRequiredMachineLabels(pgarray.StringArray{"gpu"}).
 		SetMaxConcurrent(1).
 		SetPickupStatusID(fixture.statusIDs["Todo"]).
 		SetFinishStatusID(fixture.statusIDs["Done"]).
@@ -571,8 +580,8 @@ func TestSchedulerRunTickHonorsExplicitTargetMachineBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload ticket: %v", err)
 	}
-	if ticketAfter.TargetMachineID == nil || *ticketAfter.TargetMachineID != explicitMachine.ID {
-		t.Fatalf("expected explicit target machine %s, got %+v", explicitMachine.ID, ticketAfter.TargetMachineID)
+	if ticketAfter.TargetMachineID == nil || *ticketAfter.TargetMachineID != fixture.localMachineID {
+		t.Fatalf("expected provider-bound machine %s, got %+v", fixture.localMachineID, ticketAfter.TargetMachineID)
 	}
 }
 
@@ -708,11 +717,12 @@ func waitForSchedulerEvent(t *testing.T, stream <-chan provider.Event, want prov
 }
 
 type projectFixture struct {
-	client     *ent.Client
-	orgID      uuid.UUID
-	projectID  uuid.UUID
-	providerID uuid.UUID
-	statusIDs  map[string]uuid.UUID
+	client         *ent.Client
+	orgID          uuid.UUID
+	projectID      uuid.UUID
+	providerID     uuid.UUID
+	localMachineID uuid.UUID
+	statusIDs      map[string]uuid.UUID
 }
 
 func TestSchedulerRunTickCreatesDueScheduledJobTicketsBeforeDispatch(t *testing.T) {
@@ -911,7 +921,7 @@ func seedProjectFixture(ctx context.Context, t *testing.T, client *ent.Client) p
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
-	if _, err := client.Machine.Create().
+	localMachine, err := client.Machine.Create().
 		SetOrganizationID(org.ID).
 		SetName(domaincatalog.LocalMachineName).
 		SetHost(domaincatalog.LocalMachineHost).
@@ -922,7 +932,8 @@ func seedProjectFixture(ctx context.Context, t *testing.T, client *ent.Client) p
 			"transport":    "local",
 			"last_success": true,
 		}).
-		Save(ctx); err != nil {
+		Save(ctx)
+	if err != nil {
 		t.Fatalf("create local machine: %v", err)
 	}
 	project, err := client.Project.Create().
@@ -937,6 +948,7 @@ func seedProjectFixture(ctx context.Context, t *testing.T, client *ent.Client) p
 	}
 	provider, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").
@@ -958,11 +970,12 @@ func seedProjectFixture(ctx context.Context, t *testing.T, client *ent.Client) p
 	}
 
 	return projectFixture{
-		client:     client,
-		orgID:      org.ID,
-		projectID:  project.ID,
-		providerID: provider.ID,
-		statusIDs:  statusIDs,
+		client:         client,
+		orgID:          org.ID,
+		projectID:      project.ID,
+		providerID:     provider.ID,
+		localMachineID: localMachine.ID,
+		statusIDs:      statusIDs,
 	}
 }
 

--- a/internal/repo/catalog/agent_catalog.go
+++ b/internal/repo/catalog/agent_catalog.go
@@ -27,6 +27,7 @@ func (r *EntRepository) ListAgentProviders(ctx context.Context, organizationID u
 
 	items, err := r.client.AgentProvider.Query().
 		Where(entagentprovider.OrganizationID(organizationID)).
+		WithMachine().
 		Order(entagentprovider.ByName()).
 		All(ctx)
 	if err != nil {
@@ -45,8 +46,17 @@ func (r *EntRepository) CreateAgentProvider(ctx context.Context, input domain.Cr
 		return domain.AgentProvider{}, ErrNotFound
 	}
 
+	machine, err := r.client.Machine.Get(ctx, input.MachineID)
+	if err != nil {
+		return domain.AgentProvider{}, mapReadError("get machine for agent provider", err)
+	}
+	if machine.OrganizationID != input.OrganizationID {
+		return domain.AgentProvider{}, fmt.Errorf("%w: machine organization must match provider organization", ErrInvalidInput)
+	}
+
 	item, err := r.client.AgentProvider.Create().
 		SetOrganizationID(input.OrganizationID).
+		SetMachineID(input.MachineID).
 		SetName(input.Name).
 		SetAdapterType(toEntAgentProviderAdapterType(input.AdapterType)).
 		SetCliCommand(input.CliCommand).
@@ -62,11 +72,14 @@ func (r *EntRepository) CreateAgentProvider(ctx context.Context, input domain.Cr
 		return domain.AgentProvider{}, mapWriteError("create agent provider", err)
 	}
 
-	return mapAgentProvider(item), nil
+	return r.GetAgentProvider(ctx, item.ID)
 }
 
 func (r *EntRepository) GetAgentProvider(ctx context.Context, id uuid.UUID) (domain.AgentProvider, error) {
-	item, err := r.client.AgentProvider.Get(ctx, id)
+	item, err := r.client.AgentProvider.Query().
+		Where(entagentprovider.ID(id)).
+		WithMachine().
+		Only(ctx)
 	if err != nil {
 		return domain.AgentProvider{}, mapReadError("get agent provider", err)
 	}
@@ -75,8 +88,17 @@ func (r *EntRepository) GetAgentProvider(ctx context.Context, id uuid.UUID) (dom
 }
 
 func (r *EntRepository) UpdateAgentProvider(ctx context.Context, input domain.UpdateAgentProvider) (domain.AgentProvider, error) {
+	machine, err := r.client.Machine.Get(ctx, input.MachineID)
+	if err != nil {
+		return domain.AgentProvider{}, mapReadError("get machine for agent provider update", err)
+	}
+	if machine.OrganizationID != input.OrganizationID {
+		return domain.AgentProvider{}, fmt.Errorf("%w: machine organization must match provider organization", ErrInvalidInput)
+	}
+
 	item, err := r.client.AgentProvider.UpdateOneID(input.ID).
 		SetOrganizationID(input.OrganizationID).
+		SetMachineID(input.MachineID).
 		SetName(input.Name).
 		SetAdapterType(toEntAgentProviderAdapterType(input.AdapterType)).
 		SetCliCommand(input.CliCommand).
@@ -92,7 +114,7 @@ func (r *EntRepository) UpdateAgentProvider(ctx context.Context, input domain.Up
 		return domain.AgentProvider{}, mapWriteError("update agent provider", err)
 	}
 
-	return mapAgentProvider(item), nil
+	return r.GetAgentProvider(ctx, item.ID)
 }
 
 func (r *EntRepository) ListAgents(ctx context.Context, projectID uuid.UUID) ([]domain.Agent, error) {
@@ -237,19 +259,44 @@ func mapAgentProviders(items []*ent.AgentProvider) []domain.AgentProvider {
 }
 
 func mapAgentProvider(item *ent.AgentProvider) domain.AgentProvider {
+	machineName := ""
+	machineHost := ""
+	machineStatus := domain.MachineStatus("")
+	var machineSSHUser *string
+	var machineWorkspaceRoot *string
+	var machineAgentCLIPath *string
+	machineResources := map[string]any{}
+	if item.Edges.Machine != nil {
+		machineName = item.Edges.Machine.Name
+		machineHost = item.Edges.Machine.Host
+		machineStatus = toDomainMachineStatus(item.Edges.Machine.Status)
+		machineSSHUser = optionalString(item.Edges.Machine.SSHUser)
+		machineWorkspaceRoot = optionalString(item.Edges.Machine.WorkspaceRoot)
+		machineAgentCLIPath = optionalString(item.Edges.Machine.AgentCliPath)
+		machineResources = cloneAnyMap(item.Edges.Machine.Resources)
+	}
+
 	return domain.AgentProvider{
-		ID:                 item.ID,
-		OrganizationID:     item.OrganizationID,
-		Name:               item.Name,
-		AdapterType:        toDomainAgentProviderAdapterType(item.AdapterType),
-		CliCommand:         item.CliCommand,
-		CliArgs:            append([]string(nil), item.CliArgs...),
-		AuthConfig:         cloneAnyMap(item.AuthConfig),
-		ModelName:          item.ModelName,
-		ModelTemperature:   item.ModelTemperature,
-		ModelMaxTokens:     item.ModelMaxTokens,
-		CostPerInputToken:  item.CostPerInputToken,
-		CostPerOutputToken: item.CostPerOutputToken,
+		ID:                   item.ID,
+		OrganizationID:       item.OrganizationID,
+		MachineID:            item.MachineID,
+		MachineName:          machineName,
+		MachineHost:          machineHost,
+		MachineStatus:        machineStatus,
+		MachineSSHUser:       machineSSHUser,
+		MachineWorkspaceRoot: machineWorkspaceRoot,
+		MachineAgentCLIPath:  machineAgentCLIPath,
+		MachineResources:     machineResources,
+		Name:                 item.Name,
+		AdapterType:          toDomainAgentProviderAdapterType(item.AdapterType),
+		CliCommand:           item.CliCommand,
+		CliArgs:              append([]string(nil), item.CliArgs...),
+		AuthConfig:           cloneAnyMap(item.AuthConfig),
+		ModelName:            item.ModelName,
+		ModelTemperature:     item.ModelTemperature,
+		ModelMaxTokens:       item.ModelMaxTokens,
+		CostPerInputToken:    item.CostPerInputToken,
+		CostPerOutputToken:   item.CostPerOutputToken,
 	}
 }
 

--- a/internal/repo/catalog/machine_catalog.go
+++ b/internal/repo/catalog/machine_catalog.go
@@ -105,8 +105,8 @@ func (r *EntRepository) RecordMachineProbe(ctx context.Context, input domain.Rec
 	return nil
 }
 
-func createLocalMachine(ctx context.Context, tx *ent.Tx, organizationID uuid.UUID) error {
-	_, err := tx.Machine.Create().
+func createLocalMachine(ctx context.Context, tx *ent.Tx, organizationID uuid.UUID) (*ent.Machine, error) {
+	item, err := tx.Machine.Create().
 		SetOrganizationID(organizationID).
 		SetName(domain.LocalMachineName).
 		SetHost(domain.LocalMachineHost).
@@ -119,10 +119,10 @@ func createLocalMachine(ctx context.Context, tx *ent.Tx, organizationID uuid.UUI
 		}).
 		Save(ctx)
 	if err != nil {
-		return mapWriteError("create local machine", err)
+		return nil, mapWriteError("create local machine", err)
 	}
 
-	return nil
+	return item, nil
 }
 
 func machineCreateBuilder(builder *ent.MachineCreate, input domain.CreateMachine) *ent.MachineCreate {

--- a/internal/repo/catalog/repo.go
+++ b/internal/repo/catalog/repo.go
@@ -60,10 +60,11 @@ func (r *EntRepository) CreateOrganization(ctx context.Context, input domain.Cre
 		return domain.Organization{}, mapWriteError("create organization", err)
 	}
 
-	if err := createLocalMachine(ctx, tx, item.ID); err != nil {
+	localMachine, err := createLocalMachine(ctx, tx, item.ID)
+	if err != nil {
 		return domain.Organization{}, err
 	}
-	if err := createBuiltinAgentProviders(ctx, tx, item.ID); err != nil {
+	if err := createBuiltinAgentProviders(ctx, tx, item.ID, localMachine.ID); err != nil {
 		return domain.Organization{}, err
 	}
 	if input.DefaultAgentProviderID != nil {
@@ -745,10 +746,11 @@ func clearPrimaryRepo(ctx context.Context, tx *ent.Tx, projectID uuid.UUID, excl
 	return nil
 }
 
-func createBuiltinAgentProviders(ctx context.Context, tx *ent.Tx, organizationID uuid.UUID) error {
+func createBuiltinAgentProviders(ctx context.Context, tx *ent.Tx, organizationID uuid.UUID, machineID uuid.UUID) error {
 	for _, template := range domain.BuiltinAgentProviderTemplates() {
 		builder := tx.AgentProvider.Create().
 			SetOrganizationID(organizationID).
+			SetMachineID(machineID).
 			SetName(template.Name).
 			SetAdapterType(toEntAgentProviderAdapterType(template.AdapterType)).
 			SetCliCommand(template.Command).

--- a/internal/runtime/database/database.go
+++ b/internal/runtime/database/database.go
@@ -33,6 +33,9 @@ func Open(ctx context.Context, dsn string) (*ent.Client, error) {
 		if err := reconcileLegacyProjectAccessibleMachineIDs(ctx, trimmedDSN); err != nil {
 			return err
 		}
+		if err := reconcileLegacyAgentProviderMachineIDs(ctx, trimmedDSN); err != nil {
+			return err
+		}
 		if err := client.Schema.Create(
 			ctx,
 			entmigrate.WithDropColumn(false),
@@ -168,6 +171,99 @@ func reconcileLegacyTicketIdentifierIndex(ctx context.Context, dsn string) error
 	}
 	if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS "ticket_project_id_identifier" ON "tickets" ("project_id", "identifier")`); err != nil {
 		return fmt.Errorf("create project-scoped ticket identifier index: %w", err)
+	}
+
+	return nil
+}
+
+func reconcileLegacyAgentProviderMachineIDs(ctx context.Context, dsn string) error {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return fmt.Errorf("open database for agent provider machine reconciliation: %w", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping database for agent provider machine reconciliation: %w", err)
+	}
+
+	var providerTableExists bool
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = current_schema()
+			  AND table_name = 'agent_providers'
+		)`,
+	).Scan(&providerTableExists); err != nil {
+		return fmt.Errorf("check agent_providers table: %w", err)
+	}
+	if !providerTableExists {
+		return nil
+	}
+
+	var machineTableExists bool
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = current_schema()
+			  AND table_name = 'machines'
+		)`,
+	).Scan(&machineTableExists); err != nil {
+		return fmt.Errorf("check machines table: %w", err)
+	}
+	if !machineTableExists {
+		return nil
+	}
+
+	var columnExists bool
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = 'agent_providers'
+			  AND column_name = 'machine_id'
+		)`,
+	).Scan(&columnExists); err != nil {
+		return fmt.Errorf("check agent provider machine_id column: %w", err)
+	}
+	if !columnExists {
+		if _, err := db.ExecContext(
+			ctx,
+			`ALTER TABLE "agent_providers" ADD COLUMN "machine_id" uuid NULL`,
+		); err != nil {
+			return fmt.Errorf("add agent provider machine_id column: %w", err)
+		}
+	}
+
+	if _, err := db.ExecContext(
+		ctx,
+		`UPDATE "agent_providers" AS ap
+		SET "machine_id" = m."id"
+		FROM "machines" AS m
+		WHERE ap."machine_id" IS NULL
+		  AND m."organization_id" = ap."organization_id"
+		  AND m."name" = 'local'`,
+	); err != nil {
+		return fmt.Errorf("backfill agent provider machine ids: %w", err)
+	}
+
+	var unresolved int
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(1) FROM "agent_providers" WHERE "machine_id" IS NULL`,
+	).Scan(&unresolved); err != nil {
+		return fmt.Errorf("count unresolved agent provider machine ids: %w", err)
+	}
+	if unresolved > 0 {
+		return fmt.Errorf("backfill agent provider machine ids: %d providers still missing a local machine binding", unresolved)
 	}
 
 	return nil

--- a/internal/service/catalog/agent_catalog.go
+++ b/internal/service/catalog/agent_catalog.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/google/uuid"
@@ -183,8 +184,69 @@ func annotateAgentProviderAvailability(
 		LookPath(name string) (string, error)
 	},
 ) domain.AgentProvider {
-	item.Available = isAgentProviderAvailable(item.CliCommand, resolver)
+	command := item.CliCommand
+	if item.MachineAgentCLIPath != nil && strings.TrimSpace(*item.MachineAgentCLIPath) != "" {
+		command = *item.MachineAgentCLIPath
+	}
+
+	switch {
+	case item.MachineID == uuid.Nil:
+		item.Available = isAgentProviderAvailable(command, resolver)
+	case strings.TrimSpace(item.MachineHost) == "" || item.MachineHost == domain.LocalMachineHost:
+		item.Available = isAgentProviderAvailable(command, resolver)
+	case item.MachineStatus != "" && item.MachineStatus != domain.MachineStatusOnline:
+		item.Available = false
+	default:
+		item.Available = remoteAgentProviderAvailable(item)
+	}
 	return item
+}
+
+func remoteAgentProviderAvailable(item domain.AgentProvider) bool {
+	if installed, ok := providerMachineCLIInstalled(item.AdapterType, item.MachineResources); ok {
+		return installed
+	}
+	if item.MachineAgentCLIPath != nil && strings.TrimSpace(*item.MachineAgentCLIPath) != "" {
+		return true
+	}
+	return strings.TrimSpace(item.CliCommand) != ""
+}
+
+func providerMachineCLIInstalled(adapterType domain.AgentProviderAdapterType, resources map[string]any) (bool, bool) {
+	monitor, ok := nestedResourceMap(resources, "monitor")
+	if !ok {
+		return false, false
+	}
+	level4, ok := nestedResourceMap(monitor, "l4")
+	if !ok {
+		return false, false
+	}
+	entryName := ""
+	switch adapterType {
+	case domain.AgentProviderAdapterTypeClaudeCodeCLI:
+		entryName = "claude_code"
+	case domain.AgentProviderAdapterTypeCodexAppServer:
+		entryName = "codex"
+	case domain.AgentProviderAdapterTypeGeminiCLI:
+		entryName = "gemini"
+	default:
+		return false, false
+	}
+	entry, ok := nestedResourceMap(level4, entryName)
+	if !ok {
+		return false, false
+	}
+	installed, ok := entry["installed"].(bool)
+	return installed, ok
+}
+
+func nestedResourceMap(raw map[string]any, key string) (map[string]any, bool) {
+	value, ok := raw[key]
+	if !ok {
+		return nil, false
+	}
+	item, ok := value.(map[string]any)
+	return item, ok
 }
 
 func isAgentProviderAvailable(

--- a/internal/service/catalog/agent_catalog_test.go
+++ b/internal/service/catalog/agent_catalog_test.go
@@ -17,6 +17,7 @@ func TestCreateAgentProviderAutoDetectsCLICommand(t *testing.T) {
 
 	item, err := svc.CreateAgentProvider(context.Background(), domain.CreateAgentProvider{
 		OrganizationID: uuid.New(),
+		MachineID:      uuid.New(),
 		Name:           "Codex",
 		AdapterType:    domain.AgentProviderAdapterTypeCodexAppServer,
 		ModelName:      "gpt-5.3-codex",
@@ -41,6 +42,7 @@ func TestCreateAgentProviderRejectsMissingCustomCLICommand(t *testing.T) {
 
 	_, err := svc.CreateAgentProvider(context.Background(), domain.CreateAgentProvider{
 		OrganizationID: uuid.New(),
+		MachineID:      uuid.New(),
 		Name:           "Custom",
 		AdapterType:    domain.AgentProviderAdapterTypeCustom,
 		ModelName:      "manual",
@@ -56,6 +58,7 @@ func TestCreateAgentProviderRejectsMissingExecutable(t *testing.T) {
 
 	_, err := svc.CreateAgentProvider(context.Background(), domain.CreateAgentProvider{
 		OrganizationID: uuid.New(),
+		MachineID:      uuid.New(),
 		Name:           "Gemini",
 		AdapterType:    domain.AgentProviderAdapterTypeGeminiCLI,
 		ModelName:      "gemini-2.5-pro",
@@ -71,6 +74,7 @@ func TestUpdateAgentProviderDefaultsCodexCLIArgs(t *testing.T) {
 		provider: domain.AgentProvider{
 			ID:             uuid.New(),
 			OrganizationID: uuid.New(),
+			MachineID:      uuid.New(),
 			Name:           "Codex",
 			AdapterType:    domain.AgentProviderAdapterTypeCodexAppServer,
 			CliCommand:     "/usr/local/bin/codex",
@@ -83,6 +87,7 @@ func TestUpdateAgentProviderDefaultsCodexCLIArgs(t *testing.T) {
 	item, err := svc.UpdateAgentProvider(context.Background(), domain.UpdateAgentProvider{
 		ID:             repo.provider.ID,
 		OrganizationID: repo.provider.OrganizationID,
+		MachineID:      repo.provider.MachineID,
 		Name:           repo.provider.Name,
 		AdapterType:    repo.provider.AdapterType,
 		CliCommand:     repo.provider.CliCommand,
@@ -107,6 +112,7 @@ func TestListAgentProvidersAnnotatesAvailability(t *testing.T) {
 			{
 				ID:             uuid.New(),
 				OrganizationID: orgID,
+				MachineID:      uuid.New(),
 				Name:           "Claude Code",
 				AdapterType:    domain.AgentProviderAdapterTypeClaudeCodeCLI,
 				CliCommand:     "claude",
@@ -115,6 +121,7 @@ func TestListAgentProvidersAnnotatesAvailability(t *testing.T) {
 			{
 				ID:             uuid.New(),
 				OrganizationID: orgID,
+				MachineID:      uuid.New(),
 				Name:           "OpenAI Codex",
 				AdapterType:    domain.AgentProviderAdapterTypeCodexAppServer,
 				CliCommand:     "codex",
@@ -153,6 +160,7 @@ func TestCreateOrganizationSetsDefaultProviderToPreferredAvailableBuiltin(t *tes
 			{
 				ID:             uuid.New(),
 				OrganizationID: orgID,
+				MachineID:      uuid.New(),
 				Name:           "Claude Code",
 				AdapterType:    domain.AgentProviderAdapterTypeClaudeCodeCLI,
 				CliCommand:     "claude",
@@ -161,6 +169,7 @@ func TestCreateOrganizationSetsDefaultProviderToPreferredAvailableBuiltin(t *tes
 			{
 				ID:             uuid.New(),
 				OrganizationID: orgID,
+				MachineID:      uuid.New(),
 				Name:           "OpenAI Codex",
 				AdapterType:    domain.AgentProviderAdapterTypeCodexAppServer,
 				CliCommand:     "codex",
@@ -409,6 +418,7 @@ func (r *stubRepository) CreateAgentProvider(_ context.Context, input domain.Cre
 	return domain.AgentProvider{
 		ID:             uuid.New(),
 		OrganizationID: input.OrganizationID,
+		MachineID:      input.MachineID,
 		Name:           input.Name,
 		AdapterType:    input.AdapterType,
 		CliCommand:     input.CliCommand,
@@ -428,6 +438,7 @@ func (r *stubRepository) UpdateAgentProvider(_ context.Context, input domain.Upd
 	return domain.AgentProvider{
 		ID:             input.ID,
 		OrganizationID: input.OrganizationID,
+		MachineID:      input.MachineID,
 		Name:           input.Name,
 		AdapterType:    input.AdapterType,
 		CliCommand:     input.CliCommand,

--- a/internal/ticket/cost_tracker_test.go
+++ b/internal/ticket/cost_tracker_test.go
@@ -28,6 +28,16 @@ func TestServiceRecordUsageAccumulatesTokensCostAndBudgetPause(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create organization: %v", err)
 	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
 	project, err := client.Project.Create().
 		SetOrganizationID(org.ID).
 		SetName("OpenASE").
@@ -38,6 +48,7 @@ func TestServiceRecordUsageAccumulatesTokensCostAndBudgetPause(t *testing.T) {
 	}
 	providerItem, err := client.AgentProvider.Create().
 		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
 		SetName("Codex").
 		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
 		SetCliCommand("codex").

--- a/web/src/lib/api/generated/openapi.d.ts
+++ b/web/src/lib/api/generated/openapi.d.ts
@@ -3438,6 +3438,12 @@ export interface operations {
               /** Format: double */
               cost_per_output_token?: number
               id?: string
+              machine_host?: string
+              machine_id?: string
+              machine_name?: string
+              machine_ssh_user?: string | null
+              machine_status?: string
+              machine_workspace_root?: string | null
               model_max_tokens?: number
               model_name?: string
               /** Format: double */
@@ -3510,6 +3516,7 @@ export interface operations {
           cost_per_input_token?: number | null
           /** Format: double */
           cost_per_output_token?: number | null
+          machine_id?: string
           model_max_tokens?: number | null
           model_name?: string
           /** Format: double */
@@ -3539,6 +3546,12 @@ export interface operations {
               /** Format: double */
               cost_per_output_token?: number
               id?: string
+              machine_host?: string
+              machine_id?: string
+              machine_name?: string
+              machine_ssh_user?: string | null
+              machine_status?: string
+              machine_workspace_root?: string | null
               model_max_tokens?: number
               model_name?: string
               /** Format: double */
@@ -6652,6 +6665,7 @@ export interface operations {
           cost_per_input_token?: number | null
           /** Format: double */
           cost_per_output_token?: number | null
+          machine_id?: string | null
           model_max_tokens?: number | null
           model_name?: string | null
           /** Format: double */
@@ -6681,6 +6695,12 @@ export interface operations {
               /** Format: double */
               cost_per_output_token?: number
               id?: string
+              machine_host?: string
+              machine_id?: string
+              machine_name?: string
+              machine_ssh_user?: string | null
+              machine_status?: string
+              machine_workspace_root?: string | null
               model_max_tokens?: number
               model_name?: string
               /** Format: double */

--- a/web/src/lib/api/openase.ts
+++ b/web/src/lib/api/openase.ts
@@ -165,6 +165,7 @@ export function listProviders(orgId: string) {
 export function createProvider(
   orgId: string,
   body: {
+    machine_id: string
     name: string
     adapter_type: string
     cli_command?: string
@@ -662,6 +663,7 @@ export function listBuiltinRoles() {
 export function updateProvider(
   providerId: string,
   body: {
+    machine_id?: string
     name?: string
     adapter_type?: string
     cli_command?: string

--- a/web/src/lib/features/agents/components/agent-registration-sheet.svelte
+++ b/web/src/lib/features/agents/components/agent-registration-sheet.svelte
@@ -52,8 +52,8 @@
 
   function providerLabel(provider: AgentProvider) {
     return provider.available
-      ? `${provider.name} · ${provider.adapter_type} · ${provider.model_name}`
-      : `${provider.name} · unavailable · ${provider.adapter_type} · ${provider.model_name}`
+      ? `${provider.name} · ${provider.machine_name} · ${provider.adapter_type} · ${provider.model_name}`
+      : `${provider.name} · ${provider.machine_name} · unavailable · ${provider.adapter_type} · ${provider.model_name}`
   }
 
   function selectedProviderLabel() {

--- a/web/src/lib/features/agents/components/agents-page-content.svelte
+++ b/web/src/lib/features/agents/components/agents-page-content.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AgentOutputEntry, AgentProvider } from '$lib/api/contracts'
+  import type { AgentOutputEntry, AgentProvider, Machine } from '$lib/api/contracts'
   import type { StreamConnectionState } from '$lib/api/sse'
   import type { AgentInstance, ProviderConfig, ProviderDraft, ProviderDraftField } from '../types'
   import type { AgentRegistrationDraft, AgentRegistrationDraftField } from '../registration'
@@ -27,6 +27,7 @@
     onPauseAgent,
     onResumeAgent,
     providerItems,
+    machineItems,
     registrationDraft,
     registerSaving = false,
     registerError = '',
@@ -68,6 +69,7 @@
     onPauseAgent?: (agentId: string) => void
     onResumeAgent?: (agentId: string) => void
     providerItems: AgentProvider[]
+    machineItems: Machine[]
     registrationDraft: AgentRegistrationDraft
     registerSaving?: boolean
     registerError?: string
@@ -117,6 +119,7 @@
   bind:providerConfigOpen
   bind:outputSheetOpen
   {providerItems}
+  {machineItems}
   {registrationDraft}
   {registerSaving}
   {registerError}

--- a/web/src/lib/features/agents/components/agents-page-drawers.svelte
+++ b/web/src/lib/features/agents/components/agents-page-drawers.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AgentOutputEntry, AgentProvider } from '$lib/api/contracts'
+  import type { AgentOutputEntry, AgentProvider, Machine } from '$lib/api/contracts'
   import type { StreamConnectionState } from '$lib/api/sse'
   import type { AgentRegistrationDraft, AgentRegistrationDraftField } from '../registration'
   import type { AgentInstance, ProviderConfig, ProviderDraft, ProviderDraftField } from '../types'
@@ -12,6 +12,7 @@
     providerConfigOpen = $bindable(false),
     outputSheetOpen = $bindable(false),
     providerItems,
+    machineItems,
     registrationDraft,
     registerSaving = false,
     registerError = '',
@@ -37,6 +38,7 @@
     providerConfigOpen?: boolean
     outputSheetOpen?: boolean
     providerItems: AgentProvider[]
+    machineItems: Machine[]
     registrationDraft: AgentRegistrationDraft
     registerSaving?: boolean
     registerError?: string
@@ -75,6 +77,7 @@
 <ProviderConfigSheet
   bind:open={providerConfigOpen}
   provider={selectedProvider}
+  machines={machineItems}
   draft={providerDraft}
   saving={providerSaving}
   feedback={providerFeedback}

--- a/web/src/lib/features/agents/components/agents-page.svelte
+++ b/web/src/lib/features/agents/components/agents-page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { appStore } from '$lib/stores/app.svelte'
   import { connectEventStream } from '$lib/api/sse'
-  import type { AgentProvider } from '$lib/api/contracts'
+  import type { AgentProvider, Machine } from '$lib/api/contracts'
   import type { AgentsPageData } from '../data'
   import { loadAgentsPageResult } from '../page-data'
   import { applyUpdatedProviderState } from '../model'
@@ -24,6 +24,7 @@
   let agents = $state<AgentInstance[]>([])
   let providers = $state<ProviderConfig[]>([])
   let providerItems = $state<AgentProvider[]>([])
+  let machineItems = $state<Machine[]>([])
   let loading = $state(false),
     error = $state('')
   let registerSheetOpen = $state(false)
@@ -56,6 +57,7 @@
       agents = []
       providers = []
       providerItems = []
+      machineItems = []
       resetRegistrationDraft()
       providerEditor.reset()
       outputState.reset()
@@ -113,6 +115,7 @@
 
   function applyPageData(data: AgentsPageData) {
     providerItems = data.providerItems
+    machineItems = data.machineItems
     providers = data.providers
     agents = data.agents
   }
@@ -272,6 +275,7 @@
   bind:providerConfigOpen
   bind:outputSheetOpen
   {providerItems}
+  {machineItems}
   {registrationDraft}
   {registerSaving}
   {registerError}

--- a/web/src/lib/features/agents/components/provider-config-sheet.svelte
+++ b/web/src/lib/features/agents/components/provider-config-sheet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Machine } from '$lib/api/contracts'
   import { Badge } from '$ui/badge'
   import { Button } from '$ui/button'
   import { Input } from '$ui/input'
@@ -19,6 +20,7 @@
   let {
     open = $bindable(false),
     provider,
+    machines,
     draft,
     saving = false,
     feedback = '',
@@ -28,6 +30,7 @@
   }: {
     open?: boolean
     provider: ProviderConfig | null
+    machines: Machine[]
     draft: ProviderDraft
     saving?: boolean
     feedback?: string
@@ -60,6 +63,27 @@
       <div class="flex-1 overflow-y-auto px-6 py-5">
         <div class="space-y-5">
           <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-2">
+              <Label>Execution machine</Label>
+              <Select.Root
+                type="single"
+                value={draft.machineId}
+                onValueChange={(value) => onDraftChange?.('machineId', value || '')}
+              >
+                <Select.Trigger class="w-full">
+                  {machines.find((machine) => machine.id === draft.machineId)?.name ??
+                    'Select machine'}
+                </Select.Trigger>
+                <Select.Content>
+                  {#each machines as machine (machine.id)}
+                    <Select.Item value={machine.id}>
+                      {machine.name} · {machine.status} · {machine.host}
+                    </Select.Item>
+                  {/each}
+                </Select.Content>
+              </Select.Root>
+            </div>
+
             <div class="space-y-2">
               <Label for="provider-name">Name</Label>
               <Input

--- a/web/src/lib/features/agents/components/provider-list.svelte
+++ b/web/src/lib/features/agents/components/provider-list.svelte
@@ -52,6 +52,14 @@
           <span class="text-foreground font-mono">{provider.modelName}</span>
         </div>
         <div class="flex items-center justify-between text-xs">
+          <span class="text-muted-foreground">Machine</span>
+          <span class="text-foreground">{provider.machineName}</span>
+        </div>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-muted-foreground">Status</span>
+          <span class="text-foreground">{provider.machineStatus}</span>
+        </div>
+        <div class="flex items-center justify-between text-xs">
           <span class="text-muted-foreground">Agents</span>
           <span class="text-foreground tabular-nums">{provider.agentCount}</span>
         </div>

--- a/web/src/lib/features/agents/data.ts
+++ b/web/src/lib/features/agents/data.ts
@@ -1,5 +1,5 @@
-import { listAgents, listProviders, listTickets } from '$lib/api/openase'
-import type { AgentProvider } from '$lib/api/contracts'
+import { listAgents, listMachines, listProviders, listTickets } from '$lib/api/openase'
+import type { AgentProvider, Machine } from '$lib/api/contracts'
 import { buildAgentRows, buildProviderCards } from './model'
 import type { AgentInstance, ProviderConfig } from './types'
 
@@ -7,6 +7,7 @@ export type AgentsPageData = {
   agents: AgentInstance[]
   providers: ProviderConfig[]
   providerItems: AgentProvider[]
+  machineItems: Machine[]
 }
 
 export async function loadAgentsPageData(
@@ -14,14 +15,16 @@ export async function loadAgentsPageData(
   orgId: string,
   defaultProviderId: string | null,
 ): Promise<AgentsPageData> {
-  const [agentPayload, providerPayload, ticketPayload] = await Promise.all([
+  const [agentPayload, providerPayload, ticketPayload, machinePayload] = await Promise.all([
     listAgents(projectId),
     listProviders(orgId),
     listTickets(projectId),
+    listMachines(orgId),
   ])
 
   return {
     providerItems: providerPayload.providers,
+    machineItems: machinePayload.machines,
     providers: buildProviderCards(
       providerPayload.providers,
       agentPayload.agents,

--- a/web/src/lib/features/agents/model.ts
+++ b/web/src/lib/features/agents/model.ts
@@ -17,6 +17,7 @@ export const providerAdapterOptions: Array<{ value: ProviderAdapterType; label: 
 
 export function createEmptyProviderDraft(): ProviderDraft {
   return {
+    machineId: '',
     name: '',
     adapterType: 'custom',
     cliCommand: '',
@@ -32,6 +33,7 @@ export function createEmptyProviderDraft(): ProviderDraft {
 
 export function providerToDraft(provider: ProviderConfig): ProviderDraft {
   return {
+    machineId: provider.machineId,
     name: provider.name,
     adapterType: provider.adapterType,
     cliCommand: provider.cliCommand,
@@ -49,6 +51,11 @@ export function providerToDraft(provider: ProviderConfig): ProviderDraft {
 }
 
 export function parseProviderDraft(draft: ProviderDraft): ProviderDraftParseResult {
+  const machineId = draft.machineId.trim()
+  if (!machineId) {
+    return { ok: false, error: 'Execution machine is required.' }
+  }
+
   const name = draft.name.trim()
   if (!name) {
     return { ok: false, error: 'Provider name is required.' }
@@ -95,6 +102,7 @@ export function parseProviderDraft(draft: ProviderDraft): ProviderDraftParseResu
   return {
     ok: true,
     value: {
+      machine_id: machineId,
       name,
       adapter_type: adapterType,
       cli_command: draft.cliCommand.trim(),
@@ -116,6 +124,11 @@ export function buildProviderCards(
 ): ProviderConfig[] {
   return providerItems.map((provider) => ({
     id: provider.id,
+    machineId: provider.machine_id,
+    machineName: provider.machine_name,
+    machineHost: provider.machine_host,
+    machineStatus: provider.machine_status,
+    machineWorkspaceRoot: provider.machine_workspace_root ?? null,
     name: provider.name,
     adapterType: provider.adapter_type,
     available: provider.available,
@@ -182,6 +195,11 @@ export function applyUpdatedProviderState(
     provider.id === updatedProvider.id
       ? {
           ...provider,
+          machineId: updatedProvider.machine_id,
+          machineName: updatedProvider.machine_name,
+          machineHost: updatedProvider.machine_host,
+          machineStatus: updatedProvider.machine_status,
+          machineWorkspaceRoot: updatedProvider.machine_workspace_root ?? null,
           name: updatedProvider.name,
           adapterType: updatedProvider.adapter_type,
           available: updatedProvider.available,

--- a/web/src/lib/features/agents/types.ts
+++ b/web/src/lib/features/agents/types.ts
@@ -18,6 +18,11 @@ export type AgentInstance = {
 
 export type ProviderConfig = {
   id: string
+  machineId: string
+  machineName: string
+  machineHost: string
+  machineStatus: string
+  machineWorkspaceRoot?: string | null
   name: string
   adapterType: string
   available: boolean
@@ -36,6 +41,7 @@ export type ProviderConfig = {
 export type ProviderAdapterType = 'claude-code-cli' | 'codex-app-server' | 'gemini-cli' | 'custom'
 
 export type ProviderDraft = {
+  machineId: string
   name: string
   adapterType: string
   cliCommand: string
@@ -51,6 +57,7 @@ export type ProviderDraft = {
 export type ProviderDraftField = keyof ProviderDraft
 
 export type ProviderMutation = {
+  machine_id: string
   name: string
   adapter_type: ProviderAdapterType
   cli_command: string

--- a/web/src/lib/features/catalog-creation/components/organization-creation-lanes.svelte
+++ b/web/src/lib/features/catalog-creation/components/organization-creation-lanes.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto, invalidateAll } from '$app/navigation'
-  import type { AgentProvider, Project } from '$lib/api/contracts'
+  import type { AgentProvider, Machine, Project } from '$lib/api/contracts'
   import { ApiError } from '$lib/api/client'
   import { createProject, createProvider } from '$lib/api/openase'
   import { createEmptyProviderDraft, parseProviderDraft } from '$lib/features/agents/public'
@@ -21,11 +21,13 @@
     defaultProviderId = null,
     projects,
     providers,
+    machines = [],
   }: {
     orgId: string | null
     defaultProviderId?: string | null
     projects: Project[]
     providers: AgentProvider[]
+    machines?: Machine[]
   } = $props()
 
   const machineConsoleHref = $derived(
@@ -166,6 +168,7 @@
     <div class="space-y-4">
       <ProviderCreationPanel
         draft={providerDraft}
+        {machines}
         creating={creatingProvider}
         feedback={providerFeedback}
         error={providerError}

--- a/web/src/lib/features/catalog-creation/components/provider-creation-dialog.svelte
+++ b/web/src/lib/features/catalog-creation/components/provider-creation-dialog.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation'
+  import type { Machine } from '$lib/api/contracts'
   import { ApiError } from '$lib/api/client'
-  import { createProvider } from '$lib/api/openase'
+  import { createProvider, listMachines } from '$lib/api/openase'
   import {
     createEmptyProviderDraft,
     parseProviderDraft,
@@ -26,12 +27,38 @@
   let draft = $state<ProviderDraft>(createEmptyProviderDraft())
   let creating = $state(false)
   let error = $state('')
+  let machines = $state<Machine[]>([])
 
   function reset() {
     draft = createEmptyProviderDraft()
     creating = false
     error = ''
   }
+
+  $effect(() => {
+    if (!open) {
+      return
+    }
+
+    let cancelled = false
+    void listMachines(orgId)
+      .then((payload) => {
+        if (cancelled) return
+        machines = payload.machines
+        if (!draft.machineId) {
+          draft = { ...draft, machineId: payload.machines[0]?.id ?? '' }
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          machines = []
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  })
 
   function updateField(field: keyof ProviderDraft, value: string) {
     draft = { ...draft, [field]: value }
@@ -93,6 +120,26 @@
       </div>
 
       <div class="grid gap-4 sm:grid-cols-2">
+        <div class="space-y-2">
+          <Label>Execution machine</Label>
+          <Select.Root
+            type="single"
+            value={draft.machineId}
+            onValueChange={(value) => updateField('machineId', value || '')}
+          >
+            <Select.Trigger class="w-full">
+              {machines.find((machine) => machine.id === draft.machineId)?.name ?? 'Select machine'}
+            </Select.Trigger>
+            <Select.Content>
+              {#each machines as machine (machine.id)}
+                <Select.Item value={machine.id}
+                  >{machine.name} · {machine.status} · {machine.host}</Select.Item
+                >
+              {/each}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
         <div class="space-y-2">
           <Label>Adapter</Label>
           <Select.Root

--- a/web/src/lib/features/catalog-creation/components/provider-creation-panel.svelte
+++ b/web/src/lib/features/catalog-creation/components/provider-creation-panel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Machine } from '$lib/api/contracts'
   import { providerAdapterOptions } from '$lib/features/agents/public'
   import type { ProviderDraft } from '$lib/features/agents/public'
   import { Button } from '$ui/button'
@@ -10,6 +11,7 @@
 
   let {
     draft,
+    machines = [],
     creating = false,
     feedback = '',
     error = '',
@@ -18,6 +20,7 @@
     onSubmit,
   }: {
     draft: ProviderDraft
+    machines?: Machine[]
     creating?: boolean
     feedback?: string
     error?: string
@@ -55,6 +58,26 @@
       </div>
 
       <div class="grid gap-4 md:grid-cols-2">
+        <div class="space-y-2">
+          <Label>Execution machine</Label>
+          <Select.Root
+            type="single"
+            value={draft.machineId}
+            onValueChange={(value) => onFieldChange?.('machineId', value || '')}
+          >
+            <Select.Trigger class="w-full">
+              {machines.find((machine) => machine.id === draft.machineId)?.name ?? 'Select machine'}
+            </Select.Trigger>
+            <Select.Content>
+              {#each machines as machine (machine.id)}
+                <Select.Item value={machine.id}
+                  >{machine.name} · {machine.status} · {machine.host}</Select.Item
+                >
+              {/each}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
         <div class="space-y-2">
           <Label>Adapter</Label>
           <Select.Root

--- a/web/src/lib/features/settings/components/agent-settings-inventory.svelte
+++ b/web/src/lib/features/settings/components/agent-settings-inventory.svelte
@@ -50,7 +50,7 @@
                 <Badge variant="secondary" class="text-[10px]">{agent.providerName}</Badge>
               </div>
               <div class="text-muted-foreground mt-1 text-xs">
-                Runtime phase: {agent.runtimePhase}
+                Runtime phase: {agent.runtimePhase} · Machine: {agent.machineName}
               </div>
             </div>
             <div class="text-muted-foreground text-right text-xs">

--- a/web/src/lib/features/settings/components/agent-settings-model.ts
+++ b/web/src/lib/features/settings/components/agent-settings-model.ts
@@ -3,6 +3,7 @@ import type { Agent, AgentProvider } from '$lib/api/contracts'
 export type ProviderOption = {
   id: string
   name: string
+  machineName: string
   adapterType: string
   modelName: string
   available: boolean
@@ -13,6 +14,7 @@ export type GovernanceAgent = {
   id: string
   name: string
   providerName: string
+  machineName: string
   status: 'idle' | 'claimed' | 'running' | 'paused' | 'failed' | 'terminated'
   runtimePhase: 'none' | 'launching' | 'ready' | 'failed'
   workspacePath: string
@@ -46,6 +48,7 @@ export function buildProviderOptions(
   return providerItems.map((provider) => ({
     id: provider.id,
     name: provider.name,
+    machineName: provider.machine_name,
     adapterType: provider.adapter_type,
     modelName: provider.model_name,
     available: provider.available,
@@ -67,6 +70,7 @@ export function buildGovernanceAgents(
         id: agent.id,
         name: agent.name,
         providerName: provider?.name ?? 'Unknown provider',
+        machineName: provider?.machine_name ?? 'Unknown machine',
         status: normalizeAgentStatus(agent.runtime?.status ?? 'idle'),
         runtimePhase: normalizeRuntimePhase(agent.runtime?.runtime_phase ?? 'none'),
         workspacePath: agent.workspace_path ?? '',

--- a/web/src/lib/features/settings/components/agent-settings.svelte
+++ b/web/src/lib/features/settings/components/agent-settings.svelte
@@ -202,6 +202,7 @@
                   {#each providers as provider (provider.id)}
                     <Select.Item value={provider.id}>
                       {provider.name}
+                      {' '}· {provider.machineName}
                       {#if !provider.available}
                         {' '}· unavailable
                       {/if}

--- a/web/src/routes/(app)/orgs/[orgId]/+page.svelte
+++ b/web/src/routes/(app)/orgs/[orgId]/+page.svelte
@@ -95,11 +95,12 @@
               <div class="min-w-0">
                 <p class="text-foreground truncate text-sm font-medium">{provider.name}</p>
                 <p class="text-muted-foreground truncate text-xs">
-                  {provider.model_name} · {provider.adapter_type}
+                  {provider.model_name} · {provider.adapter_type} · {provider.machine_name}
                 </p>
               </div>
             </div>
             <div class="flex shrink-0 items-center gap-2">
+              <Badge variant="outline">{provider.machine_status}</Badge>
               <Badge variant={provider.available ? 'secondary' : 'outline'}>
                 {provider.available ? 'Available' : 'Unavailable'}
               </Badge>


### PR DESCRIPTION
## Summary
- require every agent provider to bind to a concrete machine and surface that binding through the catalog API, OpenAPI schema, and agents/settings UI
- resolve scheduler and runtime launch targets strictly through `Workflow -> Agent -> Provider -> Machine`, including builtin local providers and remote machine metadata
- backfill legacy provider rows to the org local machine during startup and add coverage for provider validation plus execution target resolution

## Validation
- PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go run ./cmd/openase openapi generate --output api/openapi.json
- PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/domain/catalog ./internal/service/catalog ./internal/httpapi ./internal/orchestrator ./internal/runtime/database ./internal/agentplatform ./internal/ticket ./internal/cli -count=1
- PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run api:generate
- PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run ci
- PATH=/home/yuzhong/.local/go1.26.1/bin:/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh

## Risks / Follow-up
- CI/frontend builds still delete `internal/webui/static/.keep` in the working tree; this branch restores the tracked placeholder, but the underlying build behavior remains a repo-wide footgun.

Closes #244
