### PR TITLE
Fix self-hosted backend check stalls in CI

### DIFF
--- a/.codex/skills/push/scripts/openase_ci_gate.sh
+++ b/.codex/skills/push/scripts/openase_ci_gate.sh
@@ -144,7 +144,7 @@ fi
 
 if [[ "${go_changed}" == "true" ]]; then
   ensure_lint_placeholder
-  run_cmd make check
+  run_cmd env OPENASE_BACKEND_TEST_GROUP_SIZE=8 make check
   run_cmd make build
   run_cmd make LINT_BASE_REV="${BASE_REV}" lint
   run_cmd make lint-depguard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
         timeout-minutes: 45
         shell: bash
         env:
+          OPENASE_BACKEND_TEST_GROUP_SIZE: "8"
           OPENASE_GO_TEST_PROGRESS_MODE: plain
         run: |
           set -euo pipefail

--- a/scripts/ci/backend_coverage.sh
+++ b/scripts/ci/backend_coverage.sh
@@ -22,6 +22,7 @@ cd "${ROOT_DIR}"
 
 GO_BIN="${GO_BIN:-go}"
 GO_TEST_TIMEOUT="${OPENASE_GO_TEST_TIMEOUT:-20m}"
+GO_TEST_GROUP_SIZE_RAW="${OPENASE_BACKEND_TEST_GROUP_SIZE:-}"
 ENABLE_FULL_BACKEND_COVERAGE="${OPENASE_ENABLE_FULL_BACKEND_COVERAGE:-false}"
 BACKEND_COVERAGE_MIN="${OPENASE_BACKEND_COVERAGE_MIN:-75.0}"
 DOMAIN_COVERAGE_MIN="${OPENASE_DOMAIN_COVERAGE_MIN:-100.0}"
@@ -29,6 +30,32 @@ ORIGINAL_GOPATH="$("${GO_BIN}" env GOPATH)"
 ORIGINAL_GOMODCACHE="$("${GO_BIN}" env GOMODCACHE)"
 ORIGINAL_GOCACHE="$("${GO_BIN}" env GOCACHE)"
 GO_TEST_PROGRESS_MODE="${OPENASE_GO_TEST_PROGRESS_MODE:-}"
+
+parse_optional_positive_int() {
+  local name="$1"
+  local raw="$2"
+
+  if [[ -z "${raw}" ]]; then
+    printf '0\n'
+    return
+  fi
+
+  case "${raw}" in
+    ''|*[!0-9]*)
+      printf '%s must be a positive integer, got %s\n' "${name}" "${raw}" >&2
+      exit 1
+      ;;
+  esac
+
+  if (( raw <= 0 )); then
+    printf '%s must be a positive integer, got %s\n' "${name}" "${raw}" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${raw}"
+}
+
+GO_TEST_GROUP_SIZE="$(parse_optional_positive_int "OPENASE_BACKEND_TEST_GROUP_SIZE" "${GO_TEST_GROUP_SIZE_RAW}")"
 
 tmp_dir="$(mktemp -d)"
 backend_profile="${tmp_dir}/backend.out"
@@ -90,6 +117,44 @@ run_go_test() {
 
   "${GO_BIN}" test "$@"
 }
+
+run_backend_full_suite() {
+  if (( GO_TEST_GROUP_SIZE == 0 )); then
+    printf 'Running backend full test suite...\n'
+    run_go_test \
+      -count=1 \
+      -timeout="${GO_TEST_TIMEOUT}" \
+      -p 1 \
+      -parallel=1 \
+      "${backend_packages[@]}"
+    return
+  fi
+
+  local total_packages="${#backend_packages[@]}"
+  local total_groups=$(( (total_packages + GO_TEST_GROUP_SIZE - 1) / GO_TEST_GROUP_SIZE ))
+  local offset=0
+  local group_index=1
+
+  printf 'Running backend full test suite in %d groups (%d packages total)...\n' "${total_groups}" "${total_packages}"
+
+  while (( offset < total_packages )); do
+    local -a group_packages=( "${backend_packages[@]:offset:GO_TEST_GROUP_SIZE}" )
+
+    printf '\nRunning backend test group %d/%d (%d packages):\n' "${group_index}" "${total_groups}" "${#group_packages[@]}"
+    printf '  %s\n' "${group_packages[@]}"
+
+    run_go_test \
+      -count=1 \
+      -timeout="${GO_TEST_TIMEOUT}" \
+      -p 1 \
+      -parallel=1 \
+      "${group_packages[@]}"
+
+    offset=$(( offset + GO_TEST_GROUP_SIZE ))
+    group_index=$(( group_index + 1 ))
+  done
+}
+
 enable_full_backend_coverage() {
   case "${ENABLE_FULL_BACKEND_COVERAGE}" in
     1|true|TRUE|yes|YES|on|ON)
@@ -103,14 +168,7 @@ enable_full_backend_coverage() {
   printf 'OPENASE_ENABLE_FULL_BACKEND_COVERAGE must be one of true/false, got %s\n' "${ENABLE_FULL_BACKEND_COVERAGE}" >&2
   exit 1
 }
-
-printf 'Running backend full test suite...\n'
-run_go_test \
-  -count=1 \
-  -timeout="${GO_TEST_TIMEOUT}" \
-  -p 1 \
-  -parallel=1 \
-  "${backend_packages[@]}"
+run_backend_full_suite
 
 backend_pct=""
 if enable_full_backend_coverage; then


### PR DESCRIPTION
## Summary
- stop `actions/checkout` from force-cleaning the self-hosted workspace before each job so stale runner leftovers do not fail checkout before workflow steps start
- isolate Go module/build caches under `${RUNNER_TEMP}` and remove the `actions/setup-go` cache lifecycle from the remaining self-hosted Go jobs
- add backend heartbeat logging, bounded backend timeouts, and shard the self-hosted backend full test suite into 8-package groups so the runner no longer relies on one long-lived `go test` process

## Validation
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml')`
- `bash -n scripts/ci/backend_coverage.sh`
- `bash -n .codex/skills/push/scripts/openase_ci_gate.sh`
- `PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH OPENASE_BACKEND_TEST_GROUP_SIZE=8 OPENASE_GO_TEST_PROGRESS_MODE=plain ./scripts/ci/backend_coverage.sh`
- `PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`
- remote run `23686634968` proved `Go Lint` no longer hangs in `Post Set Up Go`, emitted backend heartbeat lines, printed `Last backend heartbeat`, and failed explicitly on the backend step timeout instead of hanging indefinitely
- remote run `23687220546` proved the widened timeout budget still left the backend job vulnerable to runner-side termination after `internal/orchestrator`, which motivated sharding the backend suite into shorter invocations

## Risks / Follow-up
- isolated caches trade self-hosted cache reuse for deterministic runner behavior
- if the self-hosted runner still proves unstable even with grouped backend invocations, the next mitigation should move only the backend job off the runner rather than reopen shared-cache behavior

Closes #316.
