### PR TITLE
feat: add remaining ephemeral chat entry points

### DIFF
--- a/scripts/dev/test_ephemeral_chat_blackbox.py
+++ b/scripts/dev/test_ephemeral_chat_blackbox.py
@@ -161,11 +161,11 @@ def main() -> int:
     base_url = args.base_url.rstrip("/")
     stamp = time.strftime("%Y%m%d%H%M%S")
 
-    print(f"[1/7] health check against {base_url}")
+    print(f"[1/11] health check against {base_url}")
     request_json(base_url, "GET", "/healthz")
     request_json(base_url, "GET", "/api/v1/healthz")
 
-    print("[2/7] create isolated organization and project")
+    print("[2/11] create isolated organization and project")
     org = request_json(
         base_url,
         "POST",
@@ -188,10 +188,10 @@ def main() -> int:
         },
     )["project"]
 
-    print("[3/9] wait for an available Ephemeral Chat provider")
+    print("[3/11] wait for an available Ephemeral Chat provider")
     chat_provider = wait_for_chat_provider(base_url, org["id"], args.timeout_seconds)
 
-    print("[4/9] set the selected provider as the default project provider")
+    print("[4/11] set the selected provider as the default project provider")
     project = request_json(
         base_url,
         "PATCH",
@@ -201,7 +201,18 @@ def main() -> int:
         },
     )["project"]
 
-    print("[5/9] start project-sidebar chat with explicit provider selection")
+    print("[5/11] create a ticket for ticket-detail chat coverage")
+    ticket = request_json(
+        base_url,
+        "POST",
+        f"/api/v1/projects/{project['id']}/tickets",
+        {
+            "title": "Ephemeral Chat ticket detail verification",
+            "description": "Created by the blackbox test to exercise ticket_detail chat entry.",
+        },
+    )["ticket"]
+
+    print("[6/11] start project-sidebar chat with explicit provider selection")
     explicit_payload = {
         "message": "Reply with one short sentence confirming this project sidebar chat is working.",
         "source": "project_sidebar",
@@ -214,7 +225,7 @@ def main() -> int:
     explicit_first_text, explicit_done_payload = start_chat_turn(base_url, args.timeout_seconds, explicit_payload)
     explicit_session_id = str(explicit_done_payload.get("session_id", "")).strip()
 
-    print("[6/9] close the explicit-provider chat session")
+    print("[7/11] close the explicit-provider chat session")
     close_request = urllib.request.Request(
         base_url + f"/api/v1/chat/{explicit_session_id}",
         headers={"Accept": "application/json"},
@@ -226,7 +237,33 @@ def main() -> int:
                 f"expected DELETE /api/v1/chat/{explicit_session_id} to return 204, got {response.status}"
             )
 
-    print("[7/9] start project-sidebar chat via default-provider fallback")
+    print("[8/11] start ticket-detail chat with explicit provider selection")
+    ticket_payload = {
+        "message": "Reply with one short sentence confirming this ticket-detail chat is working.",
+        "source": "ticket_detail",
+        "provider_id": chat_provider["id"],
+        "context": {
+            "project_id": project["id"],
+            "ticket_id": ticket["id"],
+        },
+        "session_id": None,
+    }
+    ticket_text, ticket_done_payload = start_chat_turn(base_url, args.timeout_seconds, ticket_payload)
+    ticket_session_id = str(ticket_done_payload.get("session_id", "")).strip()
+
+    print("[9/11] close the ticket-detail chat session")
+    close_request = urllib.request.Request(
+        base_url + f"/api/v1/chat/{ticket_session_id}",
+        headers={"Accept": "application/json"},
+        method="DELETE",
+    )
+    with urllib.request.urlopen(close_request, timeout=20) as response:
+        if response.status != 204:
+            raise RuntimeError(
+                f"expected DELETE /api/v1/chat/{ticket_session_id} to return 204, got {response.status}"
+            )
+
+    print("[10/11] start project-sidebar chat via default-provider fallback")
     fallback_payload = {
         "message": "Reply with one short sentence confirming default provider fallback works.",
         "source": "project_sidebar",
@@ -240,7 +277,7 @@ def main() -> int:
     )
     fallback_session_id = str(fallback_done_payload.get("session_id", "")).strip()
 
-    print("[8/9] close the fallback chat session")
+    print("[11/11] close the fallback chat session and summarize results")
     close_request = urllib.request.Request(
         base_url + f"/api/v1/chat/{fallback_session_id}",
         headers={"Accept": "application/json"},
@@ -252,7 +289,6 @@ def main() -> int:
                 f"expected DELETE /api/v1/chat/{fallback_session_id} to return 204, got {response.status}"
             )
 
-    print("[9/9] summarize results")
     print(
         json.dumps(
             {
@@ -260,14 +296,19 @@ def main() -> int:
                 "organization": org,
                 "project": project,
                 "provider": chat_provider,
+                "ticket": ticket,
                 "explicit": {
-                "assistant_text": explicit_first_text,
-                "done": explicit_done_payload,
-            },
-            "fallback": {
-                "assistant_text": fallback_first_text,
-                "done": fallback_done_payload,
-            },
+                    "assistant_text": explicit_first_text,
+                    "done": explicit_done_payload,
+                },
+                "ticket_detail": {
+                    "assistant_text": ticket_text,
+                    "done": ticket_done_payload,
+                },
+                "fallback": {
+                    "assistant_text": fallback_first_text,
+                    "done": fallback_done_payload,
+                },
             },
             indent=2,
             ensure_ascii=False,

--- a/web/src/lib/components/layout/sidebar.svelte
+++ b/web/src/lib/components/layout/sidebar.svelte
@@ -5,7 +5,7 @@
   import { Badge } from '$ui/badge'
   import { Separator } from '$ui/separator'
   import * as Tooltip from '$ui/tooltip'
-  import { ChevronsLeft, ChevronsRight } from '@lucide/svelte'
+  import { Bot, ChevronsLeft, ChevronsRight } from '@lucide/svelte'
 
   let {
     collapsed = false,
@@ -16,6 +16,7 @@
     projectName = '',
     projectHealth = 'healthy' as 'healthy' | 'degraded' | 'critical',
     agentCount = 0,
+    onOpenProjectAssistant,
     onToggleCollapse,
   }: {
     collapsed?: boolean
@@ -26,6 +27,7 @@
     projectName?: string
     projectHealth?: 'healthy' | 'degraded' | 'critical'
     agentCount?: number
+    onOpenProjectAssistant?: () => void
     onToggleCollapse?: () => void
   } = $props()
 
@@ -101,9 +103,31 @@
           <span class={cn('size-2 shrink-0 rounded-full', healthColor)}></span>
           <span class="text-sidebar-foreground truncate text-xs font-medium">{projectName}</span>
         </div>
+        <div class="mb-3 px-2.5">
+          <Button variant="outline" size="sm" class="w-full" onclick={onOpenProjectAssistant}>
+            <Bot class="size-4" />
+            Ask AI
+          </Button>
+        </div>
       {:else}
-        <div class="mb-2 flex justify-center">
+        <div class="mb-2 flex flex-col items-center gap-2">
           <span class={cn('size-2 rounded-full', healthColor)}></span>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              {#snippet child({ props })}
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  {...props}
+                  onclick={onOpenProjectAssistant}
+                  aria-label="Ask AI"
+                >
+                  <Bot class="size-4" />
+                </Button>
+              {/snippet}
+            </Tooltip.Trigger>
+            <Tooltip.Content side="right" class="text-xs">Ask AI</Tooltip.Content>
+          </Tooltip.Root>
         </div>
       {/if}
       <div class="space-y-0.5">

--- a/web/src/lib/features/app-shell/components/project-shell.svelte
+++ b/web/src/lib/features/app-shell/components/project-shell.svelte
@@ -5,6 +5,7 @@
   import Sidebar from '$lib/components/layout/sidebar.svelte'
   import TopBar from '$lib/components/layout/top-bar.svelte'
   import { capabilityCatalog } from '$lib/features/capabilities'
+  import { ProjectAssistantSheet } from '$lib/features/chat'
   import { GlobalSearchDialog } from '$lib/features/search'
   import { NewTicketDialog } from '$lib/features/tickets'
   import { TicketDrawer } from '$lib/features/ticket-detail'
@@ -28,6 +29,8 @@
     appStore.rightPanelContent?.type === 'ticket' ? appStore.rightPanelContent.id : null,
   )
   let searchOpen = $state(false)
+  let projectAssistantOpen = $state(false)
+  let projectAssistantPrompt = $state('')
   const projectHealth = $derived.by(() => {
     const status = data.currentProject?.status?.toLowerCase()
     if (status === 'healthy' || status === 'active') return 'healthy'
@@ -86,6 +89,12 @@
     searchOpen = true
   }
 
+  function handleOpenProjectAssistant(initialPrompt = '') {
+    projectAssistantPrompt = initialPrompt
+    searchOpen = false
+    projectAssistantOpen = true
+  }
+
   function handleNewTicket() {
     appStore.openNewTicketDialog()
   }
@@ -129,6 +138,7 @@
         projectName={data.currentProject?.name ?? ''}
         {projectHealth}
         agentCount={data.agentCount}
+        onOpenProjectAssistant={() => handleOpenProjectAssistant()}
         onToggleCollapse={() => appStore.toggleSidebar()}
       />
     </aside>
@@ -151,6 +161,15 @@
 
   <NewTicketDialog />
 
+  <ProjectAssistantSheet
+    bind:open={projectAssistantOpen}
+    organizationId={data.currentOrg?.id ?? ''}
+    projectId={data.currentProject?.id ?? ''}
+    projectName={data.currentProject?.name ?? ''}
+    defaultProviderId={data.currentProject?.default_agent_provider_id ?? null}
+    initialPrompt={projectAssistantPrompt}
+  />
+
   <GlobalSearchDialog
     bind:open={searchOpen}
     organizations={data.organizations}
@@ -161,6 +180,7 @@
     newTicketEnabled={isNewTicketEnabled}
     onToggleTheme={handleToggleTheme}
     onNewTicket={handleNewTicket}
+    onOpenProjectAssistant={handleOpenProjectAssistant}
     onOpenTicket={(ticketId) => appStore.openRightPanel({ type: 'ticket', id: ticketId })}
   />
 </div>

--- a/web/src/lib/features/chat/ephemeral-chat-panel.svelte
+++ b/web/src/lib/features/chat/ephemeral-chat-panel.svelte
@@ -1,0 +1,299 @@
+<script lang="ts">
+  import { ApiError } from '$lib/api/client'
+  import type { AgentProvider } from '$lib/api/contracts'
+  import { listProviders } from '$lib/api/openase'
+  import { toastStore } from '$lib/stores/toast.svelte'
+  import { Badge } from '$ui/badge'
+  import { Button } from '$ui/button'
+  import { ScrollArea } from '$ui/scroll-area'
+  import Textarea from '$ui/textarea/textarea.svelte'
+  import { Bot, LoaderCircle, RefreshCcw, Send } from '@lucide/svelte'
+  import { createEphemeralChatSessionController } from './ephemeral-chat-session-controller.svelte'
+  import EphemeralChatProviderSelect from './ephemeral-chat-provider-select.svelte'
+  import type { ChatSource } from '$lib/api/chat'
+  import { cn } from '$lib/utils'
+
+  type EphemeralChatPanelContext = {
+    projectId: string
+    workflowId?: string
+    ticketId?: string
+  }
+
+  let {
+    source,
+    context,
+    organizationId = '',
+    providers = [],
+    defaultProviderId = null,
+    title = 'Ask AI',
+    description = '',
+    placeholder = 'Ask a question about this project.',
+    emptyStateTitle = 'Start a conversation',
+    emptyStateDescription = 'Use the provider selector to choose an available chat runtime.',
+    contextNote = '',
+    initialPrompt = '',
+    messagePrefix = '',
+  }: {
+    source: ChatSource
+    context: EphemeralChatPanelContext
+    organizationId?: string
+    providers?: AgentProvider[]
+    defaultProviderId?: string | null
+    title?: string
+    description?: string
+    placeholder?: string
+    emptyStateTitle?: string
+    emptyStateDescription?: string
+    contextNote?: string
+    initialPrompt?: string
+    messagePrefix?: string
+  } = $props()
+
+  let prompt = $state('')
+  let loadingProviders = $state(false)
+  let providerError = $state('')
+  let loadedProviders = $state<AgentProvider[]>([])
+  let previousContextKey = ''
+
+  const chatController = createEphemeralChatSessionController({
+    source,
+    onError: (message) => toastStore.error(message),
+  })
+
+  const activeProviders = $derived(providers.length > 0 ? providers : loadedProviders)
+  const chatProviders = $derived(chatController.providers)
+  const providerId = $derived(chatController.providerId)
+  const selectedProvider = $derived(chatController.selectedProvider)
+  const pending = $derived(chatController.pending)
+  const sessionId = $derived(chatController.sessionId)
+  const entries = $derived(chatController.entries)
+  const providerUnavailable = $derived(
+    !loadingProviders && !providerError && chatProviders.length === 0,
+  )
+
+  $effect(() => {
+    const contextKey = [
+      source,
+      organizationId,
+      context.projectId,
+      context.workflowId ?? '',
+      context.ticketId ?? '',
+      initialPrompt,
+      messagePrefix,
+    ].join(':')
+
+    if (contextKey === previousContextKey) {
+      return
+    }
+
+    previousContextKey = contextKey
+    prompt = initialPrompt
+    void chatController.resetConversation()
+  })
+
+  $effect(() => {
+    if (providers.length > 0 || !organizationId) {
+      loadingProviders = false
+      providerError = ''
+      loadedProviders = []
+      return
+    }
+
+    let cancelled = false
+
+    const load = async () => {
+      loadingProviders = true
+      providerError = ''
+
+      try {
+        const payload = await listProviders(organizationId)
+        if (cancelled) {
+          return
+        }
+
+        loadedProviders = payload.providers
+      } catch (caughtError) {
+        if (cancelled) {
+          return
+        }
+
+        providerError =
+          caughtError instanceof ApiError ? caughtError.detail : 'Failed to load chat providers.'
+      } finally {
+        if (!cancelled) {
+          loadingProviders = false
+        }
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  })
+
+  $effect(() => {
+    chatController.syncProviders(activeProviders, defaultProviderId)
+  })
+
+  $effect(() => {
+    return () => {
+      void chatController.dispose()
+    }
+  })
+
+  function buildOutgoingMessage(message: string) {
+    const normalizedPrefix = messagePrefix.trim()
+    if (!normalizedPrefix) {
+      return message
+    }
+
+    return `${normalizedPrefix}\n\nUser request: ${message}`
+  }
+
+  async function handleSend() {
+    const message = prompt.trim()
+    if (!message || !context.projectId || !providerId || pending) {
+      return
+    }
+
+    prompt = ''
+
+    await chatController.sendTurn({
+      message: buildOutgoingMessage(message),
+      context,
+    })
+  }
+
+  async function handleProviderChange(nextProviderId: string) {
+    prompt = initialPrompt
+    await chatController.selectProvider(nextProviderId)
+  }
+
+  async function handleResetConversation() {
+    prompt = initialPrompt
+    await chatController.resetConversation()
+  }
+
+  function handlePromptKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' || event.shiftKey) {
+      return
+    }
+
+    event.preventDefault()
+    void handleSend()
+  }
+</script>
+
+<div class="bg-background flex h-full min-h-0 flex-col">
+  <div class="border-border flex items-center justify-between gap-3 border-b px-4 py-3">
+    <div class="min-w-0">
+      <div class="flex items-center gap-2">
+        <Bot class="text-primary size-4 shrink-0" />
+        <h2 class="truncate text-sm font-semibold">{title}</h2>
+        {#if selectedProvider}
+          <Badge variant="outline" class="text-[10px]">{selectedProvider.name}</Badge>
+        {/if}
+        {#if sessionId}
+          <Badge variant="outline" class="text-[10px]">Context kept</Badge>
+        {/if}
+      </div>
+      {#if description}
+        <p class="text-muted-foreground mt-1 text-xs">{description}</p>
+      {/if}
+    </div>
+
+    <Button
+      variant="ghost"
+      size="sm"
+      onclick={() => void handleResetConversation()}
+      disabled={entries.length === 0 && !pending}
+    >
+      <RefreshCcw class="size-4" />
+    </Button>
+  </div>
+
+  <ScrollArea class="min-h-0 flex-1 px-4 py-4">
+    <div class="space-y-3">
+      {#if entries.length === 0}
+        <div class="border-border bg-muted/20 rounded-2xl border px-4 py-3">
+          <div class="text-sm font-medium">{emptyStateTitle}</div>
+          <p class="text-muted-foreground mt-1 text-xs leading-5">{emptyStateDescription}</p>
+        </div>
+      {/if}
+      {#each entries as entry (entry.id)}
+        <div
+          class={cn(
+            'rounded-2xl border px-3 py-2.5 text-sm leading-6',
+            entry.role === 'user' && 'bg-primary text-primary-foreground',
+            entry.role === 'assistant' && 'border-border bg-muted/40 text-foreground',
+            entry.role === 'system' && 'border-border text-foreground bg-amber-500/10',
+          )}
+        >
+          <div class="mb-1 text-[10px] font-semibold tracking-[0.16em] uppercase opacity-70">
+            {entry.role}
+          </div>
+          <div class="break-words whitespace-pre-wrap">{entry.content}</div>
+        </div>
+      {/each}
+      {#if pending}
+        <div
+          class="border-border bg-muted/30 flex items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm"
+        >
+          <LoaderCircle class="size-4 animate-spin" />
+          Thinking…
+        </div>
+      {/if}
+    </div>
+  </ScrollArea>
+
+  <div class="border-border space-y-3 border-t px-4 py-3">
+    <EphemeralChatProviderSelect
+      providers={chatProviders}
+      {providerId}
+      onProviderChange={(nextProviderId) => void handleProviderChange(nextProviderId)}
+    />
+
+    {#if loadingProviders}
+      <div class="text-muted-foreground text-xs">Loading available chat providers…</div>
+    {:else if providerError}
+      <div class="text-destructive text-xs">{providerError}</div>
+    {:else if providerUnavailable}
+      <div class="text-muted-foreground text-xs">
+        No Ephemeral Chat provider is available for this organization.
+      </div>
+    {/if}
+
+    {#if contextNote}
+      <div class="border-border bg-muted/20 rounded-lg border px-3 py-2 text-xs leading-5">
+        {contextNote}
+      </div>
+    {/if}
+
+    <Textarea
+      bind:value={prompt}
+      rows={4}
+      class="text-sm"
+      {placeholder}
+      disabled={!context.projectId || !providerId || pending}
+      onkeydown={handlePromptKeydown}
+    />
+
+    <div class="flex items-center justify-between gap-3">
+      <p class="text-muted-foreground text-[11px] leading-4">
+        {sessionId
+          ? 'Follow-up prompts reuse the current chat context.'
+          : 'The first reply starts a new ephemeral chat session.'}
+      </p>
+      <Button
+        size="sm"
+        onclick={() => void handleSend()}
+        disabled={!prompt.trim() || !context.projectId || !providerId || pending}
+      >
+        <Send class="size-4" />
+        Send
+      </Button>
+    </div>
+  </div>
+</div>

--- a/web/src/lib/features/chat/index.ts
+++ b/web/src/lib/features/chat/index.ts
@@ -1,4 +1,6 @@
 export { default as EphemeralChatProviderSelect } from './ephemeral-chat-provider-select.svelte'
+export { default as EphemeralChatPanel } from './ephemeral-chat-panel.svelte'
+export { default as ProjectAssistantSheet } from './project-assistant-sheet.svelte'
 export * from './ephemeral-chat-session-controller.svelte'
 export * from './provider-options'
 export * from './transcript'

--- a/web/src/lib/features/chat/project-assistant-sheet.svelte
+++ b/web/src/lib/features/chat/project-assistant-sheet.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '$ui/sheet'
+  import EphemeralChatPanel from './ephemeral-chat-panel.svelte'
+
+  let {
+    open = $bindable(false),
+    organizationId = '',
+    projectId = '',
+    projectName = '',
+    defaultProviderId = null,
+    initialPrompt = '',
+  }: {
+    open?: boolean
+    organizationId?: string
+    projectId?: string
+    projectName?: string
+    defaultProviderId?: string | null
+    initialPrompt?: string
+  } = $props()
+</script>
+
+<Sheet bind:open>
+  <SheetContent side="right" class="flex w-full flex-col gap-0 p-0 sm:max-w-xl">
+    <SheetHeader class="border-border border-b px-6 py-5 text-left">
+      <SheetTitle>Ask AI</SheetTitle>
+      <SheetDescription>
+        {projectName
+          ? `Ask AI about ${projectName}, recent activity, blocked work, or platform setup.`
+          : 'Ask AI about this project.'}
+      </SheetDescription>
+    </SheetHeader>
+
+    {#if open && organizationId && projectId}
+      <EphemeralChatPanel
+        source="project_sidebar"
+        {organizationId}
+        {defaultProviderId}
+        context={{ projectId }}
+        title="Project AI"
+        description={projectName
+          ? `Project context for ${projectName}.`
+          : 'Project context loaded.'}
+        placeholder="Ask about project health, blocked work, staffing, or setup."
+        emptyStateTitle="Project context is ready"
+        emptyStateDescription="Ask about ticket flow, recent activity, staffing needs, or platform setup for this project."
+        {initialPrompt}
+      />
+    {:else}
+      <div class="text-muted-foreground px-6 py-5 text-sm">Project context is unavailable.</div>
+    {/if}
+  </SheetContent>
+</Sheet>

--- a/web/src/lib/features/search/command-items.ts
+++ b/web/src/lib/features/search/command-items.ts
@@ -1,0 +1,16 @@
+import type { Project } from '$lib/api/contracts'
+import type { SearchItem } from './types'
+
+export function buildProjectAssistantCommand(project: Project): SearchItem {
+  return {
+    id: 'command-open-project-ai',
+    group: 'Commands',
+    kind: 'command',
+    title: 'Ask AI',
+    subtitle: `Open project AI for ${project.name}.`,
+    badge: 'Command',
+    searchText:
+      'Ask AI Open project AI. Command ai assistant project chat cron repo setup blocked work',
+    action: { kind: 'open_project_ai' },
+  }
+}

--- a/web/src/lib/features/search/components/global-search-dialog.svelte
+++ b/web/src/lib/features/search/components/global-search-dialog.svelte
@@ -20,6 +20,7 @@
     onToggleTheme,
     onNewTicket,
     onOpenTicket,
+    onOpenProjectAssistant,
   }: {
     open?: boolean
     organizations?: Organization[]
@@ -31,6 +32,7 @@
     onToggleTheme?: () => void
     onNewTicket?: () => void
     onOpenTicket?: (ticketId: string) => void
+    onOpenProjectAssistant?: (initialPrompt?: string) => void
   } = $props()
 
   let tickets = $state<Ticket[]>([])
@@ -127,18 +129,22 @@
   })
 
   async function handleSelect(item: SearchItem) {
+    const selectedQuery = commandValue.trim()
     open = false
     commandValue = ''
-    await executeAction(item.action)
+    await executeAction(item.action, selectedQuery)
   }
 
-  async function executeAction(action: SearchItemAction) {
+  async function executeAction(action: SearchItemAction, selectedQuery: string) {
     switch (action.kind) {
       case 'navigate':
         await goto(action.href)
         return
       case 'open_ticket':
         onOpenTicket?.(action.ticketId)
+        return
+      case 'open_project_ai':
+        onOpenProjectAssistant?.(selectedQuery || undefined)
         return
       case 'new_ticket':
         onNewTicket?.()

--- a/web/src/lib/features/search/model.test.ts
+++ b/web/src/lib/features/search/model.test.ts
@@ -118,6 +118,7 @@ describe('global search index', () => {
   it('builds project navigation and workspace command entries', () => {
     const items = buildFixtureSearchIndex()
 
+    expect(items.some((item) => item.id === 'command-open-project-ai')).toBe(true)
     expect(items.some((item) => item.id === 'command-new-ticket')).toBe(true)
     expect(items.some((item) => item.id === 'command-toggle-theme')).toBe(true)
     expect(items.some((item) => item.id === 'page-tickets' && item.badge === 'Current')).toBe(true)
@@ -145,6 +146,16 @@ describe('global search index', () => {
         badge: 'Command',
         searchText: 'Toggle Theme Switch theme Command',
         action: { kind: 'toggle_theme' },
+      },
+      {
+        id: 'command-open-project-ai',
+        group: 'Commands',
+        kind: 'command',
+        title: 'Ask AI',
+        subtitle: 'Open project AI.',
+        badge: 'Command',
+        searchText: 'Ask AI Open project AI. Command',
+        action: { kind: 'open_project_ai' },
       },
       {
         id: 'organization-org-1',

--- a/web/src/lib/features/search/model.ts
+++ b/web/src/lib/features/search/model.ts
@@ -5,6 +5,7 @@ import {
   projectSections,
   type ProjectSection,
 } from '$lib/stores/app-context'
+import { buildProjectAssistantCommand } from './command-items'
 import type { SearchItem, SearchItemAction, SearchItemGroup, SearchItemKind } from './types'
 import { searchItemGroupOrder } from './types'
 
@@ -85,6 +86,10 @@ function buildCommandItems({
         keywords: ['create ticket issue work item'],
       }),
     )
+  }
+
+  if (currentProject) {
+    items.unshift(buildProjectAssistantCommand(currentProject))
   }
 
   return items

--- a/web/src/lib/features/search/types.ts
+++ b/web/src/lib/features/search/types.ts
@@ -1,6 +1,7 @@
 export type SearchItemAction =
   | { kind: 'navigate'; href: string }
   | { kind: 'open_ticket'; ticketId: string }
+  | { kind: 'open_project_ai' }
   | { kind: 'new_ticket' }
   | { kind: 'toggle_theme' }
 

--- a/web/src/lib/features/settings/components/workflow-scheduled-job-editor.svelte
+++ b/web/src/lib/features/settings/components/workflow-scheduled-job-editor.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+  import { appStore } from '$lib/stores/app.svelte'
+  import { EphemeralChatPanel } from '$lib/features/chat'
+  import * as Dialog from '$ui/dialog'
   import type { ScheduledJob } from '$lib/api/contracts'
   import { formatRelativeTime } from '$lib/utils'
   import { Button } from '$ui/button'
   import { Input } from '$ui/input'
   import { Label } from '$ui/label'
+  import Bot from '@lucide/svelte/icons/bot'
   import * as Select from '$ui/select'
   import { Switch } from '$ui/switch'
   import { Textarea } from '$ui/textarea'
@@ -20,6 +24,7 @@
 
   let {
     draft,
+    projectId,
     selectedJob = null,
     workflowOptions,
     saving = false,
@@ -31,6 +36,7 @@
     onTrigger,
   }: {
     draft: ScheduledJobDraft
+    projectId: string
     selectedJob?: ScheduledJob | null
     workflowOptions: WorkflowOption[]
     saving?: boolean
@@ -43,6 +49,22 @@
   } = $props()
 
   const editorTitle = $derived(selectedJob ? 'Edit scheduled job' : 'Create scheduled job')
+  let assistantOpen = $state(false)
+
+  const cronContextNote = $derived(
+    draft.cronExpression.trim()
+      ? `Current cron expression: ${draft.cronExpression.trim()}`
+      : 'Describe the cadence in natural language and the assistant will help turn it into a cron expression.',
+  )
+  const cronMessagePrefix = $derived(
+    draft.cronExpression.trim()
+      ? [
+          'The user is editing a scheduled job for this project.',
+          `Current cron expression: ${draft.cronExpression.trim()}.`,
+          'Help explain, validate, or revise the cron schedule.',
+        ].join('\n')
+      : 'The user is creating a scheduled job for this project and needs help drafting a cron expression.',
+  )
 </script>
 
 <div class="min-w-0 flex-1 px-5 py-5">
@@ -68,14 +90,22 @@
       </div>
 
       <div class="space-y-2">
-        <Label for="scheduled-job-cron">Cron expression</Label>
-        <Input
-          id="scheduled-job-cron"
-          value={draft.cronExpression}
-          placeholder="0 2 * * *"
-          oninput={(event) =>
-            onFieldChange?.('cronExpression', (event.currentTarget as HTMLInputElement).value)}
-        />
+        <div class="flex items-center justify-between gap-3">
+          <Label for="scheduled-job-cron">Cron expression</Label>
+          <Button variant="outline" size="sm" onclick={() => (assistantOpen = true)}>
+            <Bot class="size-4" />
+            AI
+          </Button>
+        </div>
+        <div class="flex items-center gap-2">
+          <Input
+            id="scheduled-job-cron"
+            value={draft.cronExpression}
+            placeholder="0 2 * * *"
+            oninput={(event) =>
+              onFieldChange?.('cronExpression', (event.currentTarget as HTMLInputElement).value)}
+          />
+        </div>
       </div>
     </div>
 
@@ -237,3 +267,31 @@
     </div>
   </div>
 </div>
+
+<Dialog.Root bind:open={assistantOpen}>
+  <Dialog.Content class="flex h-[80vh] max-h-[48rem] max-w-3xl flex-col overflow-hidden p-0">
+    <Dialog.Header class="border-border border-b px-6 py-5">
+      <Dialog.Title>Cron helper</Dialog.Title>
+      <Dialog.Description>
+        Ask AI to translate natural-language schedules, review an existing cron expression, or
+        suggest safer timing.
+      </Dialog.Description>
+    </Dialog.Header>
+
+    {#if assistantOpen}
+      <EphemeralChatPanel
+        source="project_sidebar"
+        organizationId={appStore.currentOrg?.id ?? ''}
+        defaultProviderId={appStore.currentProject?.default_agent_provider_id ?? null}
+        context={{ projectId }}
+        title="Scheduled Job AI"
+        description="Project context plus cron-specific guidance."
+        placeholder="Describe the schedule you want, or ask what the current cron expression means."
+        emptyStateTitle="Cron context is ready"
+        emptyStateDescription="Ask for cron translation, validation, or safer scheduling guidance for this recurring job."
+        contextNote={cronContextNote}
+        messagePrefix={cronMessagePrefix}
+      />
+    {/if}
+  </Dialog.Content>
+</Dialog.Root>

--- a/web/src/lib/features/settings/components/workflow-scheduled-jobs-panel.svelte
+++ b/web/src/lib/features/settings/components/workflow-scheduled-jobs-panel.svelte
@@ -233,6 +233,7 @@
       <WorkflowScheduledJobList {jobs} {selectedJobId} {workflowLabelById} onSelect={selectJob} />
 
       <WorkflowScheduledJobEditor
+        {projectId}
         {draft}
         {selectedJob}
         {workflowOptions}

--- a/web/src/lib/features/ticket-detail/components/ticket-drawer-content.svelte
+++ b/web/src/lib/features/ticket-detail/components/ticket-drawer-content.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { appStore } from '$lib/stores/app.svelte'
+  import { EphemeralChatPanel } from '$lib/features/chat'
   import { Badge } from '$ui/badge'
   import { Separator } from '$ui/separator'
   import Bot from '@lucide/svelte/icons/bot'
@@ -26,6 +28,7 @@
 
   let {
     ticket,
+    projectId,
     hooks,
     comments,
     activities,
@@ -57,6 +60,7 @@
     onDeleteComment,
   }: {
     ticket: TicketDetail
+    projectId: string
     hooks: HookExecution[]
     comments: TicketComment[]
     activities: TicketActivity[]
@@ -118,9 +122,44 @@
     ticket.budgetUsd > 0 ? Math.round((ticket.costAmount / ticket.budgetUsd) * 100) : 0,
   )
   const costOverBudget = $derived(costPercent > 80)
+  let assistantOpen = $state(false)
+  let previousTicketId = ''
+
+  $effect(() => {
+    if (ticket.id === previousTicketId) {
+      return
+    }
+
+    previousTicketId = ticket.id
+    assistantOpen = false
+  })
 </script>
 
-<TicketHeader {ticket} {statuses} {savingFields} {onClose} {onSaveFields} />
+<TicketHeader
+  {ticket}
+  {statuses}
+  {savingFields}
+  {onClose}
+  {onSaveFields}
+  {assistantOpen}
+  onToggleAssistant={() => (assistantOpen = !assistantOpen)}
+/>
+
+{#if assistantOpen}
+  <div class="border-border h-[26rem] border-b">
+    <EphemeralChatPanel
+      source="ticket_detail"
+      organizationId={appStore.currentOrg?.id ?? ''}
+      defaultProviderId={appStore.currentProject?.default_agent_provider_id ?? null}
+      context={{ projectId, ticketId: ticket.id }}
+      title="Ticket AI Analysis"
+      description={`AI context for ${ticket.identifier}.`}
+      placeholder="Ask why this ticket failed, what the agent did, or how to split the work."
+      emptyStateTitle="Ticket context is ready"
+      emptyStateDescription="Ask for failure analysis, execution summaries, or sub-ticket suggestions."
+    />
+  </div>
+{/if}
 
 <div class="flex flex-1 gap-0 overflow-hidden">
   <TicketCommentsThread

--- a/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
+++ b/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
@@ -251,6 +251,7 @@
       </div>
     {:else if drawerState.ticket}
       <TicketDrawerContent
+        projectId={projectId ?? ''}
         ticket={drawerState.ticket}
         hooks={drawerState.hooks}
         comments={drawerState.comments}

--- a/web/src/lib/features/ticket-detail/components/ticket-header.svelte
+++ b/web/src/lib/features/ticket-detail/components/ticket-header.svelte
@@ -4,6 +4,7 @@
   import { Input } from '$ui/input'
   import { Separator } from '$ui/separator'
   import * as Select from '$ui/select'
+  import Bot from '@lucide/svelte/icons/bot'
   import Copy from '@lucide/svelte/icons/copy'
   import Check from '@lucide/svelte/icons/check'
   import Pencil from '@lucide/svelte/icons/pencil'
@@ -16,13 +17,17 @@
     ticket,
     statuses,
     savingFields = false,
+    assistantOpen = false,
     onClose,
+    onToggleAssistant,
     onSaveFields,
   }: {
     ticket: TicketDetail
     statuses: TicketStatusOption[]
     savingFields?: boolean
+    assistantOpen?: boolean
     onClose?: () => void
+    onToggleAssistant?: () => void
     onSaveFields?: (draft: { title: string; description: string; statusId: string }) => void
   } = $props()
 
@@ -134,7 +139,15 @@
         {typeLabels[ticket.type] ?? ticket.type}
       </Badge>
     </div>
-    <div class="flex items-center gap-1">
+    <div class="flex items-center gap-2">
+      <Button
+        variant={assistantOpen ? 'secondary' : 'outline'}
+        size="sm"
+        onclick={onToggleAssistant}
+      >
+        <Bot class="size-4" />
+        AI 分析
+      </Button>
       <Button variant="ghost" size="icon-sm" onclick={onClose}>
         <X class="size-3.5" />
       </Button>


### PR DESCRIPTION
## Summary
- add a shared Ephemeral Chat panel and project-level sheet for non-Harness entry points
- wire project sidebar, command palette, ticket detail, and scheduled-job cron helper to Ephemeral Chat
- extend blackbox coverage with a `ticket_detail` flow and keep command-palette coverage in web tests

## Validation
- `python3 -m py_compile scripts/dev/test_ephemeral_chat_blackbox.py`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/search/model.test.ts src/lib/features/chat/ephemeral-chat-session-controller.test.ts`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- cron helper and command-palette entry both reuse the existing `project_sidebar` backend source and add source-specific context from the frontend; no new backend chat source was introduced in this slice

Closes #295
