### PR TITLE
Fix ticket detail timeline refresh wiring

### DIFF
--- a/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
+++ b/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
@@ -92,10 +92,7 @@
     }
 
     return connectTicketDetailStreams(projectId, ticketId, () => {
-      void drawerState.load(projectId, ticketId, {
-        background: true,
-        preserveMessages: true,
-      })
+      void drawerState.refreshTimeline(projectId, ticketId)
     })
   })
 

--- a/web/src/lib/features/ticket-detail/drawer-comment-actions.test.ts
+++ b/web/src/lib/features/ticket-detail/drawer-comment-actions.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '$lib/api/client'
+import {
+  handleCreateTicketComment,
+  handleDeleteTicketComment,
+  handleUpdateTicketComment,
+} from './drawer-comment-actions'
+
+const {
+  createTicketComment,
+  deleteTicketComment,
+  listTicketCommentRevisions,
+  updateTicketComment,
+} = vi.hoisted(() => ({
+  createTicketComment: vi.fn(),
+  deleteTicketComment: vi.fn(),
+  listTicketCommentRevisions: vi.fn(),
+  updateTicketComment: vi.fn(),
+}))
+
+vi.mock('$lib/api/openase', () => ({
+  createTicketComment,
+  deleteTicketComment,
+  listTicketCommentRevisions,
+  updateTicketComment,
+}))
+
+function createDrawerState() {
+  return {
+    creatingComment: false,
+    updatingCommentId: null as string | null,
+    deletingCommentId: null as string | null,
+    clearMutationMessages: vi.fn(),
+    setMutationError: vi.fn(),
+    setMutationNotice: vi.fn(),
+    refreshTimeline: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('ticket detail comment actions', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('refreshes the unified timeline after creating a comment', async () => {
+    createTicketComment.mockResolvedValue({
+      comment: {
+        id: 'comment-1',
+      },
+    })
+
+    const drawerState = createDrawerState()
+    const result = await handleCreateTicketComment({
+      projectId: 'project-1',
+      ticketId: 'ticket-1',
+      drawerState,
+      body: 'Ship it',
+    })
+
+    expect(result).toBe(true)
+    expect(drawerState.setMutationNotice).toHaveBeenCalledWith('Comment added.')
+    expect(drawerState.refreshTimeline).toHaveBeenCalledWith('project-1', 'ticket-1', {
+      background: true,
+      preserveMessages: true,
+    })
+  })
+
+  it('refreshes the unified timeline after updating a comment', async () => {
+    updateTicketComment.mockResolvedValue({
+      comment: {
+        id: 'comment-1',
+      },
+    })
+
+    const drawerState = createDrawerState()
+    const result = await handleUpdateTicketComment({
+      projectId: 'project-1',
+      ticketId: 'ticket-1',
+      drawerState,
+      commentId: 'comment-1',
+      body: 'Edited body',
+    })
+
+    expect(result).toBe(true)
+    expect(drawerState.setMutationNotice).toHaveBeenCalledWith('Comment updated.')
+    expect(drawerState.refreshTimeline).toHaveBeenCalledWith('project-1', 'ticket-1', {
+      background: true,
+      preserveMessages: true,
+    })
+  })
+
+  it('re-syncs the timeline after a delete failure so placeholders and history stay current', async () => {
+    deleteTicketComment.mockRejectedValue(new ApiError(500, 'delete failed'))
+
+    const drawerState = createDrawerState()
+    const result = await handleDeleteTicketComment({
+      projectId: 'project-1',
+      ticketId: 'ticket-1',
+      drawerState,
+      commentId: 'comment-1',
+    })
+
+    expect(result).toBe(false)
+    expect(drawerState.setMutationError).toHaveBeenCalledWith('delete failed')
+    expect(drawerState.refreshTimeline).toHaveBeenCalledWith('project-1', 'ticket-1', {
+      background: true,
+      preserveMessages: true,
+    })
+  })
+})

--- a/web/src/lib/features/ticket-detail/drawer-comment-actions.ts
+++ b/web/src/lib/features/ticket-detail/drawer-comment-actions.ts
@@ -20,7 +20,7 @@ type TicketDrawerCommentState = {
   clearMutationMessages: () => void
   setMutationError: (message: string) => void
   setMutationNotice: (message: string) => void
-  load: (projectId: string, ticketId: string, options?: LoadOptions) => Promise<void>
+  refreshTimeline: (projectId: string, ticketId: string, options?: LoadOptions) => Promise<void>
 }
 
 export async function handleCreateTicketComment({
@@ -42,7 +42,10 @@ export async function handleCreateTicketComment({
   try {
     await createTicketComment(ticketId, { body })
     drawerState.setMutationNotice('Comment added.')
-    await drawerState.load(projectId, ticketId, { background: true, preserveMessages: true })
+    await drawerState.refreshTimeline(projectId, ticketId, {
+      background: true,
+      preserveMessages: true,
+    })
     return true
   } catch (caughtError) {
     drawerState.setMutationError(
@@ -75,7 +78,10 @@ export async function handleUpdateTicketComment({
   try {
     await updateTicketComment(ticketId, commentId, { body })
     drawerState.setMutationNotice('Comment updated.')
-    await drawerState.load(projectId, ticketId, { background: true, preserveMessages: true })
+    await drawerState.refreshTimeline(projectId, ticketId, {
+      background: true,
+      preserveMessages: true,
+    })
     return true
   } catch (caughtError) {
     drawerState.setMutationError(
@@ -106,13 +112,19 @@ export async function handleDeleteTicketComment({
   try {
     await deleteTicketComment(ticketId, commentId)
     drawerState.setMutationNotice('Comment deleted.')
-    await drawerState.load(projectId, ticketId, { background: true, preserveMessages: true })
+    await drawerState.refreshTimeline(projectId, ticketId, {
+      background: true,
+      preserveMessages: true,
+    })
     return true
   } catch (caughtError) {
     drawerState.setMutationError(
       caughtError instanceof ApiError ? caughtError.detail : 'Failed to delete comment.',
     )
-    await drawerState.load(projectId, ticketId, { background: true, preserveMessages: true })
+    await drawerState.refreshTimeline(projectId, ticketId, {
+      background: true,
+      preserveMessages: true,
+    })
     return false
   } finally {
     drawerState.deletingCommentId = null

--- a/web/src/lib/features/ticket-detail/drawer-state.svelte.test.ts
+++ b/web/src/lib/features/ticket-detail/drawer-state.svelte.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { TicketDetailContext } from './context'
+import { createTicketDrawerState } from './drawer-state.svelte'
+
+function buildContext(overrides: Partial<TicketDetailContext> = {}): TicketDetailContext {
+  return {
+    ticket: {
+      id: 'ticket-1',
+      identifier: 'ASE-336',
+      title: 'Align Ticket Detail refresh wiring',
+      description: 'Initial description',
+      status: {
+        id: 'status-1',
+        name: 'Todo',
+        color: '#2563eb',
+      },
+      priority: 'high',
+      type: 'feature',
+      repoScopes: [],
+      attemptCount: 0,
+      costAmount: 0,
+      budgetUsd: 0,
+      dependencies: [],
+      externalLinks: [],
+      children: [],
+      createdBy: 'codex',
+      createdAt: '2026-03-29T10:00:00Z',
+      updatedAt: '2026-03-29T10:00:00Z',
+    },
+    timeline: [
+      {
+        id: 'description:ticket-1',
+        ticketId: 'ticket-1',
+        kind: 'description',
+        actor: { name: 'codex', type: 'user' },
+        title: 'Align Ticket Detail refresh wiring',
+        bodyMarkdown: 'Initial description',
+        createdAt: '2026-03-29T10:00:00Z',
+        updatedAt: '2026-03-29T10:00:00Z',
+        editedAt: undefined,
+        isCollapsible: false,
+        isDeleted: false,
+        identifier: 'ASE-336',
+      },
+    ],
+    hooks: [],
+    statuses: [
+      {
+        id: 'status-1',
+        name: 'Todo',
+        color: '#2563eb',
+      },
+    ],
+    dependencyCandidates: [
+      {
+        id: 'ticket-2',
+        identifier: 'ASE-337',
+        title: 'Follow-up',
+      },
+    ],
+    repoOptions: [
+      {
+        id: 'repo-1',
+        name: 'openase',
+        defaultBranch: 'main',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('createTicketDrawerState', () => {
+  it('refreshes only the live ticket timeline snapshot', async () => {
+    const initialContext = buildContext()
+    const refreshedContext = buildContext({
+      ticket: {
+        ...initialContext.ticket,
+        title: 'Align Ticket Detail SSE refresh wiring',
+      },
+      timeline: [
+        ...initialContext.timeline,
+        {
+          id: 'comment:comment-1',
+          ticketId: 'ticket-1',
+          kind: 'comment',
+          commentId: 'comment-1',
+          actor: { name: 'reviewer', type: 'user' },
+          bodyMarkdown: 'Looks good.',
+          createdAt: '2026-03-29T10:05:00Z',
+          updatedAt: '2026-03-29T10:05:00Z',
+          editedAt: undefined,
+          isCollapsible: true,
+          isDeleted: false,
+          editCount: 0,
+          revisionCount: 1,
+          lastEditedBy: undefined,
+        },
+      ],
+      hooks: [
+        {
+          id: 'hook-1',
+          hookName: 'ticket.timeline.refresh',
+          status: 'pass',
+          timestamp: '2026-03-29T10:05:00Z',
+        },
+      ],
+    })
+
+    const fetchContext = vi
+      .fn<(projectId: string, ticketId: string) => Promise<TicketDetailContext>>()
+      .mockResolvedValueOnce(initialContext)
+      .mockResolvedValueOnce(refreshedContext)
+
+    const state = createTicketDrawerState({ fetchContext })
+
+    await state.load('project-1', 'ticket-1')
+    await state.refreshTimeline('project-1', 'ticket-1')
+
+    expect(state.ticket?.title).toBe('Align Ticket Detail SSE refresh wiring')
+    expect(state.timeline).toEqual(refreshedContext.timeline)
+    expect(state.hooks).toEqual(refreshedContext.hooks)
+    expect(state.statuses).toEqual(initialContext.statuses)
+    expect(state.dependencyCandidates).toEqual(initialContext.dependencyCandidates)
+    expect(state.repoOptions).toEqual(initialContext.repoOptions)
+  })
+
+  it('queues one follow-up refresh when another event arrives mid-refresh', async () => {
+    const initialContext = buildContext()
+    const interimContext = buildContext({
+      timeline: [
+        ...initialContext.timeline,
+        {
+          id: 'activity:event-1',
+          ticketId: 'ticket-1',
+          kind: 'activity',
+          actor: { name: 'dispatcher', type: 'system' },
+          eventType: 'agent_started',
+          title: 'agent_started',
+          bodyText: 'Agent started work.',
+          createdAt: '2026-03-29T10:06:00Z',
+          updatedAt: '2026-03-29T10:06:00Z',
+          editedAt: undefined,
+          isCollapsible: true,
+          isDeleted: false,
+          metadata: {},
+        },
+      ],
+    })
+    const finalContext = buildContext({
+      timeline: [
+        ...interimContext.timeline,
+        {
+          id: 'comment:comment-2',
+          ticketId: 'ticket-1',
+          kind: 'comment',
+          commentId: 'comment-2',
+          actor: { name: 'reviewer', type: 'user' },
+          bodyMarkdown: 'History count updated.',
+          createdAt: '2026-03-29T10:07:00Z',
+          updatedAt: '2026-03-29T10:07:00Z',
+          editedAt: undefined,
+          isCollapsible: true,
+          isDeleted: false,
+          editCount: 0,
+          revisionCount: 1,
+          lastEditedBy: undefined,
+        },
+      ],
+    })
+    const deferredRefresh = createDeferred<TicketDetailContext>()
+
+    const fetchContext = vi
+      .fn<(projectId: string, ticketId: string) => Promise<TicketDetailContext>>()
+      .mockResolvedValueOnce(initialContext)
+      .mockReturnValueOnce(deferredRefresh.promise)
+      .mockResolvedValueOnce(finalContext)
+
+    const state = createTicketDrawerState({ fetchContext })
+    await state.load('project-1', 'ticket-1')
+
+    const firstRefresh = state.refreshTimeline('project-1', 'ticket-1')
+    const secondRefresh = state.refreshTimeline('project-1', 'ticket-1')
+
+    expect(fetchContext).toHaveBeenCalledTimes(2)
+
+    deferredRefresh.resolve(interimContext)
+    await Promise.all([firstRefresh, secondRefresh])
+
+    expect(fetchContext).toHaveBeenCalledTimes(3)
+    expect(state.timeline).toEqual(finalContext.timeline)
+  })
+})

--- a/web/src/lib/features/ticket-detail/drawer-state.svelte.ts
+++ b/web/src/lib/features/ticket-detail/drawer-state.svelte.ts
@@ -15,7 +15,15 @@ type LoadOptions = {
   preserveMessages?: boolean
 }
 
-export function createTicketDrawerState() {
+type TicketDrawerStateDeps = {
+  fetchContext: typeof fetchTicketDetailContext
+}
+
+const defaultDeps: TicketDrawerStateDeps = {
+  fetchContext: fetchTicketDetailContext,
+}
+
+export function createTicketDrawerState(deps: TicketDrawerStateDeps = defaultDeps) {
   let loading = $state(false)
   let error = $state('')
   let ticket = $state<TicketDetail | null>(null)
@@ -36,6 +44,62 @@ export function createTicketDrawerState() {
   let updatingCommentId = $state<string | null>(null)
   let deletingCommentId = $state<string | null>(null)
   let loadRequestId = 0
+  let timelineRefreshQueued = false
+  let timelineRefreshLoop: Promise<void> | null = null
+
+  function applyFullContext(detailContext: Awaited<ReturnType<typeof fetchTicketDetailContext>>) {
+    ticket = detailContext.ticket
+    timeline = detailContext.timeline
+    hooks = detailContext.hooks
+    statuses = detailContext.statuses
+    dependencyCandidates = detailContext.dependencyCandidates
+    repoOptions = detailContext.repoOptions
+  }
+
+  function applyTimelineRefresh(
+    detailContext: Awaited<ReturnType<typeof fetchTicketDetailContext>>,
+  ) {
+    ticket = detailContext.ticket
+    timeline = detailContext.timeline
+    hooks = detailContext.hooks
+  }
+
+  async function runTimelineRefresh(projectId: string, ticketId: string) {
+    if (loading || !ticket) {
+      return
+    }
+    if (timelineRefreshLoop) {
+      await timelineRefreshLoop
+      return
+    }
+
+    timelineRefreshLoop = (async () => {
+      while (timelineRefreshQueued && !loading && ticket) {
+        timelineRefreshQueued = false
+        const requestId = loadRequestId
+        try {
+          const detailContext = await deps.fetchContext(projectId, ticketId)
+          if (requestId !== loadRequestId || !ticket) {
+            continue
+          }
+          applyTimelineRefresh(detailContext)
+        } catch (caughtError) {
+          if (requestId !== loadRequestId || !ticket) {
+            continue
+          }
+          const message =
+            caughtError instanceof ApiError
+              ? caughtError.detail
+              : 'Failed to refresh ticket timeline.'
+          toastStore.error(message)
+        }
+      }
+    })().finally(() => {
+      timelineRefreshLoop = null
+    })
+
+    await timelineRefreshLoop
+  }
 
   return {
     get loading() {
@@ -150,15 +214,10 @@ export function createTicketDrawerState() {
         error = ''
       }
       try {
-        const detailContext = await fetchTicketDetailContext(projectId, ticketId)
+        const detailContext = await deps.fetchContext(projectId, ticketId)
         if (requestId !== loadRequestId) return
 
-        ticket = detailContext.ticket
-        timeline = detailContext.timeline
-        hooks = detailContext.hooks
-        statuses = detailContext.statuses
-        dependencyCandidates = detailContext.dependencyCandidates
-        repoOptions = detailContext.repoOptions
+        applyFullContext(detailContext)
       } catch (caughtError) {
         if (requestId !== loadRequestId) return
         const message =
@@ -174,8 +233,20 @@ export function createTicketDrawerState() {
         }
       }
     },
+    async refreshTimeline(projectId: string, ticketId: string) {
+      if (loading || !ticket) {
+        return
+      }
+      timelineRefreshQueued = true
+      await runTimelineRefresh(projectId, ticketId)
+      if (timelineRefreshQueued) {
+        await runTimelineRefresh(projectId, ticketId)
+      }
+    },
     reset() {
       loadRequestId += 1
+      timelineRefreshQueued = false
+      timelineRefreshLoop = null
       loading = false
       error = ''
       ticket = null


### PR DESCRIPTION
## Summary
- route ticket-detail SSE updates through a queued timeline-only refresh path so open drawers stay synced without a full detail reload
- refresh the unified timeline contract after comment create, edit, and delete mutations so edited metadata and history affordances stay current
- add focused ticket-detail tests for queued refresh behavior and comment mutation resyncs

## PRD Alignment
- No PRD change required. `OpenASE-PRD.md` already defines timeline-item refresh semantics for comment and activity updates.

## Validation
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/ticket-detail/context.test.ts src/lib/features/ticket-detail/drawer-state.svelte.test.ts src/lib/features/ticket-detail/drawer-comment-actions.test.ts src/lib/features/ticket-detail/components/ticket-comments-thread.test.ts`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec svelte-check --tsconfig ./tsconfig.json`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- none

Closes #336
