### PR TITLE
feat: expand HR Advisor workflow pressure recommendations

### DIFF
--- a/OpenASE-PRD.md
+++ b/OpenASE-PRD.md
@@ -7138,7 +7138,8 @@ OpenASE 内置一个 "HR Advisor" 功能，根据项目当前状态推荐应该"
 
 - 项目描述、状态（`Backlog` / `Planned` / `In Progress` / `Completed` / `Canceled` / `Archived`）
 - 现有工单分布（多少 coding / test / doc / security）
-- 已有角色/Workflow 列表
+- 工单状态分布与各状态的排队压力（例如 `Backlog`、`待测试`、`待文档`）
+- 已有角色/Workflow 列表，以及每个 Workflow 的 `pickup` / `finish` 状态绑定
 - 最近的活动趋势（PR 合并率下降？测试覆盖率低？文档过时？）
 
 **输出：**
@@ -7196,6 +7197,14 @@ func (h *HRAdvisor) Recommend(ctx context.Context, project *project.Project) []R
                 Reason: "科研项目刚启动，建议先招募 Idea 挖掘角色进行文献调研和方向探索。",
             })
         }
+    }
+
+    // 规则 6: 某个状态列积压，但没有 Workflow pickup 该列 → 推荐补齐对应 lane
+    if stats.StatusQueue["待测试"] >= 2 && !stats.HasPickupWorkflow("待测试") {
+        recs = append(recs, RoleRecommendation{
+            Role:   "qa-engineer",
+            Reason: fmt.Sprintf("状态列待测试中有 %d 个工单，但没有任何 Workflow pickup 该列。建议新增 QA Workflow 处理待测试 lane。", stats.StatusQueue["待测试"]),
+        })
     }
 
     return recs

--- a/internal/domain/hradvisor/analysis.go
+++ b/internal/domain/hradvisor/analysis.go
@@ -26,15 +26,19 @@ type TicketContext struct {
 	Type              string
 	StatusName        string
 	WorkflowType      string
+	HasActiveRun      bool
 	ConsecutiveErrors int
 	RetryPaused       bool
 }
 
 // WorkflowContext summarizes one workflow for staffing analysis.
 type WorkflowContext struct {
-	Name     string
-	Type     string
-	IsActive bool
+	Name              string
+	Type              string
+	RoleSlug          string
+	IsActive          bool
+	PickupStatusNames []string
+	FinishStatusNames []string
 }
 
 // AgentContext summarizes one agent for staffing analysis.

--- a/internal/httpapi/hr_advisor_api.go
+++ b/internal/httpapi/hr_advisor_api.go
@@ -95,7 +95,18 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 	}
 
 	workflowTypes := make(map[uuid.UUID]string, len(workflows))
+	statusNamesByID := make(map[uuid.UUID]string)
+	if s.ticketStatusService != nil {
+		statuses, err := s.ticketStatusService.List(ctx, projectID)
+		if err != nil {
+			return writeTicketStatusError(c, err)
+		}
+		for _, statusItem := range statuses.Statuses {
+			statusNamesByID[statusItem.ID] = statusItem.Name
+		}
+	}
 	activeRoleWorkflows := make(map[string]string)
+	workflowRoleSlugs := make(map[uuid.UUID]string)
 	for _, workflowItem := range workflows {
 		workflowTypes[workflowItem.ID] = string(workflowItem.Type)
 		if !workflowItem.IsActive {
@@ -108,6 +119,7 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 		}
 		if roleSlug := parseHarnessRoleSlug(detail.HarnessContent); roleSlug != "" {
 			activeRoleWorkflows[roleSlug] = workflowItem.Name
+			workflowRoleSlugs[workflowItem.ID] = roleSlug
 		}
 	}
 
@@ -140,6 +152,7 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 			Type:              string(ticketItem.Type),
 			StatusName:        ticketItem.StatusName,
 			WorkflowType:      workflowType,
+			HasActiveRun:      ticketItem.CurrentRunID != nil,
 			ConsecutiveErrors: ticketItem.ConsecutiveErrors,
 			RetryPaused:       ticketItem.RetryPaused,
 		})
@@ -147,9 +160,12 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 
 	for _, workflowItem := range workflows {
 		snapshot.Workflows = append(snapshot.Workflows, hrdomain.WorkflowContext{
-			Name:     workflowItem.Name,
-			Type:     string(workflowItem.Type),
-			IsActive: workflowItem.IsActive,
+			Name:              workflowItem.Name,
+			Type:              string(workflowItem.Type),
+			RoleSlug:          workflowRoleSlugs[workflowItem.ID],
+			IsActive:          workflowItem.IsActive,
+			PickupStatusNames: statusNamesFromIDs(workflowItem.PickupStatusIDs, statusNamesByID),
+			FinishStatusNames: statusNamesFromIDs(workflowItem.FinishStatusIDs, statusNamesByID),
 		})
 	}
 
@@ -269,4 +285,18 @@ func extractHarnessFrontmatter(content string) (string, error) {
 	}
 
 	return "", workflowservice.ErrHarnessInvalid
+}
+
+func statusNamesFromIDs(statusIDs []uuid.UUID, statusNamesByID map[uuid.UUID]string) []string {
+	if len(statusIDs) == 0 || len(statusNamesByID) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(statusIDs))
+	for _, statusID := range statusIDs {
+		if name := strings.TrimSpace(statusNamesByID[statusID]); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }

--- a/internal/httpapi/hr_advisor_api_test.go
+++ b/internal/httpapi/hr_advisor_api_test.go
@@ -289,6 +289,161 @@ func TestHRAdvisorRouteReturnsDefaultRecommendationsForFreshProject(t *testing.T
 	}
 }
 
+func TestHRAdvisorRouteIncludesDispatcherRecommendationFromBacklogPressure(t *testing.T) {
+	client := openTestEntClient(t)
+	repoRoot := createTestGitRepo(t)
+
+	workflowSvc, err := workflowservice.NewService(client, slog.New(slog.NewTextHandler(io.Discard, nil)), repoRoot)
+	if err != nil {
+		t.Fatalf("create workflow service: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := workflowSvc.Close(); closeErr != nil {
+			t.Errorf("close workflow service: %v", closeErr)
+		}
+	})
+
+	server := NewServer(
+		config.ServerConfig{Port: 40023},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		ticketservice.NewService(client),
+		ticketstatus.NewService(client),
+		nil,
+		catalogservice.New(catalogrepo.NewEntRepository(client), executable.NewPathResolver(), nil),
+		workflowSvc,
+	)
+
+	ctx := context.Background()
+	org, err := client.Organization.Create().
+		SetName("Better And Better").
+		SetSlug("better-and-better").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create organization: %v", err)
+	}
+	project, err := client.Project.Create().
+		SetOrganizationID(org.ID).
+		SetName("OpenASE").
+		SetSlug("openase").
+		SetStatus("In Progress").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	createPrimaryProjectRepo(ctx, t, client, project.ID, repoRoot)
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
+
+	statuses, err := ticketstatus.NewService(client).ResetToDefaultTemplate(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("reset ticket statuses: %v", err)
+	}
+	backlogID := findStatusIDByName(t, statuses, "Backlog")
+	todoID := findStatusIDByName(t, statuses, "Todo")
+	doneID := findStatusIDByName(t, statuses, "Done")
+
+	fullstackRole, ok := builtin.RoleBySlug("fullstack-developer")
+	if !ok {
+		t.Fatal("expected builtin fullstack-developer role")
+	}
+
+	provider, err := client.AgentProvider.Create().
+		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
+		SetName("Codex").
+		SetAdapterType(entagentprovider.AdapterTypeCustom).
+		SetCliCommand("codex").
+		SetModelName("gpt-5.4").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create agent provider: %v", err)
+	}
+	agentItem, err := client.Agent.Create().
+		SetProviderID(provider.ID).
+		SetProjectID(project.ID).
+		SetName("codex-1").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	executeJSON(
+		t,
+		server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/workflows", project.ID),
+		map[string]any{
+			"name":              "Fullstack Developer",
+			"type":              "coding",
+			"harness_path":      fullstackRole.HarnessPath,
+			"harness_content":   fullstackRole.Content,
+			"agent_id":          agentItem.ID.String(),
+			"pickup_status_ids": []string{todoID.String()},
+			"finish_status_ids": []string{doneID.String()},
+		},
+		http.StatusCreated,
+		nil,
+	)
+
+	for index := 0; index < 11; index++ {
+		if _, err := client.Ticket.Create().
+			SetProjectID(project.ID).
+			SetIdentifier(fmt.Sprintf("ASE-%d", index+1)).
+			SetTitle(fmt.Sprintf("Backlog %d", index+1)).
+			SetStatusID(backlogID).
+			SetPriority(entticket.PriorityHigh).
+			SetType(entticket.TypeFeature).
+			SetCreatedBy("user:test").
+			Save(ctx); err != nil {
+			t.Fatalf("create backlog ticket %d: %v", index+1, err)
+		}
+	}
+
+	resp := struct {
+		Recommendations []hrAdvisorRecommendationResponse `json:"recommendations"`
+	}{}
+	executeJSON(
+		t,
+		server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/hr-advisor", project.ID),
+		nil,
+		http.StatusOK,
+		&resp,
+	)
+
+	var dispatcherRecommendation *hrAdvisorRecommendationResponse
+	for index := range resp.Recommendations {
+		recommendation := &resp.Recommendations[index]
+		if recommendation.RoleSlug == "dispatcher" {
+			dispatcherRecommendation = recommendation
+			break
+		}
+	}
+	if dispatcherRecommendation == nil {
+		t.Fatalf("expected dispatcher recommendation, got %+v", resp.Recommendations)
+	}
+	if dispatcherRecommendation.SuggestedWorkflowName != "Dispatcher" {
+		t.Fatalf("expected dispatcher workflow suggestion, got %+v", dispatcherRecommendation)
+	}
+	if !strings.Contains(dispatcherRecommendation.Reason, "Backlog") {
+		t.Fatalf("expected backlog-specific reason, got %+v", dispatcherRecommendation)
+	}
+	if !strings.Contains(strings.Join(dispatcherRecommendation.Evidence, " "), "pick up and finish Backlog") {
+		t.Fatalf("expected backlog lane evidence, got %+v", dispatcherRecommendation.Evidence)
+	}
+}
+
 func parseUUID(t *testing.T, raw string) uuid.UUID {
 	t.Helper()
 

--- a/internal/service/hradvisor/analyzer.go
+++ b/internal/service/hradvisor/analyzer.go
@@ -19,7 +19,25 @@ type snapshotStats struct {
 	testWorkflowCount     int
 	docWorkflowCount      int
 	securityWorkflowCount int
+	backlogTickets        int
+	hasDispatcherWorkflow bool
+	statusPressure        []statusPressure
 	activeWorkflowTypes   []string
+}
+
+type statusPressure struct {
+	StatusName          string
+	QueuedTickets       int
+	PickupWorkflowNames []string
+	FinishWorkflowNames []string
+}
+
+type laneProfile struct {
+	RoleSlug         string
+	WorkflowName     string
+	WorkflowType     string
+	MinQueuedTickets int
+	HeadcountDivisor int
 }
 
 type projectStatus string
@@ -45,12 +63,30 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 		}
 	}
 
-	recommendations := make([]domain.Recommendation, 0, 6)
-	add := func(recommendation domain.Recommendation) {
-		if _, exists := activeRoles[recommendation.RoleSlug]; exists {
+	recommendations := make([]domain.Recommendation, 0, 8)
+	recommendedRoles := make(map[string]struct{}, 8)
+	add := func(recommendation domain.Recommendation, allowExistingRole bool) {
+		if recommendation.RoleSlug == "" {
 			return
 		}
+		if !allowExistingRole {
+			if _, exists := activeRoles[recommendation.RoleSlug]; exists {
+				return
+			}
+		}
+		if _, exists := recommendedRoles[recommendation.RoleSlug]; exists {
+			return
+		}
+		recommendedRoles[recommendation.RoleSlug] = struct{}{}
 		recommendations = append(recommendations, recommendation)
+	}
+
+	for _, pressure := range stats.statusPressure {
+		recommendation, ok := recommendationForPressure(pressure, stats)
+		if !ok {
+			continue
+		}
+		add(recommendation, true)
 	}
 
 	if status == projectStatusPlanned && stats.openTickets == 0 && stats.workflowCount == 0 {
@@ -61,7 +97,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{"Project status is Planned.", "No workflows are configured yet.", "No open tickets are currently staged."},
 			SuggestedHeadcount:    1,
 			SuggestedWorkflowName: "Product Manager",
-		})
+		}, false)
 	}
 
 	if status == projectStatusInProgress && stats.activeAgents == 0 {
@@ -72,7 +108,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{"Project status is In Progress.", fmt.Sprintf("Open tickets: %d.", stats.openTickets), "No active agents are attached."},
 			SuggestedHeadcount:    max(1, scaleHeadcount(stats.codingTickets, 4)),
 			SuggestedWorkflowName: "Fullstack Developer",
-		})
+		}, false)
 	}
 
 	if stats.codingTickets >= 3 && stats.testWorkflowCount == 0 {
@@ -83,7 +119,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{fmt.Sprintf("Open coding tickets: %d.", stats.codingTickets), fmt.Sprintf("Active test workflows: %d.", stats.testWorkflowCount)},
 			SuggestedHeadcount:    max(1, scaleHeadcount(stats.codingTickets, 6)),
 			SuggestedWorkflowName: "QA Engineer",
-		})
+		}, false)
 	}
 
 	if (stats.openTickets >= 5 || stats.workflowCount >= 3) && stats.docWorkflowCount == 0 {
@@ -94,7 +130,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{fmt.Sprintf("Open tickets: %d.", stats.openTickets), fmt.Sprintf("Configured workflows: %d.", stats.workflowCount), fmt.Sprintf("Active doc workflows: %d.", stats.docWorkflowCount)},
 			SuggestedHeadcount:    1,
 			SuggestedWorkflowName: "Technical Writer",
-		})
+		}, false)
 	}
 
 	if (stats.openTickets >= 8 || stats.failingTickets >= 2) && stats.securityWorkflowCount == 0 {
@@ -105,7 +141,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{fmt.Sprintf("Open tickets: %d.", stats.openTickets), fmt.Sprintf("Failing tickets: %d.", stats.failingTickets), fmt.Sprintf("Active security workflows: %d.", stats.securityWorkflowCount)},
 			SuggestedHeadcount:    1,
 			SuggestedWorkflowName: "Security Engineer",
-		})
+		}, false)
 	}
 
 	if isResearchProject(snapshot.Project) && stats.workflowCount == 0 {
@@ -116,7 +152,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			Evidence:              []string{"Project title or description contains research-oriented keywords.", "No workflows are configured yet."},
 			SuggestedHeadcount:    1,
 			SuggestedWorkflowName: "Research Ideation",
-		})
+		}, false)
 	}
 
 	sortRecommendations(recommendations)
@@ -140,6 +176,10 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 func collectStats(snapshot domain.Snapshot) snapshotStats {
 	stats := snapshotStats{}
 	activeWorkflowTypes := make(map[string]struct{})
+	queuedTicketsByStatus := make(map[string]int)
+	statusDisplayNames := make(map[string]string)
+	pickupWorkflowsByStatus := make(map[string]map[string]struct{})
+	finishWorkflowsByStatus := make(map[string]map[string]struct{})
 
 	for _, workflow := range snapshot.Workflows {
 		stats.workflowCount++
@@ -160,6 +200,12 @@ func collectStats(snapshot domain.Snapshot) snapshotStats {
 		case "security":
 			stats.securityWorkflowCount++
 		}
+
+		if isDispatcherWorkflow(workflow) {
+			stats.hasDispatcherWorkflow = true
+		}
+		registerWorkflowCoverage(pickupWorkflowsByStatus, statusDisplayNames, workflow.PickupStatusNames, workflow.Name)
+		registerWorkflowCoverage(finishWorkflowsByStatus, statusDisplayNames, workflow.FinishStatusNames, workflow.Name)
 	}
 
 	for _, agent := range snapshot.Agents {
@@ -181,6 +227,18 @@ func collectStats(snapshot domain.Snapshot) snapshotStats {
 		if ticket.RetryPaused {
 			stats.blockedTickets++
 		}
+		if !ticket.HasActiveRun {
+			statusKey := normalizeStatusName(ticket.StatusName)
+			if statusKey != "" {
+				queuedTicketsByStatus[statusKey]++
+				if statusDisplayNames[statusKey] == "" {
+					statusDisplayNames[statusKey] = strings.TrimSpace(ticket.StatusName)
+				}
+				if statusKey == normalizeStatusName(string(projectStatusBacklog)) {
+					stats.backlogTickets++
+				}
+			}
+		}
 
 		switch strings.TrimSpace(ticket.WorkflowType) {
 		case "coding":
@@ -195,7 +253,65 @@ func collectStats(snapshot domain.Snapshot) snapshotStats {
 	}
 
 	stats.activeWorkflowTypes = mapKeys(activeWorkflowTypes)
+	stats.statusPressure = buildStatusPressure(queuedTicketsByStatus, statusDisplayNames, pickupWorkflowsByStatus, finishWorkflowsByStatus)
 	return stats
+}
+
+func recommendationForPressure(pressure statusPressure, stats snapshotStats) (domain.Recommendation, bool) {
+	if len(pressure.PickupWorkflowNames) > 0 {
+		return domain.Recommendation{}, false
+	}
+
+	profile, ok := profileForStatus(pressure.StatusName)
+	if !ok || pressure.QueuedTickets < profile.MinQueuedTickets {
+		return domain.Recommendation{}, false
+	}
+	if profile.RoleSlug == "dispatcher" && stats.hasDispatcherWorkflow {
+		return domain.Recommendation{}, false
+	}
+
+	reason := fmt.Sprintf(
+		"%s has %d queued tickets, but no active workflow picks up that lane. Add a %s workflow bound to %s.",
+		pressure.StatusName,
+		pressure.QueuedTickets,
+		profile.WorkflowName,
+		pressure.StatusName,
+	)
+	if profile.RoleSlug == "dispatcher" {
+		reason = fmt.Sprintf(
+			"Backlog has %d queued tickets, but no active Dispatcher workflow is bound to pick up and finish that lane.",
+			pressure.QueuedTickets,
+		)
+	}
+
+	evidence := []string{
+		fmt.Sprintf("Queued tickets in status %q: %d.", pressure.StatusName, pressure.QueuedTickets),
+		fmt.Sprintf("Active workflows picking up %q: none.", pressure.StatusName),
+	}
+	if len(pressure.FinishWorkflowNames) > 0 {
+		evidence = append(
+			evidence,
+			fmt.Sprintf("Active workflows finishing into %q: %s.", pressure.StatusName, strings.Join(pressure.FinishWorkflowNames, ", ")),
+		)
+	}
+	if profile.WorkflowType != "" {
+		evidence = append(
+			evidence,
+			fmt.Sprintf("Suggested workflow type for %q: %s.", pressure.StatusName, profile.WorkflowType),
+		)
+	}
+	if profile.RoleSlug == "dispatcher" {
+		evidence = append(evidence, "Dispatcher coverage requires a workflow bound to pick up and finish Backlog.")
+	}
+
+	return domain.Recommendation{
+		RoleSlug:              profile.RoleSlug,
+		Priority:              pressurePriority(profile, pressure.QueuedTickets),
+		Reason:                reason,
+		Evidence:              evidence,
+		SuggestedHeadcount:    max(1, scaleHeadcount(pressure.QueuedTickets, profile.HeadcountDivisor)),
+		SuggestedWorkflowName: suggestedWorkflowName(profile, pressure.StatusName),
+	}, true
 }
 
 func parseProjectStatus(raw string) projectStatus {
@@ -269,6 +385,39 @@ func sortRecommendations(items []domain.Recommendation) {
 	})
 }
 
+func buildStatusPressure(
+	queuedTicketsByStatus map[string]int,
+	statusDisplayNames map[string]string,
+	pickupWorkflowsByStatus map[string]map[string]struct{},
+	finishWorkflowsByStatus map[string]map[string]struct{},
+) []statusPressure {
+	pressures := make([]statusPressure, 0, len(queuedTicketsByStatus))
+	for statusKey, queuedTickets := range queuedTicketsByStatus {
+		if queuedTickets <= 0 {
+			continue
+		}
+
+		statusName := statusDisplayNames[statusKey]
+		if statusName == "" {
+			statusName = statusKey
+		}
+		pressures = append(pressures, statusPressure{
+			StatusName:          statusName,
+			QueuedTickets:       queuedTickets,
+			PickupWorkflowNames: workflowNamesForStatus(pickupWorkflowsByStatus, statusKey),
+			FinishWorkflowNames: workflowNamesForStatus(finishWorkflowsByStatus, statusKey),
+		})
+	}
+
+	sort.SliceStable(pressures, func(i int, j int) bool {
+		if pressures[i].QueuedTickets != pressures[j].QueuedTickets {
+			return pressures[i].QueuedTickets > pressures[j].QueuedTickets
+		}
+		return pressures[i].StatusName < pressures[j].StatusName
+	})
+	return pressures
+}
+
 func mapKeys(items map[string]struct{}) []string {
 	keys := make([]string, 0, len(items))
 	for key := range items {
@@ -276,6 +425,141 @@ func mapKeys(items map[string]struct{}) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func workflowNamesForStatus(items map[string]map[string]struct{}, statusKey string) []string {
+	values := items[statusKey]
+	if len(values) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func registerWorkflowCoverage(
+	items map[string]map[string]struct{},
+	statusDisplayNames map[string]string,
+	statusNames []string,
+	workflowName string,
+) {
+	trimmedWorkflowName := strings.TrimSpace(workflowName)
+	if trimmedWorkflowName == "" {
+		return
+	}
+
+	for _, statusName := range statusNames {
+		statusKey := normalizeStatusName(statusName)
+		if statusKey == "" {
+			continue
+		}
+
+		if statusDisplayNames[statusKey] == "" {
+			statusDisplayNames[statusKey] = strings.TrimSpace(statusName)
+		}
+		if items[statusKey] == nil {
+			items[statusKey] = make(map[string]struct{})
+		}
+		items[statusKey][trimmedWorkflowName] = struct{}{}
+	}
+}
+
+func profileForStatus(statusName string) (laneProfile, bool) {
+	normalized := normalizeStatusName(statusName)
+	switch {
+	case normalized == normalizeStatusName(string(projectStatusBacklog)):
+		return laneProfile{
+			RoleSlug:         "dispatcher",
+			WorkflowName:     "Dispatcher",
+			WorkflowType:     "custom",
+			MinQueuedTickets: 11,
+			HeadcountDivisor: 10,
+		}, true
+	case containsStatusKeyword(normalized, "test", "qa", "测试", "验证"):
+		return laneProfile{
+			RoleSlug:         "qa-engineer",
+			WorkflowName:     "QA Engineer",
+			WorkflowType:     "test",
+			MinQueuedTickets: 2,
+			HeadcountDivisor: 6,
+		}, true
+	case containsStatusKeyword(normalized, "doc", "docs", "write", "writer", "文档", "撰写"):
+		return laneProfile{
+			RoleSlug:         "technical-writer",
+			WorkflowName:     "Technical Writer",
+			WorkflowType:     "doc",
+			MinQueuedTickets: 2,
+			HeadcountDivisor: 8,
+		}, true
+	case containsStatusKeyword(normalized, "security", "scan", "audit", "安全", "扫描", "审计"):
+		return laneProfile{
+			RoleSlug:         "security-engineer",
+			WorkflowName:     "Security Engineer",
+			WorkflowType:     "security",
+			MinQueuedTickets: 2,
+			HeadcountDivisor: 8,
+		}, true
+	case containsStatusKeyword(normalized, "todo", "develop", "development", "coding", "implement", "待开发", "开发", "编码", "实现"):
+		return laneProfile{
+			RoleSlug:         "fullstack-developer",
+			WorkflowName:     "Fullstack Developer",
+			WorkflowType:     "coding",
+			MinQueuedTickets: 2,
+			HeadcountDivisor: 4,
+		}, true
+	default:
+		return laneProfile{}, false
+	}
+}
+
+func suggestedWorkflowName(profile laneProfile, statusName string) string {
+	trimmedStatusName := strings.TrimSpace(statusName)
+	if trimmedStatusName == "" || profile.RoleSlug == "dispatcher" {
+		return profile.WorkflowName
+	}
+	return fmt.Sprintf("%s - %s", profile.WorkflowName, trimmedStatusName)
+}
+
+func pressurePriority(profile laneProfile, queuedTickets int) string {
+	if profile.RoleSlug == "dispatcher" || queuedTickets >= 4 {
+		return "high"
+	}
+	return "medium"
+}
+
+func containsStatusKeyword(normalized string, keywords ...string) bool {
+	for _, keyword := range keywords {
+		if strings.Contains(normalized, strings.ToLower(strings.TrimSpace(keyword))) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeStatusName(statusName string) string {
+	return strings.ToLower(strings.TrimSpace(statusName))
+}
+
+func isDispatcherWorkflow(workflow domain.WorkflowContext) bool {
+	if strings.TrimSpace(workflow.RoleSlug) == "dispatcher" {
+		return true
+	}
+	return hasStatusBinding(workflow.PickupStatusNames, string(projectStatusBacklog)) &&
+		hasStatusBinding(workflow.FinishStatusNames, string(projectStatusBacklog))
+}
+
+func hasStatusBinding(statusNames []string, want string) bool {
+	wantNormalized := normalizeStatusName(want)
+	for _, statusName := range statusNames {
+		if normalizeStatusName(statusName) == wantNormalized {
+			return true
+		}
+	}
+	return false
 }
 
 func isDoneStatus(statusName string) bool {

--- a/internal/service/hradvisor/analyzer_test.go
+++ b/internal/service/hradvisor/analyzer_test.go
@@ -1,6 +1,7 @@
 package hradvisor
 
 import (
+	"strings"
 	"testing"
 
 	domain "github.com/BetterAndBetterII/openase/internal/domain/hradvisor"
@@ -133,5 +134,106 @@ func TestAnalyzeDoesNotAcceptLegacyProjectStatuses(t *testing.T) {
 	}
 	if analysis.Staffing.Product != 0 || analysis.Staffing.Developers != 0 {
 		t.Fatalf("expected no legacy-status staffing bump, got %+v", analysis.Staffing)
+	}
+}
+
+func TestAnalyzeRecommendsDispatcherFromBacklogPressure(t *testing.T) {
+	tickets := make([]domain.TicketContext, 0, 11)
+	for index := 0; index < 11; index++ {
+		tickets = append(tickets, domain.TicketContext{
+			Identifier: "ASE-backlog",
+			Type:       "feature",
+			StatusName: "Backlog",
+		})
+	}
+
+	analysis := Analyze(domain.Snapshot{
+		Project: domain.ProjectContext{
+			Name:   "OpenASE",
+			Status: "In Progress",
+		},
+		Tickets: tickets,
+		Workflows: []domain.WorkflowContext{
+			{
+				Name:              "Coding Workflow",
+				Type:              "coding",
+				IsActive:          true,
+				PickupStatusNames: []string{"Todo"},
+				FinishStatusNames: []string{"Done"},
+			},
+		},
+	})
+
+	var dispatcherRecommendation *domain.Recommendation
+	for index := range analysis.Recommendations {
+		recommendation := &analysis.Recommendations[index]
+		if recommendation.RoleSlug == "dispatcher" {
+			dispatcherRecommendation = recommendation
+			break
+		}
+	}
+	if dispatcherRecommendation == nil {
+		t.Fatalf("expected dispatcher recommendation, got %+v", analysis.Recommendations)
+	}
+	if dispatcherRecommendation.SuggestedWorkflowName != "Dispatcher" {
+		t.Fatalf("expected dispatcher workflow name, got %+v", dispatcherRecommendation)
+	}
+	if !strings.Contains(dispatcherRecommendation.Reason, "Backlog") {
+		t.Fatalf("expected backlog reason, got %+v", dispatcherRecommendation)
+	}
+	if len(dispatcherRecommendation.Evidence) < 2 || !strings.Contains(strings.Join(dispatcherRecommendation.Evidence, " "), "pick up and finish Backlog") {
+		t.Fatalf("expected dispatcher evidence to mention backlog lane coverage, got %+v", dispatcherRecommendation.Evidence)
+	}
+}
+
+func TestAnalyzeRecommendsMissingLaneEvenWhenRoleIsAlreadyActiveElsewhere(t *testing.T) {
+	analysis := Analyze(domain.Snapshot{
+		Project: domain.ProjectContext{
+			Name:   "OpenASE",
+			Status: "In Progress",
+		},
+		Tickets: []domain.TicketContext{
+			{Identifier: "ASE-1", Type: "feature", StatusName: "Ready for Test"},
+			{Identifier: "ASE-2", Type: "feature", StatusName: "Ready for Test"},
+		},
+		Workflows: []domain.WorkflowContext{
+			{
+				Name:              "Coding Workflow",
+				Type:              "coding",
+				IsActive:          true,
+				PickupStatusNames: []string{"Todo"},
+				FinishStatusNames: []string{"Ready for Test"},
+			},
+			{
+				Name:              "QA Regression",
+				Type:              "test",
+				RoleSlug:          "qa-engineer",
+				IsActive:          true,
+				PickupStatusNames: []string{"Regression Queue"},
+				FinishStatusNames: []string{"Done"},
+			},
+		},
+		ActiveRoleSlugs: []string{"qa-engineer"},
+	})
+
+	var qaRecommendation *domain.Recommendation
+	for index := range analysis.Recommendations {
+		recommendation := &analysis.Recommendations[index]
+		if recommendation.RoleSlug == "qa-engineer" {
+			qaRecommendation = recommendation
+			break
+		}
+	}
+	if qaRecommendation == nil {
+		t.Fatalf("expected qa recommendation for missing lane, got %+v", analysis.Recommendations)
+	}
+	if qaRecommendation.SuggestedWorkflowName != "QA Engineer - Ready for Test" {
+		t.Fatalf("expected lane-specific workflow suggestion, got %+v", qaRecommendation)
+	}
+	if !strings.Contains(qaRecommendation.Reason, "Ready for Test") {
+		t.Fatalf("expected lane-specific reason, got %+v", qaRecommendation)
+	}
+	if !strings.Contains(strings.Join(qaRecommendation.Evidence, " "), "Coding Workflow") {
+		t.Fatalf("expected evidence to mention upstream workflow finish binding, got %+v", qaRecommendation.Evidence)
 	}
 }


### PR DESCRIPTION
## Summary
- extend HR Advisor snapshots with workflow pickup/finish bindings, role slugs, and active-run ticket signals
- recommend Dispatcher from `Backlog` pressure and recommend missing workflow lanes from queued status distribution
- add analyzer/API coverage for backlog and lane-aware recommendations and update the PRD inputs/rules

## Validation
- PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/service/hradvisor -run 'TestAnalyze'
- PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run 'TestHRAdvisor'
- .codex/skills/push/scripts/openase_ci_gate.sh

## Risks / Follow-up
- Status-to-role lane mapping is still keyword-based; additional built-in lane profiles can be added as more workflow conventions stabilize.

Closes #301
