### PR TITLE
fix: align Gemini orchestrator runtime with the PRD

### DIFF
--- a/OpenASE-PRD.md
+++ b/OpenASE-PRD.md
@@ -2418,6 +2418,11 @@ OpenASE 第一阶段不要试图一次补完复杂交互式审批、Hook Gate、
 
 与 Claude Code 类似，通过 CLI subprocess + stdio stream 接入。
 
+- 编排运行时通过 `internal/orchestrator/agent_adapter_gemini.go` 提供 Gemini adapter，支持 provider 选择、session start、连续 turn 执行、失败传播和统一 `agentEvent` 归一化。
+- 当前实现采用“每个 turn 启动一个 Gemini CLI 进程 + 由 OpenASE 在内存维护对话历史”的最小可交付语义，因此可以满足 orchestrator 的连续执行需求。
+- `internal/chat/runtime_gemini.go` 继续服务于即时对话语义；两条路径共享相同的 Gemini CLI 非交互 JSON 输出模式。
+- 跨 OpenASE 编排进程的 Gemini session resume 暂不支持；如果未来需要 crash-recovery 级恢复，需要补持久化 transcript 或 Gemini 原生 resume 能力。
+
 ---
 
 ## 第十二章 GitHub / GitLab 集成
@@ -5095,7 +5100,7 @@ export function createTicketStream(projectId: string) {
 | **GitHub / GitLab** | REST API + Webhook | `internal/httpapi/github_webhook.go` + `internal/infra/issueconnector/github/connector.go` | 双向 | Phase 2 |
 | **Claude Code** | CLI subprocess (NDJSON stream) | `internal/infra/adapter/claudecode/` | 双向 | Phase 1 |
 | **OpenAI Codex** | JSON-RPC over stdio | `internal/infra/adapter/codex/` | 双向 | Phase 1 |
-| **Gemini CLI** | CLI subprocess (stdio stream) | 当前作为 Agent Provider 扩展点，由 `internal/service/catalog` + `internal/domain/catalog` 管理 | 双向 | Phase 2 |
+| **Gemini CLI** | CLI subprocess (stdio stream) | `internal/orchestrator/agent_adapter_gemini.go` + `internal/chat/runtime_gemini.go` | 双向 | Phase 1 |
 | **PostgreSQL** | SQL (ent ORM) + LISTEN/NOTIFY | `internal/repo/` + `internal/infra/event/pgnotify.go` | 双向 | Phase 1 |
 | **OIDC Provider** | OIDC Discovery + JWT 验证 | 当前仓库尚未落地统一 OIDC adapter，安全边界说明见 `internal/httpapi/security_settings_api.go` | 读 | Phase 4 |
 | **Slack / Telegram / Webhook / WeCom** | Webhook / Bot API | `internal/notification/` | 写 | Phase 2 |

--- a/internal/orchestrator/agent_adapter.go
+++ b/internal/orchestrator/agent_adapter.go
@@ -132,10 +132,7 @@ func newDefaultAgentAdapterRegistry() *agentAdapterRegistry {
 		adapters: map[entagentprovider.AdapterType]agentAdapter{
 			entagentprovider.AdapterTypeCodexAppServer: codexAgentAdapter{},
 			entagentprovider.AdapterTypeClaudeCodeCli:  claudeCodeAgentAdapter{},
-			entagentprovider.AdapterTypeGeminiCli: unsupportedAgentAdapter{
-				adapterType: entagentprovider.AdapterTypeGeminiCli,
-				reason:      "Gemini CLI is not yet wired into the orchestrator runtime",
-			},
+			entagentprovider.AdapterTypeGeminiCli:      geminiAgentAdapter{},
 		},
 	}
 }

--- a/internal/orchestrator/agent_adapter_gemini.go
+++ b/internal/orchestrator/agent_adapter_gemini.go
@@ -1,0 +1,385 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
+	"github.com/BetterAndBetterII/openase/internal/provider"
+	"github.com/google/uuid"
+)
+
+type geminiAgentAdapter struct{}
+
+func (geminiAgentAdapter) Start(_ context.Context, spec agentSessionStartSpec) (agentSession, error) {
+	if spec.ProcessManager == nil {
+		return nil, fmt.Errorf("gemini process manager must not be nil")
+	}
+
+	return newGeminiAgentSession(spec), nil
+}
+
+func (geminiAgentAdapter) Resume(_ context.Context, _ agentSessionResumeSpec) (agentSession, error) {
+	return nil, unsupportedAgentAdapter{
+		adapterType: entagentprovider.AdapterTypeGeminiCli,
+		reason:      "Gemini CLI sessions cannot be resumed across orchestrator processes because conversation history is kept in memory",
+	}.unsupportedError("resume")
+}
+
+type geminiAgentSession struct {
+	process               provider.AgentCLIProcessSpec
+	processManager        provider.AgentCLIProcessManager
+	model                 string
+	developerInstructions string
+
+	events chan agentEvent
+
+	mu         sync.Mutex
+	sessionID  string
+	turnCount  int
+	history    []geminiTranscriptEntry
+	activeStop context.CancelFunc
+	lastPID    int
+	lastStderr string
+	stopped    bool
+
+	turnWG    sync.WaitGroup
+	closeOnce sync.Once
+}
+
+type geminiTranscriptEntry struct {
+	role    string
+	content string
+}
+
+func newGeminiAgentSession(spec agentSessionStartSpec) *geminiAgentSession {
+	return &geminiAgentSession{
+		process:               spec.Process,
+		processManager:        spec.ProcessManager,
+		model:                 spec.Model,
+		developerInstructions: spec.DeveloperInstructions,
+		sessionID:             "gemini-session-" + uuid.NewString(),
+		events:                make(chan agentEvent, 64),
+	}
+}
+
+func (s *geminiAgentSession) SessionID() (string, bool) {
+	if s == nil {
+		return "", false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sessionID, s.sessionID != ""
+}
+
+func (s *geminiAgentSession) Events() <-chan agentEvent {
+	if s == nil {
+		return nil
+	}
+
+	return s.events
+}
+
+func (s *geminiAgentSession) SendPrompt(ctx context.Context, prompt string) (agentTurnStartResult, error) {
+	if s == nil {
+		return agentTurnStartResult{}, fmt.Errorf("gemini session must not be nil")
+	}
+
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return agentTurnStartResult{}, fmt.Errorf("gemini session is stopped")
+	}
+	if s.activeStop != nil {
+		s.mu.Unlock()
+		return agentTurnStartResult{}, fmt.Errorf("gemini turn is already in progress")
+	}
+
+	s.turnCount++
+	turnID := fmt.Sprintf("%s-turn-%d", s.sessionID, s.turnCount)
+	promptText := s.buildPromptLocked(prompt)
+	processSpec, err := provider.NewAgentCLIProcessSpec(
+		s.process.Command,
+		buildGeminiTurnArgs(s.process.Args, s.model, promptText),
+		s.process.WorkingDirectory,
+		s.process.Environment,
+	)
+	if err != nil {
+		s.mu.Unlock()
+		return agentTurnStartResult{}, err
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	process, err := s.processManager.Start(runCtx, processSpec)
+	if err != nil {
+		cancel()
+		s.mu.Unlock()
+		return agentTurnStartResult{}, fmt.Errorf("start gemini turn: %w", err)
+	}
+	if stdin := process.Stdin(); stdin != nil {
+		if err := stdin.Close(); err != nil {
+			cancel()
+			s.mu.Unlock()
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer stopCancel()
+			_ = process.Stop(stopCtx)
+			return agentTurnStartResult{}, fmt.Errorf("close gemini stdin: %w", err)
+		}
+	}
+
+	s.activeStop = cancel
+	s.lastPID = process.PID()
+	s.turnWG.Add(1)
+	s.mu.Unlock()
+
+	go s.collectTurn(runCtx, turnID, prompt, process)
+
+	return agentTurnStartResult{TurnID: turnID}, nil
+}
+
+func (s *geminiAgentSession) Stop(_ context.Context) error {
+	if s == nil {
+		return fmt.Errorf("gemini session must not be nil")
+	}
+
+	s.mu.Lock()
+	s.stopped = true
+	cancel := s.activeStop
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	s.turnWG.Wait()
+	s.closeEvents()
+	return nil
+}
+
+func (s *geminiAgentSession) Err() error {
+	return nil
+}
+
+func (s *geminiAgentSession) Diagnostic() agentSessionDiagnostic {
+	if s == nil {
+		return agentSessionDiagnostic{}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return agentSessionDiagnostic{
+		PID:       s.lastPID,
+		SessionID: s.sessionID,
+		Stderr:    s.lastStderr,
+	}
+}
+
+func (s *geminiAgentSession) buildPromptLocked(prompt string) string {
+	var builder strings.Builder
+	if instructions := strings.TrimSpace(s.developerInstructions); instructions != "" {
+		builder.WriteString(instructions)
+		builder.WriteString("\n\n")
+	}
+	if len(s.history) > 0 {
+		builder.WriteString("## Previous conversation\n")
+		for _, entry := range s.history {
+			_, _ = fmt.Fprintf(&builder, "%s: %s\n\n", entry.role, entry.content)
+		}
+	}
+	builder.WriteString("## User request\n")
+	builder.WriteString(strings.TrimSpace(prompt))
+	return strings.TrimSpace(builder.String())
+}
+
+func (s *geminiAgentSession) collectTurn(
+	ctx context.Context,
+	turnID string,
+	prompt string,
+	process provider.AgentCLIProcess,
+) {
+	defer s.turnWG.Done()
+	defer s.clearActiveTurn()
+
+	stopDone := make(chan struct{})
+	defer close(stopDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+			defer stopCancel()
+			_ = process.Stop(stopCtx)
+		case <-stopDone:
+		}
+	}()
+
+	stdout := process.Stdout()
+	stderr := process.Stderr()
+
+	var stdoutBytes []byte
+	var stderrBytes []byte
+	var stdoutErr error
+	var stderrErr error
+	var readers sync.WaitGroup
+	readers.Add(2)
+	go func() {
+		defer readers.Done()
+		stdoutBytes, stdoutErr = io.ReadAll(stdout)
+	}()
+	go func() {
+		defer readers.Done()
+		stderrBytes, stderrErr = io.ReadAll(stderr)
+	}()
+
+	waitErr := process.Wait()
+	readers.Wait()
+
+	s.setLastStderr(string(stderrBytes))
+	if ctx.Err() != nil {
+		return
+	}
+	if stdoutErr != nil {
+		s.emitTurnFailed(turnID, stdoutErr.Error())
+		return
+	}
+	if stderrErr != nil {
+		s.emitTurnFailed(turnID, stderrErr.Error())
+		return
+	}
+	if waitErr != nil {
+		messageText := strings.TrimSpace(string(stderrBytes))
+		if messageText == "" {
+			messageText = waitErr.Error()
+		}
+		s.emitTurnFailed(turnID, messageText)
+		return
+	}
+
+	var payload struct {
+		Response string         `json:"response"`
+		Error    map[string]any `json:"error"`
+	}
+	if err := json.Unmarshal(stdoutBytes, &payload); err != nil {
+		s.emitTurnFailed(turnID, fmt.Sprintf("parse gemini response: %v", err))
+		return
+	}
+	if len(payload.Error) > 0 {
+		messageText := strings.TrimSpace(string(stdoutBytes))
+		if messageText == "" {
+			messageText = "Gemini CLI returned an error payload"
+		}
+		s.emitTurnFailed(turnID, messageText)
+		return
+	}
+
+	responseText := strings.TrimSpace(payload.Response)
+	if responseText != "" {
+		s.emit(agentEvent{
+			Type: agentEventTypeOutputProduced,
+			Output: &agentOutputEvent{
+				ThreadID: s.sessionID,
+				TurnID:   turnID,
+				ItemID:   turnID,
+				Stream:   "assistant",
+				Text:     responseText,
+				Snapshot: true,
+			},
+		})
+	}
+
+	s.appendHistory(prompt, responseText)
+	s.emit(agentEvent{
+		Type: agentEventTypeTurnCompleted,
+		Turn: &agentTurnEvent{
+			ThreadID: s.sessionID,
+			TurnID:   turnID,
+			Status:   "completed",
+		},
+	})
+}
+
+func (s *geminiAgentSession) appendHistory(prompt string, responseText string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.history = append(s.history,
+		geminiTranscriptEntry{role: "User", content: strings.TrimSpace(prompt)},
+		geminiTranscriptEntry{role: "Assistant", content: responseText},
+	)
+}
+
+func (s *geminiAgentSession) emitTurnFailed(turnID string, message string) {
+	s.emit(agentEvent{
+		Type: agentEventTypeTurnFailed,
+		Turn: &agentTurnEvent{
+			ThreadID: s.sessionID,
+			TurnID:   turnID,
+			Status:   "failed",
+			Error: &agentTurnError{
+				Message: strings.TrimSpace(message),
+			},
+		},
+	})
+}
+
+func (s *geminiAgentSession) emit(event agentEvent) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	stopped := s.stopped
+	s.mu.Unlock()
+	if stopped {
+		return
+	}
+
+	s.events <- event
+}
+
+func (s *geminiAgentSession) clearActiveTurn() {
+	s.mu.Lock()
+	s.activeStop = nil
+	s.lastPID = 0
+	s.mu.Unlock()
+}
+
+func (s *geminiAgentSession) setLastStderr(stderr string) {
+	s.mu.Lock()
+	s.lastStderr = strings.TrimSpace(stderr)
+	s.mu.Unlock()
+}
+
+func (s *geminiAgentSession) closeEvents() {
+	s.closeOnce.Do(func() {
+		close(s.events)
+	})
+}
+
+func buildGeminiTurnArgs(baseArgs []string, model string, prompt string) []string {
+	args := append([]string(nil), baseArgs...)
+	if trimmed := strings.TrimSpace(model); trimmed != "" && !hasGeminiModelArg(args) {
+		args = append(args, "-m", trimmed)
+	}
+	args = append(args, "-p", prompt, "--output-format", "json")
+	return args
+}
+
+func hasGeminiModelArg(args []string) bool {
+	for index, arg := range args {
+		switch {
+		case arg == "-m" && index+1 < len(args):
+			return true
+		case arg == "--model" && index+1 < len(args):
+			return true
+		case strings.HasPrefix(arg, "--model="):
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/orchestrator/agent_adapter_test.go
+++ b/internal/orchestrator/agent_adapter_test.go
@@ -151,16 +151,27 @@ func TestClaudeCodeAgentAdapterSatisfiesRuntimeContract(t *testing.T) {
 	}
 }
 
-func TestDefaultAgentAdapterRegistryRegistersGeminiUnsupportedPath(t *testing.T) {
+func TestDefaultAgentAdapterRegistryRegistersGeminiRuntimeContract(t *testing.T) {
+	process := newRuntimeRunnerFakeProcess()
+	manager := &geminiAdapterTestProcessManager{process: process}
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- runGeminiRuntimeProtocol(process)
+	}()
+
 	registry := newDefaultAgentAdapterRegistry()
 	adapter, err := registry.adapterFor(entagentprovider.AdapterTypeGeminiCli)
 	if err != nil {
 		t.Fatalf("adapterFor(gemini) returned error: %v", err)
 	}
+	if _, ok := adapter.(geminiAgentAdapter); !ok {
+		t.Fatalf("adapterFor(gemini) = %T, want geminiAgentAdapter", adapter)
+	}
 
 	processSpec, err := provider.NewAgentCLIProcessSpec(
 		provider.MustParseAgentCLICommand("gemini"),
-		nil,
+		[]string{"--sandbox", "danger-full-access"},
 		nil,
 		nil,
 	)
@@ -168,11 +179,55 @@ func TestDefaultAgentAdapterRegistryRegistersGeminiUnsupportedPath(t *testing.T)
 		t.Fatalf("NewAgentCLIProcessSpec returned error: %v", err)
 	}
 
-	_, err = adapter.Start(context.Background(), agentSessionStartSpec{
-		Process: processSpec,
+	session, err := adapter.Start(context.Background(), agentSessionStartSpec{
+		Process:        processSpec,
+		ProcessManager: manager,
+		Model:          "gemini-2.5-pro",
 	})
-	if err == nil || !strings.Contains(err.Error(), "Gemini CLI is not yet wired into the orchestrator runtime") {
-		t.Fatalf("gemini Start() error = %v", err)
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	turn, err := session.SendPrompt(context.Background(), "Implement the fix.")
+	if err != nil {
+		t.Fatalf("SendPrompt returned error: %v", err)
+	}
+	if turn.TurnID == "" {
+		t.Fatal("SendPrompt() turn id = empty, want generated Gemini turn id")
+	}
+
+	first := requireAgentEvent(t, session.Events())
+	if first.Type != agentEventTypeOutputProduced || first.Output == nil || first.Output.Text != "Implemented the shared contract." {
+		t.Fatalf("unexpected first event: %+v", first)
+	}
+	if first.Output.Stream != "assistant" || !first.Output.Snapshot || first.Output.TurnID != turn.TurnID {
+		t.Fatalf("unexpected first output metadata: %+v", first.Output)
+	}
+
+	second := requireAgentEvent(t, session.Events())
+	if second.Type != agentEventTypeTurnCompleted || second.Turn == nil || second.Turn.Status != "completed" || second.Turn.TurnID != turn.TurnID {
+		t.Fatalf("unexpected second event: %+v", second)
+	}
+
+	if manager.capturedSpec.Command != provider.MustParseAgentCLICommand("gemini") {
+		t.Fatalf("process command = %q, want gemini", manager.capturedSpec.Command)
+	}
+	joinedArgs := strings.Join(manager.capturedSpec.Args, " ")
+	if !strings.Contains(joinedArgs, "-m gemini-2.5-pro") {
+		t.Fatalf("process args = %v, want model flag", manager.capturedSpec.Args)
+	}
+	if !strings.Contains(joinedArgs, "--output-format json") {
+		t.Fatalf("process args = %v, want json output mode", manager.capturedSpec.Args)
+	}
+	if !strings.Contains(joinedArgs, "-p") {
+		t.Fatalf("process args = %v, want prompt flag", manager.capturedSpec.Args)
+	}
+
+	if err := <-serverDone; err != nil {
+		t.Fatalf("fake server returned error: %v", err)
+	}
+	if err := session.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
 	}
 }
 
@@ -204,6 +259,27 @@ func runClaudeRuntimeProtocol(process *runtimeRunnerFakeProcess) error {
 		return err
 	}
 	if _, err := io.WriteString(process.stdoutWrite, `{"type":"result","subtype":"success","session_id":"claude-session-1","result":"done","num_turns":1}`+"\n"); err != nil {
+		return err
+	}
+	process.finish(nil)
+	return nil
+}
+
+type geminiAdapterTestProcessManager struct {
+	process      provider.AgentCLIProcess
+	capturedSpec provider.AgentCLIProcessSpec
+}
+
+func (m *geminiAdapterTestProcessManager) Start(_ context.Context, spec provider.AgentCLIProcessSpec) (provider.AgentCLIProcess, error) {
+	m.capturedSpec = spec
+	return m.process, nil
+}
+
+func runGeminiRuntimeProtocol(process *runtimeRunnerFakeProcess) error {
+	if _, err := io.ReadAll(process.stdinRead); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(process.stdoutWrite, `{"response":"Implemented the shared contract."}`); err != nil {
 		return err
 	}
 	process.finish(nil)

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/BetterAndBetterII/openase/ent"
 	entactivityevent "github.com/BetterAndBetterII/openase/ent/activityevent"
 	entagent "github.com/BetterAndBetterII/openase/ent/agent"
+	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
 	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
 	entagentstepevent "github.com/BetterAndBetterII/openase/ent/agentstepevent"
 	entagenttraceevent "github.com/BetterAndBetterII/openase/ent/agenttraceevent"
@@ -558,6 +559,90 @@ Blocked lifecycle publish regression test.
 			Count(ctx)
 		return err == nil && activityCount >= 3
 	})
+}
+
+func TestRuntimeLauncherStartRuntimeSessionSupportsGeminiProvider(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	fixture := seedProjectFixture(ctx, t, client)
+	now := time.Date(2026, 3, 31, 11, 0, 0, 0, time.UTC)
+
+	if _, err := client.AgentProvider.UpdateOneID(fixture.providerID).
+		SetName("Gemini").
+		SetAdapterType(entagentprovider.AdapterTypeGeminiCli).
+		SetCliCommand("gemini").
+		SetModelName("gemini-2.5-pro").
+		Save(ctx); err != nil {
+		t.Fatalf("update provider to gemini: %v", err)
+	}
+
+	process := newRuntimeRunnerFakeProcess()
+	manager := &geminiAdapterTestProcessManager{process: process}
+	workflowItem, workflowSvc, ticketItem, agentItem, runItem, launcher := newRuntimeExecutionFixture(
+		ctx,
+		t,
+		client,
+		fixture,
+		now,
+		"Gemini Coding",
+		"ASE-402",
+		"Align Gemini orchestrator runtime",
+		"gemini-runner-01",
+		"Implement the ticket using Gemini.",
+		manager,
+	)
+	_ = workflowItem
+	t.Cleanup(func() {
+		if err := workflowSvc.Close(); err != nil {
+			t.Errorf("close workflow service: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := launcher.Close(context.Background()); err != nil {
+			t.Errorf("close launcher: %v", err)
+		}
+	})
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- runGeminiRuntimeProtocol(process)
+	}()
+
+	session, err := launcher.startRuntimeSession(ctx, runtimeAssignment{
+		ticket: ticketItem,
+		agent:  agentItem,
+		run:    runItem,
+	})
+	if err != nil {
+		t.Fatalf("startRuntimeSession() error = %v", err)
+	}
+
+	turn, err := session.SendPrompt(context.Background(), "Implement the fix.")
+	if err != nil {
+		t.Fatalf("SendPrompt returned error: %v", err)
+	}
+	if turn.TurnID == "" {
+		t.Fatal("SendPrompt() turn id = empty, want Gemini turn id")
+	}
+
+	first := requireAgentEvent(t, session.Events())
+	if first.Type != agentEventTypeOutputProduced || first.Output == nil || first.Output.Text != "Implemented the shared contract." {
+		t.Fatalf("unexpected first event: %+v", first)
+	}
+	second := requireAgentEvent(t, session.Events())
+	if second.Type != agentEventTypeTurnCompleted || second.Turn == nil || second.Turn.TurnID != turn.TurnID {
+		t.Fatalf("unexpected second event: %+v", second)
+	}
+
+	if manager.capturedSpec.Command != provider.MustParseAgentCLICommand("gemini") {
+		t.Fatalf("process command = %q, want gemini", manager.capturedSpec.Command)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("fake gemini process returned error: %v", err)
+	}
+	if err := session.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
 }
 
 func TestRuntimeLauncherRunTickDoesNotStarveLaterLaunchesWhenFirstStartBlocks(t *testing.T) {
@@ -3375,7 +3460,7 @@ func newRuntimeExecutionFixture(
 	ticketTitle string,
 	agentName string,
 	harnessBody string,
-	manager *runtimeFakeProcessManager,
+	manager provider.AgentCLIProcessManager,
 ) (*ent.Workflow, *workflowservice.Service, *ent.Ticket, *ent.Agent, *ent.AgentRun, *RuntimeLauncher) {
 	t.Helper()
 
@@ -3440,12 +3525,12 @@ func newRuntimeExecutionFixture(
 	launcher.now = func() time.Time {
 		return now
 	}
-	if manager != nil && manager.releaseTurn != nil {
+	if fakeManager, ok := manager.(*runtimeFakeProcessManager); ok && fakeManager.releaseTurn != nil {
 		t.Cleanup(func() {
 			select {
-			case <-manager.releaseTurn:
+			case <-fakeManager.releaseTurn:
 			default:
-				close(manager.releaseTurn)
+				close(fakeManager.releaseTurn)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- replace the orchestrator's hardcoded Gemini unsupported path with a real Gemini session adapter
- add Gemini adapter and launcher tests covering provider registration and a successful runtime launch path
- update `OpenASE-PRD.md` to reflect shipped Gemini orchestrator support and the current cross-process resume limitation

## Validation
- `PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator -run 'Test(DefaultAgentAdapterRegistryRegistersGeminiRuntimeContract|RuntimeLauncherStartRuntimeSessionSupportsGeminiProvider)'`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest PATH=$PWD/.tooling/go/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- Gemini now supports orchestrator start and multi-turn execution, but cross-process session resume remains intentionally unsupported and is documented in the PRD.

Fixes #402
