### PR TITLE
Add HR Advisor trend signals from recent activity

### DIFF
--- a/internal/domain/hradvisor/analysis.go
+++ b/internal/domain/hradvisor/analysis.go
@@ -4,12 +4,13 @@ import "time"
 
 // Snapshot is the project state analyzed by the HR advisor.
 type Snapshot struct {
-	Project         ProjectContext
-	Tickets         []TicketContext
-	Workflows       []WorkflowContext
-	Agents          []AgentContext
-	RecentActivity  []ActivityContext
-	ActiveRoleSlugs []string
+	Project             ProjectContext
+	Tickets             []TicketContext
+	Workflows           []WorkflowContext
+	Agents              []AgentContext
+	RecentActivityCount int
+	RecentTrends        []ActivityTrendContext
+	ActiveRoleSlugs     []string
 }
 
 // ProjectContext summarizes the project-level planning signals.
@@ -46,11 +47,17 @@ type AgentContext struct {
 	Status string
 }
 
-// ActivityContext summarizes recent activity for staffing analysis.
-type ActivityContext struct {
-	EventType string
-	Message   string
-	CreatedAt time.Time
+const (
+	ActivityTrendDocumentationDrift = "documentation_drift"
+	ActivityTrendFailureBurst       = "failure_burst"
+)
+
+// ActivityTrendContext summarizes one parsed recent-activity trend.
+type ActivityTrendContext struct {
+	Kind     string
+	Count    int
+	Evidence []string
+	LastSeen time.Time
 }
 
 // Analysis is the staffing recommendation result produced by the advisor.

--- a/internal/httpapi/hr_advisor_activity_trends.go
+++ b/internal/httpapi/hr_advisor_activity_trends.go
@@ -1,0 +1,122 @@
+package httpapi
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	hrdomain "github.com/BetterAndBetterII/openase/internal/domain/hradvisor"
+)
+
+type hrActivityTrendAccumulator struct {
+	mergedPRCount  int
+	docUpdateCount int
+	failureCount   int
+	lastSeen       time.Time
+}
+
+func parseHRActivityTrends(items []catalogdomain.ActivityEvent) []hrdomain.ActivityTrendContext {
+	if len(items) == 0 {
+		return nil
+	}
+
+	var accumulator hrActivityTrendAccumulator
+	for _, item := range items {
+		if item.CreatedAt.After(accumulator.lastSeen) {
+			accumulator.lastSeen = item.CreatedAt
+		}
+		if isMergeLikeActivity(item) {
+			accumulator.mergedPRCount++
+		}
+		if isDocumentationUpdateActivity(item) {
+			accumulator.docUpdateCount++
+		}
+		if isFailureActivity(item) {
+			accumulator.failureCount++
+		}
+	}
+
+	trends := make([]hrdomain.ActivityTrendContext, 0, 2)
+	if docDriftCount := accumulator.mergedPRCount - accumulator.docUpdateCount; accumulator.mergedPRCount >= 2 && docDriftCount > 0 {
+		trends = append(trends, hrdomain.ActivityTrendContext{
+			Kind:  hrdomain.ActivityTrendDocumentationDrift,
+			Count: docDriftCount,
+			Evidence: []string{
+				fmt.Sprintf("Recent merge-like activity events: %d.", accumulator.mergedPRCount),
+				fmt.Sprintf("Recent documentation update events: %d.", accumulator.docUpdateCount),
+			},
+			LastSeen: accumulator.lastSeen,
+		})
+	}
+	if accumulator.failureCount >= 3 {
+		trends = append(trends, hrdomain.ActivityTrendContext{
+			Kind:  hrdomain.ActivityTrendFailureBurst,
+			Count: accumulator.failureCount,
+			Evidence: []string{
+				fmt.Sprintf("Recent failure-like activity events: %d.", accumulator.failureCount),
+			},
+			LastSeen: accumulator.lastSeen,
+		})
+	}
+
+	return trends
+}
+
+func isMergeLikeActivity(item catalogdomain.ActivityEvent) bool {
+	eventType := normalizedActivityText(item.EventType)
+	message := normalizedActivityText(item.Message)
+	return strings.Contains(eventType, "pr.merged") ||
+		strings.Contains(eventType, "pull_request.merged") ||
+		strings.Contains(eventType, "merged") ||
+		strings.Contains(message, "merged pull request") ||
+		strings.Contains(message, "pull request merged") ||
+		strings.Contains(message, "merged pr") ||
+		strings.Contains(message, "pr merged")
+}
+
+func isDocumentationUpdateActivity(item catalogdomain.ActivityEvent) bool {
+	eventType := normalizedActivityText(item.EventType)
+	message := normalizedActivityText(item.Message)
+	if strings.Contains(eventType, "docs.") || strings.Contains(eventType, "doc.") || strings.Contains(eventType, "documentation") {
+		return true
+	}
+	if strings.Contains(message, "without docs") || strings.Contains(message, "without documentation") ||
+		strings.Contains(message, "no docs") || strings.Contains(message, "no documentation") {
+		return false
+	}
+
+	hasDocKeyword := false
+	for _, keyword := range []string{
+		"docs",
+		"documentation",
+		"readme",
+		"runbook",
+		"guide",
+		"manual",
+		"changelog",
+	} {
+		if strings.Contains(message, keyword) {
+			hasDocKeyword = true
+			break
+		}
+	}
+	if !hasDocKeyword {
+		return false
+	}
+	for _, keyword := range []string{"update", "updated", "refresh", "refreshed", "publish", "published", "write", "wrote", "edit", "edited"} {
+		if strings.Contains(message, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func isFailureActivity(item catalogdomain.ActivityEvent) bool {
+	eventType := normalizedActivityText(item.EventType)
+	return strings.Contains(eventType, "failed") || strings.Contains(eventType, "error")
+}
+
+func normalizedActivityText(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}

--- a/internal/httpapi/hr_advisor_api.go
+++ b/internal/httpapi/hr_advisor_api.go
@@ -130,11 +130,12 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 			Status:              string(project.Status),
 			MaxConcurrentAgents: project.MaxConcurrentAgents,
 		},
-		Tickets:         make([]hrdomain.TicketContext, 0, len(tickets)),
-		Workflows:       make([]hrdomain.WorkflowContext, 0, len(workflows)),
-		Agents:          make([]hrdomain.AgentContext, 0, len(agents)),
-		RecentActivity:  make([]hrdomain.ActivityContext, 0, len(activityItems)),
-		ActiveRoleSlugs: make([]string, 0, len(activeRoleWorkflows)),
+		Tickets:             make([]hrdomain.TicketContext, 0, len(tickets)),
+		Workflows:           make([]hrdomain.WorkflowContext, 0, len(workflows)),
+		Agents:              make([]hrdomain.AgentContext, 0, len(agents)),
+		RecentActivityCount: len(activityItems),
+		RecentTrends:        parseHRActivityTrends(activityItems),
+		ActiveRoleSlugs:     make([]string, 0, len(activeRoleWorkflows)),
 	}
 
 	for roleSlug := range activeRoleWorkflows {
@@ -176,14 +177,6 @@ func (s *Server) handleGetHRAdvisor(c echo.Context) error {
 		}
 		snapshot.Agents = append(snapshot.Agents, hrdomain.AgentContext{
 			Status: status,
-		})
-	}
-
-	for _, activityItem := range activityItems {
-		snapshot.RecentActivity = append(snapshot.RecentActivity, hrdomain.ActivityContext{
-			EventType: activityItem.EventType,
-			Message:   activityItem.Message,
-			CreatedAt: activityItem.CreatedAt,
 		})
 	}
 

--- a/internal/httpapi/hr_advisor_api_test.go
+++ b/internal/httpapi/hr_advisor_api_test.go
@@ -289,6 +289,98 @@ func TestHRAdvisorRouteReturnsDefaultRecommendationsForFreshProject(t *testing.T
 	}
 }
 
+func TestHRAdvisorRouteIncludesDocumentationDriftTrendEvidence(t *testing.T) {
+	client := openTestEntClient(t)
+	repoRoot := createTestGitRepo(t)
+
+	workflowSvc, err := workflowservice.NewService(client, slog.New(slog.NewTextHandler(io.Discard, nil)), repoRoot)
+	if err != nil {
+		t.Fatalf("create workflow service: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := workflowSvc.Close(); closeErr != nil {
+			t.Errorf("close workflow service: %v", closeErr)
+		}
+	})
+
+	server := NewServer(
+		config.ServerConfig{Port: 40023},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		ticketservice.NewService(client),
+		ticketstatus.NewService(client),
+		nil,
+		catalogservice.New(catalogrepo.NewEntRepository(client), executable.NewPathResolver(), nil),
+		workflowSvc,
+	)
+
+	ctx := context.Background()
+	org, err := client.Organization.Create().
+		SetName("Better And Better").
+		SetSlug("better-and-better").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create organization: %v", err)
+	}
+	project, err := client.Project.Create().
+		SetOrganizationID(org.ID).
+		SetName("OpenASE").
+		SetSlug("openase").
+		SetStatus("In Progress").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	createPrimaryProjectRepo(ctx, t, client, project.ID, repoRoot)
+
+	for index := 0; index < 4; index++ {
+		if _, err := client.ActivityEvent.Create().
+			SetProjectID(project.ID).
+			SetEventType("pr.merged").
+			SetMessage(fmt.Sprintf("Merged PR #%d without docs update", index+1)).
+			Save(ctx); err != nil {
+			t.Fatalf("create merged activity event %d: %v", index+1, err)
+		}
+	}
+
+	resp := struct {
+		Summary struct {
+			RecentActivityCount int `json:"recent_activity_count"`
+		} `json:"summary"`
+		Recommendations []hrAdvisorRecommendationResponse `json:"recommendations"`
+	}{}
+	executeJSON(
+		t,
+		server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/hr-advisor", project.ID),
+		nil,
+		http.StatusOK,
+		&resp,
+	)
+
+	if resp.Summary.RecentActivityCount != 4 {
+		t.Fatalf("expected recent activity count 4, got %+v", resp.Summary)
+	}
+
+	var writerRecommendation *hrAdvisorRecommendationResponse
+	for index := range resp.Recommendations {
+		recommendation := &resp.Recommendations[index]
+		if recommendation.RoleSlug == "technical-writer" {
+			writerRecommendation = recommendation
+			break
+		}
+	}
+	if writerRecommendation == nil {
+		t.Fatalf("expected technical writer recommendation, got %+v", resp.Recommendations)
+	}
+	evidence := strings.Join(writerRecommendation.Evidence, " ")
+	if !strings.Contains(evidence, "merge-like activity events: 4") || !strings.Contains(evidence, "documentation update events: 0") {
+		t.Fatalf("expected documentation drift evidence, got %+v", writerRecommendation.Evidence)
+	}
+}
+
 func TestHRAdvisorRouteIncludesDispatcherRecommendationFromBacklogPressure(t *testing.T) {
 	client := openTestEntClient(t)
 	repoRoot := createTestGitRepo(t)

--- a/internal/service/hradvisor/analyzer.go
+++ b/internal/service/hradvisor/analyzer.go
@@ -21,6 +21,9 @@ type snapshotStats struct {
 	securityWorkflowCount int
 	backlogTickets        int
 	hasDispatcherWorkflow bool
+	documentationDrift    int
+	failureBurstCount     int
+	trendEvidenceByKind   map[string][]string
 	statusPressure        []statusPressure
 	activeWorkflowTypes   []string
 }
@@ -122,26 +125,12 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 		}, false)
 	}
 
-	if (stats.openTickets >= 5 || stats.workflowCount >= 3) && stats.docWorkflowCount == 0 {
-		add(domain.Recommendation{
-			RoleSlug:              "technical-writer",
-			Priority:              "medium",
-			Reason:                "The delivery surface is growing without a documentation lane to keep operator guidance and implementation notes current.",
-			Evidence:              []string{fmt.Sprintf("Open tickets: %d.", stats.openTickets), fmt.Sprintf("Configured workflows: %d.", stats.workflowCount), fmt.Sprintf("Active doc workflows: %d.", stats.docWorkflowCount)},
-			SuggestedHeadcount:    1,
-			SuggestedWorkflowName: "Technical Writer",
-		}, false)
+	if recommendation, ok := documentationRecommendation(stats); ok {
+		add(recommendation, false)
 	}
 
-	if (stats.openTickets >= 8 || stats.failingTickets >= 2) && stats.securityWorkflowCount == 0 {
-		add(domain.Recommendation{
-			RoleSlug:              "security-engineer",
-			Priority:              "medium",
-			Reason:                "Load and failure signals are high enough that a dedicated security pass should be added before the project scales further.",
-			Evidence:              []string{fmt.Sprintf("Open tickets: %d.", stats.openTickets), fmt.Sprintf("Failing tickets: %d.", stats.failingTickets), fmt.Sprintf("Active security workflows: %d.", stats.securityWorkflowCount)},
-			SuggestedHeadcount:    1,
-			SuggestedWorkflowName: "Security Engineer",
-		}, false)
+	if recommendation, ok := securityRecommendation(stats); ok {
+		add(recommendation, false)
 	}
 
 	if isResearchProject(snapshot.Project) && stats.workflowCount == 0 {
@@ -165,7 +154,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 			BlockedTickets:      stats.blockedTickets,
 			ActiveAgents:        stats.activeAgents,
 			WorkflowCount:       stats.workflowCount,
-			RecentActivityCount: len(snapshot.RecentActivity),
+			RecentActivityCount: snapshot.RecentActivityCount,
 			ActiveWorkflowTypes: stats.activeWorkflowTypes,
 		},
 		Recommendations: recommendations,
@@ -174,7 +163,7 @@ func Analyze(snapshot domain.Snapshot) domain.Analysis {
 }
 
 func collectStats(snapshot domain.Snapshot) snapshotStats {
-	stats := snapshotStats{}
+	stats := snapshotStats{trendEvidenceByKind: make(map[string][]string)}
 	activeWorkflowTypes := make(map[string]struct{})
 	queuedTicketsByStatus := make(map[string]int)
 	statusDisplayNames := make(map[string]string)
@@ -252,9 +241,92 @@ func collectStats(snapshot domain.Snapshot) snapshotStats {
 		}
 	}
 
+	for _, trend := range snapshot.RecentTrends {
+		switch trend.Kind {
+		case domain.ActivityTrendDocumentationDrift:
+			stats.documentationDrift += trend.Count
+		case domain.ActivityTrendFailureBurst:
+			stats.failureBurstCount += trend.Count
+		}
+		if len(trend.Evidence) > 0 {
+			stats.trendEvidenceByKind[trend.Kind] = append(stats.trendEvidenceByKind[trend.Kind], trend.Evidence...)
+		}
+	}
+
 	stats.activeWorkflowTypes = mapKeys(activeWorkflowTypes)
 	stats.statusPressure = buildStatusPressure(queuedTicketsByStatus, statusDisplayNames, pickupWorkflowsByStatus, finishWorkflowsByStatus)
 	return stats
+}
+
+func documentationRecommendation(stats snapshotStats) (domain.Recommendation, bool) {
+	if stats.docWorkflowCount > 0 {
+		return domain.Recommendation{}, false
+	}
+
+	hasStaticPressure := stats.openTickets >= 5 || stats.workflowCount >= 3
+	hasTrendPressure := stats.documentationDrift > 0
+	if !hasStaticPressure && !hasTrendPressure {
+		return domain.Recommendation{}, false
+	}
+
+	reason := "The delivery surface is growing without a documentation lane to keep operator guidance and implementation notes current."
+	if hasTrendPressure {
+		reason = "Recent delivery activity shows merges outpacing documentation updates, and there is no documentation lane to absorb that drift."
+	}
+
+	evidence := make([]string, 0, 5)
+	if hasStaticPressure {
+		evidence = append(evidence,
+			fmt.Sprintf("Open tickets: %d.", stats.openTickets),
+			fmt.Sprintf("Configured workflows: %d.", stats.workflowCount),
+		)
+	}
+	if hasTrendPressure {
+		evidence = append(evidence, stats.trendEvidenceByKind[domain.ActivityTrendDocumentationDrift]...)
+		evidence = append(evidence, fmt.Sprintf("Documentation drift signals: %d.", stats.documentationDrift))
+	}
+	evidence = append(evidence, fmt.Sprintf("Active doc workflows: %d.", stats.docWorkflowCount))
+
+	priority := "medium"
+	if stats.documentationDrift >= 3 {
+		priority = "high"
+	}
+
+	return domain.Recommendation{
+		RoleSlug:              "technical-writer",
+		Priority:              priority,
+		Reason:                reason,
+		Evidence:              evidence,
+		SuggestedHeadcount:    1,
+		SuggestedWorkflowName: "Technical Writer",
+	}, true
+}
+
+func securityRecommendation(stats snapshotStats) (domain.Recommendation, bool) {
+	if stats.securityWorkflowCount > 0 {
+		return domain.Recommendation{}, false
+	}
+	if stats.openTickets < 8 && stats.failingTickets < 2 && stats.failureBurstCount == 0 {
+		return domain.Recommendation{}, false
+	}
+
+	evidence := []string{
+		fmt.Sprintf("Open tickets: %d.", stats.openTickets),
+		fmt.Sprintf("Failing tickets: %d.", stats.failingTickets),
+		fmt.Sprintf("Active security workflows: %d.", stats.securityWorkflowCount),
+	}
+	if stats.failureBurstCount > 0 {
+		evidence = append(evidence, stats.trendEvidenceByKind[domain.ActivityTrendFailureBurst]...)
+	}
+
+	return domain.Recommendation{
+		RoleSlug:              "security-engineer",
+		Priority:              "medium",
+		Reason:                "Load and failure signals are high enough that a dedicated security pass should be added before the project scales further.",
+		Evidence:              evidence,
+		SuggestedHeadcount:    1,
+		SuggestedWorkflowName: "Security Engineer",
+	}, true
 }
 
 func recommendationForPressure(pressure statusPressure, stats snapshotStats) (domain.Recommendation, bool) {
@@ -349,10 +421,10 @@ func buildStaffingPlan(projectStatus projectStatus, stats snapshotStats) domain.
 	if stats.codingTickets >= 3 {
 		plan.QA = max(1, scaleHeadcount(stats.codingTickets, 6))
 	}
-	if stats.openTickets >= 5 || stats.workflowCount >= 3 {
+	if stats.openTickets >= 5 || stats.workflowCount >= 3 || stats.documentationDrift > 0 {
 		plan.Docs = 1
 	}
-	if stats.openTickets >= 8 || stats.failingTickets >= 2 {
+	if stats.openTickets >= 8 || stats.failingTickets >= 2 || stats.failureBurstCount > 0 {
 		plan.Security = 1
 	}
 	if projectStatus == projectStatusPlanned && stats.workflowCount == 0 {

--- a/internal/service/hradvisor/analyzer_test.go
+++ b/internal/service/hradvisor/analyzer_test.go
@@ -52,6 +52,48 @@ func TestAnalyzeRecommendsQADocsAndSecurityFromWorkloadShape(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRecommendsTechnicalWriterFromDocumentationDriftTrend(t *testing.T) {
+	analysis := Analyze(domain.Snapshot{
+		Project: domain.ProjectContext{
+			Name:   "OpenASE",
+			Status: "In Progress",
+		},
+		RecentActivityCount: 4,
+		RecentTrends: []domain.ActivityTrendContext{
+			{
+				Kind:  domain.ActivityTrendDocumentationDrift,
+				Count: 4,
+				Evidence: []string{
+					"Recent merge-like activity events: 4.",
+					"Recent documentation update events: 0.",
+				},
+			},
+		},
+	})
+
+	var writerRecommendation *domain.Recommendation
+	for index := range analysis.Recommendations {
+		recommendation := &analysis.Recommendations[index]
+		if recommendation.RoleSlug == "technical-writer" {
+			writerRecommendation = recommendation
+			break
+		}
+	}
+	if writerRecommendation == nil {
+		t.Fatalf("expected technical writer recommendation, got %+v", analysis.Recommendations)
+	}
+	if writerRecommendation.Priority != "high" {
+		t.Fatalf("expected high-priority documentation trend recommendation, got %+v", writerRecommendation)
+	}
+	evidence := strings.Join(writerRecommendation.Evidence, " ")
+	if !strings.Contains(evidence, "merge-like activity events: 4") || !strings.Contains(evidence, "documentation update events: 0") {
+		t.Fatalf("expected documentation drift evidence, got %+v", writerRecommendation.Evidence)
+	}
+	if analysis.Staffing.Docs != 1 {
+		t.Fatalf("expected docs staffing to reflect documentation drift, got %+v", analysis.Staffing)
+	}
+}
+
 func TestAnalyzeSkipsRolesThatAreAlreadyActive(t *testing.T) {
 	analysis := Analyze(domain.Snapshot{
 		Project: domain.ProjectContext{


### PR DESCRIPTION
## Summary
- parse recent project activity into HR-specific trend signals at the HTTP boundary
- recommend a technical writer when recent merge activity outpaces documentation updates
- include concrete trend evidence in HR Advisor recommendations and lock the path with tests

## Validation
- `PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/service/hradvisor`
- `PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run 'TestHRAdvisorRoute'`
- `.codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- This PR ships the narrow PRD-aligned documentation-drift slice first; other recent-activity trends can build on the same parsed trend boundary.

Closes #302
