### PR TITLE
fix: normalize Ephemeral Chat runtime semantics across providers

### DIFF
--- a/internal/chat/runtime_claude.go
+++ b/internal/chat/runtime_claude.go
@@ -171,22 +171,15 @@ func mapClaudeEvent(sessionID SessionID, maxTurns int, event provider.ClaudeCode
 
 		items := make([]StreamEvent, 0, len(texts))
 		for _, text := range texts {
-			if proposal, ok := parseActionProposalText(text); ok {
-				items = append(items, StreamEvent{Event: "message", Payload: proposal})
-				continue
-			}
-			items = append(items, StreamEvent{
-				Event:   "message",
-				Payload: textPayload{Type: "text", Content: text},
-			})
+			items = append(items, normalizeAssistantText(text)...)
 		}
 		return items
 	case provider.ClaudeCodeEventKindTaskStart:
-		return []StreamEvent{{Event: "message", Payload: map[string]any{"type": "task_started", "raw": decodeRawJSON(event.Raw)}}}
+		return []StreamEvent{newTaskMessageEvent(chatMessageTypeTaskStarted, decodeRawJSON(event.Raw))}
 	case provider.ClaudeCodeEventKindTaskProgress:
-		return []StreamEvent{{Event: "message", Payload: map[string]any{"type": "task_progress", "raw": decodeRawJSON(event.Raw)}}}
+		return []StreamEvent{newTaskMessageEvent(chatMessageTypeTaskProgress, decodeRawJSON(event.Raw))}
 	case provider.ClaudeCodeEventKindTaskNotice:
-		return []StreamEvent{{Event: "message", Payload: map[string]any{"type": "task_notification", "raw": decodeRawJSON(event.Raw)}}}
+		return []StreamEvent{newTaskMessageEvent(chatMessageTypeTaskNotification, decodeRawJSON(event.Raw))}
 	case provider.ClaudeCodeEventKindUnknown:
 		payload := map[string]any{"type": event.UnknownType}
 		if data := decodeRawJSON(event.Raw); data != nil {

--- a/internal/chat/runtime_codex.go
+++ b/internal/chat/runtime_codex.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,6 +22,12 @@ type codexRuntimeSession struct {
 	session   *codexadapter.Session
 	turnsUsed int
 	running   bool
+}
+
+type codexAssistantItemState struct {
+	text              strings.Builder
+	emittedText       bool
+	waitingOnSnapshot bool
 }
 
 func NewCodexRuntime(adapter *codexadapter.Adapter) *CodexRuntime {
@@ -180,45 +187,43 @@ func (r *CodexRuntime) bridgeTurn(
 		r.mu.Unlock()
 	}()
 
+	assistantItems := make(map[string]*codexAssistantItemState)
+
 	for event := range state.session.Events() {
 		switch event.Type {
+		case codexadapter.EventTypeTurnStarted:
+			if event.Turn == nil || event.Turn.TurnID != turnID {
+				continue
+			}
+			events <- newTaskMessageEvent(chatMessageTypeTaskStarted, map[string]any{
+				"thread_id": event.Turn.ThreadID,
+				"turn_id":   event.Turn.TurnID,
+				"status":    event.Turn.Status,
+			})
 		case codexadapter.EventTypeOutputProduced:
 			if event.Output == nil || event.Output.TurnID != turnID || event.Output.Text == "" {
 				continue
 			}
 			if event.Output.Stream == "assistant" {
-				events <- StreamEvent{
-					Event:   "message",
-					Payload: textPayload{Type: "text", Content: event.Output.Text},
+				for _, item := range mapCodexAssistantOutput(event.Output, assistantItems) {
+					events <- item
 				}
 				continue
 			}
-			events <- StreamEvent{
-				Event: "message",
-				Payload: map[string]any{
-					"type": "task_progress",
-					"raw": map[string]any{
-						"stream":   event.Output.Stream,
-						"text":     event.Output.Text,
-						"phase":    event.Output.Phase,
-						"snapshot": event.Output.Snapshot,
-					},
-				},
-			}
+			events <- newTaskMessageEvent(chatMessageTypeTaskProgress, map[string]any{
+				"stream":   event.Output.Stream,
+				"text":     event.Output.Text,
+				"phase":    event.Output.Phase,
+				"snapshot": event.Output.Snapshot,
+			})
 		case codexadapter.EventTypeToolCallRequested:
 			if event.ToolCall == nil || event.ToolCall.TurnID != turnID {
 				continue
 			}
-			events <- StreamEvent{
-				Event: "message",
-				Payload: map[string]any{
-					"type": "task_notification",
-					"raw": map[string]any{
-						"tool":      event.ToolCall.Tool,
-						"arguments": decodeRawJSON(event.ToolCall.Arguments),
-					},
-				},
-			}
+			events <- newTaskMessageEvent(chatMessageTypeTaskNotification, map[string]any{
+				"tool":      event.ToolCall.Tool,
+				"arguments": decodeRawJSON(event.ToolCall.Arguments),
+			})
 		case codexadapter.EventTypeTurnCompleted:
 			if event.Turn == nil || event.Turn.TurnID != turnID {
 				continue
@@ -262,6 +267,61 @@ func (r *CodexRuntime) bridgeTurn(
 		Event:   "error",
 		Payload: errorPayload{Message: "codex chat session ended unexpectedly"},
 	}
+}
+
+func mapCodexAssistantOutput(
+	output *codexadapter.OutputEvent,
+	items map[string]*codexAssistantItemState,
+) []StreamEvent {
+	if output == nil || strings.TrimSpace(output.Text) == "" {
+		return nil
+	}
+
+	itemID := strings.TrimSpace(output.ItemID)
+	if itemID == "" {
+		return normalizeAssistantText(output.Text)
+	}
+
+	state := items[itemID]
+	if state == nil {
+		state = &codexAssistantItemState{}
+		items[itemID] = state
+	}
+	state.text.WriteString(output.Text)
+	combined := state.text.String()
+
+	if state.waitingOnSnapshot {
+		if !output.Snapshot {
+			return nil
+		}
+		delete(items, itemID)
+		return normalizeAssistantText(combined)
+	}
+
+	if !state.emittedText && shouldDelayCodexAssistantEmission(combined) {
+		state.waitingOnSnapshot = true
+		if !output.Snapshot {
+			return nil
+		}
+		delete(items, itemID)
+		return normalizeAssistantText(combined)
+	}
+
+	if output.Snapshot {
+		delete(items, itemID)
+		if state.emittedText {
+			return nil
+		}
+		return normalizeAssistantText(combined)
+	}
+
+	state.emittedText = true
+	return []StreamEvent{newTextMessageEvent(output.Text)}
+}
+
+func shouldDelayCodexAssistantEmission(text string) bool {
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "```")
 }
 
 func boolPointer(value bool) *bool {

--- a/internal/chat/runtime_gemini.go
+++ b/internal/chat/runtime_gemini.go
@@ -230,9 +230,8 @@ func (r *GeminiRuntime) collectTurn(
 
 	responseText := strings.TrimSpace(payload.Response)
 	if responseText != "" {
-		events <- StreamEvent{
-			Event:   "message",
-			Payload: textPayload{Type: "text", Content: responseText},
+		for _, item := range normalizeAssistantText(responseText) {
+			events <- item
 		}
 	}
 

--- a/internal/chat/runtime_messages.go
+++ b/internal/chat/runtime_messages.go
@@ -1,0 +1,115 @@
+package chat
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+const (
+	chatMessageTypeText             = "text"
+	chatMessageTypeActionProposal   = "action_proposal"
+	chatMessageTypeTaskStarted      = "task_started"
+	chatMessageTypeTaskProgress     = "task_progress"
+	chatMessageTypeTaskNotification = "task_notification"
+)
+
+var codeFencePattern = regexp.MustCompile("(?s)^```(?:json)?\\s*(\\{.*\\})\\s*```$")
+
+func newTextMessageEvent(content string) StreamEvent {
+	return StreamEvent{
+		Event:   "message",
+		Payload: textPayload{Type: chatMessageTypeText, Content: content},
+	}
+}
+
+func newTaskMessageEvent(kind string, raw any) StreamEvent {
+	payload := map[string]any{"type": kind}
+	if raw != nil {
+		payload["raw"] = raw
+	}
+
+	return StreamEvent{Event: "message", Payload: payload}
+}
+
+func normalizeAssistantText(text string) []StreamEvent {
+	if proposal, ok := parseActionProposalText(text); ok {
+		return []StreamEvent{{Event: "message", Payload: proposal}}
+	}
+
+	return []StreamEvent{newTextMessageEvent(text)}
+}
+
+func extractAssistantTextBlocks(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &message); err != nil {
+		return nil
+	}
+
+	items := make([]string, 0, len(message.Content))
+	for _, block := range message.Content {
+		if block.Type != chatMessageTypeText {
+			continue
+		}
+		text := strings.TrimSpace(block.Text)
+		if text == "" {
+			continue
+		}
+		items = append(items, text)
+	}
+	return items
+}
+
+func parseActionProposalText(text string) (map[string]any, bool) {
+	trimmed := extractJSONObjectCandidate(text)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return nil, false
+	}
+	if strings.TrimSpace(stringValue(payload["type"])) != chatMessageTypeActionProposal {
+		return nil, false
+	}
+	if _, ok := payload["actions"]; !ok {
+		return nil, false
+	}
+	return payload, true
+}
+
+func extractJSONObjectCandidate(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if matches := codeFencePattern.FindStringSubmatch(trimmed); len(matches) == 2 {
+		return strings.TrimSpace(matches[1])
+	}
+
+	return trimmed
+}
+
+func decodeRawJSON(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return string(raw)
+	}
+	return decoded
+}
+
+func stringValue(value any) string {
+	typed, _ := value.(string)
+	return typed
+}

--- a/internal/chat/runtime_semantics_test.go
+++ b/internal/chat/runtime_semantics_test.go
@@ -1,0 +1,133 @@
+package chat
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	codexadapter "github.com/BetterAndBetterII/openase/internal/infra/adapter/codex"
+	"github.com/BetterAndBetterII/openase/internal/provider"
+)
+
+func TestMapCodexAssistantOutputPromotesActionProposalFromSnapshot(t *testing.T) {
+	items := make(map[string]*codexAssistantItemState)
+
+	events := mapCodexAssistantOutput(&codexadapter.OutputEvent{
+		ItemID: "item-1",
+		Stream: "assistant",
+		Text:   "```json\n{\"type\":\"action_proposal\",",
+	}, items)
+	if len(events) != 0 {
+		t.Fatalf("first assistant delta should be buffered, got %+v", events)
+	}
+
+	events = mapCodexAssistantOutput(&codexadapter.OutputEvent{
+		ItemID:   "item-1",
+		Stream:   "assistant",
+		Text:     "\"summary\":\"Create child ticket\",\"actions\":[{\"method\":\"POST\",\"path\":\"/api/v1/projects/p/tickets\"}]}\n```",
+		Snapshot: true,
+	}, items)
+	if len(events) != 1 {
+		t.Fatalf("snapshot should emit one normalized event, got %d", len(events))
+	}
+
+	payload, ok := events[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload = %#v, want action proposal payload map", events[0].Payload)
+	}
+	if payload["type"] != chatMessageTypeActionProposal || payload["summary"] != "Create child ticket" {
+		t.Fatalf("unexpected action proposal payload: %#v", payload)
+	}
+}
+
+func TestGeminiRuntimeStartTurnPromotesActionProposalJSON(t *testing.T) {
+	manager := &fakeAgentCLIProcessManager{
+		process: &fakeAgentCLIProcess{
+			stdout: "{\"response\":\"```json\\n{\\\"type\\\":\\\"action_proposal\\\",\\\"summary\\\":\\\"Create 2 tickets\\\",\\\"actions\\\":[{\\\"method\\\":\\\"POST\\\",\\\"path\\\":\\\"/api/v1/projects/p/tickets\\\"}]}\\n```\"}",
+		},
+	}
+	runtime := NewGeminiRuntime(manager)
+
+	stream, err := runtime.StartTurn(context.Background(), RuntimeTurnInput{
+		SessionID:        SessionID("session-gemini-1"),
+		Message:          "Split this into two tickets",
+		SystemPrompt:     "You are OpenASE.",
+		MaxTurns:         DefaultMaxTurns,
+		WorkingDirectory: provider.MustParseAbsolutePath("/tmp/openase"),
+		Provider: catalogdomain.AgentProvider{
+			AdapterType: catalogdomain.AgentProviderAdapterTypeGeminiCLI,
+			CliCommand:  "gemini",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+
+	events := collectStreamEvents(stream.Events)
+	if len(events) != 2 {
+		t.Fatalf("stream event count = %d, want 2: %+v", len(events), events)
+	}
+
+	payload, ok := events[0].Payload.(map[string]any)
+	if events[0].Event != "message" || !ok {
+		t.Fatalf("first event = %+v, want normalized message", events[0])
+	}
+	if payload["type"] != chatMessageTypeActionProposal || payload["summary"] != "Create 2 tickets" {
+		t.Fatalf("unexpected action proposal payload: %#v", payload)
+	}
+
+	done, ok := events[1].Payload.(donePayload)
+	if events[1].Event != "done" || !ok {
+		t.Fatalf("second event = %+v, want done payload", events[1])
+	}
+	if done.SessionID != "session-gemini-1" || done.TurnsUsed != 1 || done.TurnsRemaining != DefaultMaxTurns-1 {
+		t.Fatalf("unexpected done payload: %#v", done)
+	}
+
+	if manager.startSpec.Command != provider.MustParseAgentCLICommand("gemini") {
+		t.Fatalf("process command = %q, want gemini", manager.startSpec.Command)
+	}
+	if joined := strings.Join(manager.startSpec.Args, " "); !strings.Contains(joined, "--output-format json") {
+		t.Fatalf("process args = %v, want json output mode", manager.startSpec.Args)
+	}
+}
+
+type fakeAgentCLIProcessManager struct {
+	process   provider.AgentCLIProcess
+	startSpec provider.AgentCLIProcessSpec
+}
+
+func (m *fakeAgentCLIProcessManager) Start(_ context.Context, spec provider.AgentCLIProcessSpec) (provider.AgentCLIProcess, error) {
+	m.startSpec = spec
+	return m.process, nil
+}
+
+type fakeAgentCLIProcess struct {
+	stdout  string
+	stderr  string
+	waitErr error
+}
+
+func (p *fakeAgentCLIProcess) PID() int { return 4242 }
+
+func (p *fakeAgentCLIProcess) Stdin() io.WriteCloser { return nopWriteCloser{} }
+
+func (p *fakeAgentCLIProcess) Stdout() io.ReadCloser {
+	return io.NopCloser(strings.NewReader(p.stdout))
+}
+
+func (p *fakeAgentCLIProcess) Stderr() io.ReadCloser {
+	return io.NopCloser(strings.NewReader(p.stderr))
+}
+
+func (p *fakeAgentCLIProcess) Wait() error { return p.waitErr }
+
+func (p *fakeAgentCLIProcess) Stop(context.Context) error { return nil }
+
+type nopWriteCloser struct{}
+
+func (nopWriteCloser) Write(data []byte) (int, error) { return len(data), nil }
+
+func (nopWriteCloser) Close() error { return nil }

--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -2,12 +2,10 @@ package chat
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +31,6 @@ var (
 	ErrProviderUnavailable     = errors.New("chat provider is unavailable")
 	ErrSessionNotFound         = errors.New("chat session not found")
 	ErrSessionProviderMismatch = errors.New("chat session cannot resume across providers")
-	codeFencePattern           = regexp.MustCompile("(?s)^```(?:json)?\\s*(\\{.*\\})\\s*```$")
 )
 
 type Source string
@@ -674,80 +671,6 @@ func isHookActivityEvent(item catalogdomain.ActivityEvent) bool {
 		}
 	}
 	return false
-}
-
-func extractAssistantTextBlocks(raw json.RawMessage) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	var message struct {
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.Unmarshal(raw, &message); err != nil {
-		return nil
-	}
-
-	items := make([]string, 0, len(message.Content))
-	for _, block := range message.Content {
-		if block.Type != "text" {
-			continue
-		}
-		text := strings.TrimSpace(block.Text)
-		if text == "" {
-			continue
-		}
-		items = append(items, text)
-	}
-	return items
-}
-
-func parseActionProposalText(text string) (map[string]any, bool) {
-	trimmed := extractJSONObjectCandidate(text)
-	if trimmed == "" {
-		return nil, false
-	}
-
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-		return nil, false
-	}
-	if strings.TrimSpace(stringValue(payload["type"])) != "action_proposal" {
-		return nil, false
-	}
-	if _, ok := payload["actions"]; !ok {
-		return nil, false
-	}
-	return payload, true
-}
-
-func extractJSONObjectCandidate(text string) string {
-	trimmed := strings.TrimSpace(text)
-	if matches := codeFencePattern.FindStringSubmatch(trimmed); len(matches) == 2 {
-		return strings.TrimSpace(matches[1])
-	}
-
-	return trimmed
-}
-
-func decodeRawJSON(raw json.RawMessage) any {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	var decoded any
-	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return string(raw)
-	}
-	return decoded
-}
-
-func stringValue(value any) string {
-	typed, _ := value.(string)
-	return typed
 }
 
 func uuidPtrValue(value *uuid.UUID) uuid.UUID {


### PR DESCRIPTION
## Summary
- extract a shared Ephemeral Chat message normalizer for text, action proposals, and stable task message kinds
- route Claude, Codex, and Gemini runtimes through the shared helpers while preserving provider-local session semantics
- add Codex/Gemini-focused coverage for normalized `action_proposal` handling outside the existing Claude path

## Validation
- `PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/chat`
- `PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test -run 'TestChatRouteStreamsTicketDetailContext|TestChatDeleteRouteAndErrorMappings' -count=1 -timeout 60s -v ./internal/httpapi`
- `.codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- Codex only delays assistant streaming when the accumulated text looks like a structured JSON/code-fence reply; plain-text-first replies that later embed an `action_proposal` block still stream as text first.

Closes #296
