### PR TITLE
Align repo scope and control-plane workflow/skill UX

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -10925,7 +10925,7 @@
               "schema": {
                 "properties": {
                   "default_branch": {
-                    "description": "Default branch name used for mirrors and workspaces.",
+                    "description": "Default branch name used when a repo scope does not provide an explicit branch override.",
                     "type": "string"
                   },
                   "labels": {
@@ -11300,7 +11300,7 @@
               "schema": {
                 "properties": {
                   "default_branch": {
-                    "description": "Default branch name used for mirrors and workspaces.",
+                    "description": "Default branch name used when a repo scope does not provide an explicit branch override.",
                     "nullable": true,
                     "type": "string"
                   },
@@ -13639,6 +13639,9 @@
                           "created_by": {
                             "type": "string"
                           },
+                          "current_version": {
+                            "type": "integer"
+                          },
                           "description": {
                             "type": "string"
                           },
@@ -13766,7 +13769,7 @@
                     "type": "boolean"
                   },
                   "name": {
-                    "description": "Project-unique skill directory name.",
+                    "description": "Project-unique skill name in the control plane.",
                     "type": "string"
                   }
                 },
@@ -13785,6 +13788,26 @@
                   "properties": {
                     "content": {
                       "type": "string"
+                    },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
                     },
                     "skill": {
                       "properties": {
@@ -13810,6 +13833,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -16792,11 +16818,11 @@
                     "type": "array"
                   },
                   "harness_content": {
-                    "description": "Initial harness content written when creating the workflow.",
+                    "description": "Initial harness content written into the versioned control-plane workflow record.",
                     "type": "string"
                   },
                   "harness_path": {
-                    "description": "Repository path where the workflow harness file is stored.",
+                    "description": "Logical harness path tracked by the control plane for this workflow.",
                     "nullable": true,
                     "type": "string"
                   },
@@ -18486,6 +18512,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -18510,6 +18556,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -18643,6 +18692,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -18667,6 +18736,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -18808,6 +18880,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -18832,6 +18924,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -18946,6 +19041,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -18970,6 +19085,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -19084,6 +19202,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -19108,6 +19246,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -19198,6 +19339,115 @@
         ]
       }
     },
+    "/api/v1/skills/{skillId}/history": {
+      "get": {
+        "operationId": "getSkillHistory",
+        "parameters": [
+          {
+            "description": "Skill ID.",
+            "in": "path",
+            "name": "skillId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "List published skill versions response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found response."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Internal Server Error response."
+          }
+        },
+        "summary": "List published skill versions",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
     "/api/v1/skills/{skillId}/unbind": {
       "post": {
         "operationId": "unbindSkill",
@@ -19249,6 +19499,26 @@
                     "content": {
                       "type": "string"
                     },
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "skill": {
                       "properties": {
                         "bound_workflows": {
@@ -19273,6 +19543,9 @@
                         },
                         "created_by": {
                           "type": "string"
+                        },
+                        "current_version": {
+                          "type": "integer"
                         },
                         "description": {
                           "type": "string"
@@ -22041,7 +22314,7 @@
                     "type": "array"
                   },
                   "harness_path": {
-                    "description": "Repository path where the workflow harness file is stored.",
+                    "description": "Logical harness path tracked by the control plane for this workflow.",
                     "nullable": true,
                     "type": "string"
                   },
@@ -22496,6 +22769,115 @@
           }
         },
         "summary": "Update workflow harness content",
+        "tags": [
+          "workflows"
+        ]
+      }
+    },
+    "/api/v1/workflows/{workflowId}/harness/history": {
+      "get": {
+        "operationId": "getWorkflowHarnessHistory",
+        "parameters": [
+          {
+            "description": "Workflow ID.",
+            "in": "path",
+            "name": "workflowId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "history": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "created_by": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "List published workflow harness versions response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found response."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Internal Server Error response."
+          }
+        },
+        "summary": "List published workflow harness versions",
         "tags": [
           "workflows"
         ]

--- a/internal/httpapi/openapi.go
+++ b/internal/httpapi/openapi.go
@@ -533,6 +533,13 @@ type OpenAPIHarnessDocument struct {
 	Version    int    `json:"version"`
 }
 
+type OpenAPIVersionSummary struct {
+	ID        string `json:"id"`
+	Version   int    `json:"version"`
+	CreatedBy string `json:"created_by"`
+	CreatedAt string `json:"created_at"`
+}
+
 type OpenAPIScheduledJobTicketTemplate struct {
 	Title       string  `json:"title"`
 	Description string  `json:"description"`
@@ -594,6 +601,7 @@ type OpenAPISkill struct {
 	Name           string                        `json:"name"`
 	Description    string                        `json:"description"`
 	Path           string                        `json:"path"`
+	CurrentVersion int                           `json:"current_version"`
 	IsBuiltin      bool                          `json:"is_builtin"`
 	IsEnabled      bool                          `json:"is_enabled"`
 	CreatedBy      string                        `json:"created_by"`
@@ -860,6 +868,10 @@ type OpenAPIWorkflowResponse struct {
 	Workflow OpenAPIWorkflow `json:"workflow"`
 }
 
+type OpenAPIWorkflowHistoryResponse struct {
+	History []OpenAPIVersionSummary `json:"history"`
+}
+
 type OpenAPIWorkflowRepositoryPrerequisiteResponse struct {
 	Prerequisite OpenAPIWorkflowRepositoryPrerequisite `json:"prerequisite"`
 }
@@ -970,8 +982,13 @@ type OpenAPISkillsResponse struct {
 }
 
 type OpenAPISkillDetailResponse struct {
-	Skill   OpenAPISkill `json:"skill"`
-	Content string       `json:"content"`
+	Skill   OpenAPISkill            `json:"skill"`
+	Content string                  `json:"content"`
+	History []OpenAPIVersionSummary `json:"history"`
+}
+
+type OpenAPISkillHistoryResponse struct {
+	History []OpenAPIVersionSummary `json:"history"`
 }
 
 type OpenAPIDeleteSkillResponse struct {
@@ -1265,7 +1282,7 @@ var (
 	openAPIRepoRequestDescriptions = map[string]string{
 		"name":              "Human-readable repository name within the project.",
 		"repository_url":    "Remote Git repository URL.",
-		"default_branch":    "Default branch name used for mirrors and workspaces.",
+		"default_branch":    "Default branch name used when a repo scope does not provide an explicit branch override.",
 		"workspace_dirname": "Directory name used for this repository inside a ticket workspace.",
 		"labels":            "Labels attached to the repository for workflow selection and filtering.",
 	}
@@ -1297,8 +1314,8 @@ var (
 		"timeout_minutes":       "Hard execution timeout for workflow runs, in minutes.",
 		"stall_timeout_minutes": "Timeout for detecting stalled workflow runs, in minutes.",
 		"max_retry_attempts":    "Maximum retry attempts before the workflow run fails permanently.",
-		"harness_path":          "Repository path where the workflow harness file is stored.",
-		"harness_content":       "Initial harness content written when creating the workflow.",
+		"harness_path":          "Logical harness path tracked by the control plane for this workflow.",
+		"harness_content":       "Initial harness content written into the versioned control-plane workflow record.",
 		"hooks":                 "Workflow hook configuration keyed by lifecycle phase.",
 	}
 	openAPIHarnessContentDescriptions = map[string]string{
@@ -1428,7 +1445,7 @@ var (
 		"skills": "Skill names included in this workflow skill binding request.",
 	}
 	openAPISkillCreateDescriptions = map[string]string{
-		"name":        "Project-unique skill directory name.",
+		"name":        "Project-unique skill name in the control plane.",
 		"content":     "Skill markdown content. Frontmatter is optional on input and will be normalized on write.",
 		"description": "Optional description used when the input content does not declare one.",
 		"created_by":  "Optional creator descriptor such as user:gary or agent:codex-01 via ASE-42.",
@@ -2642,6 +2659,23 @@ func (b openAPISpecBuilder) addWorkflowOperations() error {
 	harnessGet.AddParameter(uuidPathParameter("workflowId", "Workflow ID."))
 	b.doc.AddOperation("/api/v1/workflows/{workflowId}/harness", http.MethodGet, harnessGet)
 
+	harnessHistoryGet, err := b.jsonOperation(
+		"getWorkflowHarnessHistory",
+		"List published workflow harness versions",
+		[]string{"workflows"},
+		http.StatusOK,
+		OpenAPIWorkflowHistoryResponse{},
+		nil,
+		http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	)
+	if err != nil {
+		return err
+	}
+	harnessHistoryGet.AddParameter(uuidPathParameter("workflowId", "Workflow ID."))
+	b.doc.AddOperation("/api/v1/workflows/{workflowId}/harness/history", http.MethodGet, harnessHistoryGet)
+
 	harnessPut, err := b.jsonOperation(
 		"updateWorkflowHarness",
 		"Update workflow harness content",
@@ -2773,6 +2807,23 @@ func (b openAPISpecBuilder) addWorkflowOperations() error {
 	}
 	skillGet.AddParameter(uuidPathParameter("skillId", "Skill ID."))
 	b.doc.AddOperation("/api/v1/skills/{skillId}", http.MethodGet, skillGet)
+
+	skillHistoryGet, err := b.jsonOperation(
+		"getSkillHistory",
+		"List published skill versions",
+		[]string{"skills"},
+		http.StatusOK,
+		OpenAPISkillHistoryResponse{},
+		nil,
+		http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	)
+	if err != nil {
+		return err
+	}
+	skillHistoryGet.AddParameter(uuidPathParameter("skillId", "Skill ID."))
+	b.doc.AddOperation("/api/v1/skills/{skillId}/history", http.MethodGet, skillHistoryGet)
 
 	skillUpdate, err := b.jsonOperation(
 		"updateSkill",

--- a/internal/httpapi/skills_api.go
+++ b/internal/httpapi/skills_api.go
@@ -13,6 +13,7 @@ type skillResponse struct {
 	Name           string                         `json:"name"`
 	Description    string                         `json:"description"`
 	Path           string                         `json:"path"`
+	CurrentVersion int                            `json:"current_version"`
 	IsBuiltin      bool                           `json:"is_builtin"`
 	IsEnabled      bool                           `json:"is_enabled"`
 	CreatedBy      string                         `json:"created_by"`
@@ -20,9 +21,21 @@ type skillResponse struct {
 	BoundWorkflows []skillWorkflowBindingResponse `json:"bound_workflows"`
 }
 
+type skillVersionResponse struct {
+	ID        string `json:"id"`
+	Version   int    `json:"version"`
+	CreatedBy string `json:"created_by"`
+	CreatedAt string `json:"created_at"`
+}
+
 type skillDetailResponse struct {
-	Skill   skillResponse `json:"skill"`
-	Content string        `json:"content"`
+	Skill   skillResponse          `json:"skill"`
+	Content string                 `json:"content"`
+	History []skillVersionResponse `json:"history"`
+}
+
+type skillHistoryResponse struct {
+	History []skillVersionResponse `json:"history"`
 }
 
 type skillWorkflowBindingResponse struct {
@@ -44,6 +57,7 @@ func (s *Server) registerSkillRoutes(api *echo.Group) {
 	api.POST("/projects/:projectId/skills/refresh", s.handleRefreshSkills)
 	api.POST("/projects/:projectId/skills/harvest", s.handleHarvestSkills)
 	api.GET("/skills/:skillId", s.handleGetSkill)
+	api.GET("/skills/:skillId/history", s.handleGetSkillHistory)
 	api.PUT("/skills/:skillId", s.handleUpdateSkill)
 	api.DELETE("/skills/:skillId", s.handleDeleteSkill)
 	api.POST("/skills/:skillId/enable", s.handleEnableSkill)
@@ -181,6 +195,26 @@ func (s *Server) handleGetSkill(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, mapSkillDetailResponse(item))
+}
+
+func (s *Server) handleGetSkillHistory(c echo.Context) error {
+	if s.workflowService == nil {
+		return writeWorkflowError(c, workflowservice.ErrUnavailable)
+	}
+
+	skillID, err := parseUUIDPathParamValue(c, "skillId")
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_SKILL_ID", err.Error())
+	}
+
+	items, err := s.workflowService.ListSkillVersions(c.Request().Context(), skillID)
+	if err != nil {
+		return writeWorkflowError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, skillHistoryResponse{
+		History: mapSkillVersionResponses(items),
+	})
 }
 
 func (s *Server) handleUpdateSkill(c echo.Context) error {
@@ -376,6 +410,7 @@ func mapSkillResponse(item workflowservice.Skill) skillResponse {
 		Name:           item.Name,
 		Description:    item.Description,
 		Path:           item.Path,
+		CurrentVersion: item.CurrentVersion,
 		IsBuiltin:      item.IsBuiltin,
 		IsEnabled:      item.IsEnabled,
 		CreatedBy:      item.CreatedBy,
@@ -388,6 +423,7 @@ func mapSkillDetailResponse(item workflowservice.SkillDetail) skillDetailRespons
 	return skillDetailResponse{
 		Skill:   mapSkillResponse(item.Skill),
 		Content: item.Content,
+		History: mapSkillVersionResponses(item.History),
 	}
 }
 
@@ -398,6 +434,19 @@ func mapSkillWorkflowBindings(items []workflowservice.SkillWorkflowBinding) []sk
 			ID:          item.ID.String(),
 			Name:        item.Name,
 			HarnessPath: item.HarnessPath,
+		})
+	}
+	return response
+}
+
+func mapSkillVersionResponses(items []workflowservice.VersionSummary) []skillVersionResponse {
+	response := make([]skillVersionResponse, 0, len(items))
+	for _, item := range items {
+		response = append(response, skillVersionResponse{
+			ID:        item.ID.String(),
+			Version:   item.Version,
+			CreatedBy: item.CreatedBy,
+			CreatedAt: item.CreatedAt.UTC().Format(time.RFC3339),
 		})
 	}
 	return response

--- a/internal/httpapi/skills_api_test.go
+++ b/internal/httpapi/skills_api_test.go
@@ -232,6 +232,9 @@ func TestSkillRoutesRefreshHarvestBindAndUnbind(t *testing.T) {
 	if len(reviewSkill.BoundWorkflows) != 1 || reviewSkill.BoundWorkflows[0].Name != "Coding Workflow" {
 		t.Fatalf("expected review-code to bind to Coding Workflow, got %+v", reviewSkill)
 	}
+	if reviewSkill.CurrentVersion != 1 {
+		t.Fatalf("expected review-code current version to be published as v1, got %+v", reviewSkill)
+	}
 	if !reviewSkill.IsBuiltin {
 		t.Fatalf("expected review-code to be marked as built-in, got %+v", reviewSkill)
 	}
@@ -244,6 +247,34 @@ func TestSkillRoutesRefreshHarvestBindAndUnbind(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(repoRoot, ".openase", "skills", "openase-platform", "SKILL.md")); !os.IsNotExist(err) {
 		t.Fatalf("expected built-in platform skill to stay out of repo authority paths, stat err=%v", err)
+	}
+
+	detailResp := skillDetailResponse{}
+	executeJSON(
+		t,
+		server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/skills/%s", reviewSkill.ID),
+		nil,
+		http.StatusOK,
+		&detailResp,
+	)
+	if detailResp.Skill.CurrentVersion != 1 || len(detailResp.History) != 1 || detailResp.History[0].Version != 1 {
+		t.Fatalf("expected skill detail to expose current published version and history, got %+v", detailResp)
+	}
+
+	historyResp := skillHistoryResponse{}
+	executeJSON(
+		t,
+		server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/skills/%s/history", reviewSkill.ID),
+		nil,
+		http.StatusOK,
+		&historyResp,
+	)
+	if len(historyResp.History) != 1 || historyResp.History[0].Version != 1 {
+		t.Fatalf("expected skill history route to expose published versions, got %+v", historyResp)
 	}
 
 	workspaceRoot := t.TempDir()

--- a/internal/httpapi/workflow_api.go
+++ b/internal/httpapi/workflow_api.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	workflowservice "github.com/BetterAndBetterII/openase/internal/workflow"
 	"github.com/labstack/echo/v4"
@@ -34,6 +35,17 @@ type harnessResponse struct {
 	Version    int    `json:"version"`
 }
 
+type workflowVersionResponse struct {
+	ID        string `json:"id"`
+	Version   int    `json:"version"`
+	CreatedBy string `json:"created_by"`
+	CreatedAt string `json:"created_at"`
+}
+
+type workflowHistoryResponse struct {
+	History []workflowVersionResponse `json:"history"`
+}
+
 type harnessValidationResponse struct {
 	Valid  bool                              `json:"valid"`
 	Issues []workflowservice.ValidationIssue `json:"issues"`
@@ -61,6 +73,7 @@ func (s *Server) registerWorkflowRoutes(api *echo.Group) {
 	api.PATCH("/workflows/:workflowId", s.handleUpdateWorkflow)
 	api.DELETE("/workflows/:workflowId", s.handleDeleteWorkflow)
 	api.GET("/workflows/:workflowId/harness", s.handleGetWorkflowHarness)
+	api.GET("/workflows/:workflowId/harness/history", s.handleGetWorkflowHarnessHistory)
 	api.PUT("/workflows/:workflowId/harness", s.handleUpdateWorkflowHarness)
 	api.GET("/harness/variables", s.handleListHarnessVariables)
 	api.POST("/harness/validate", s.handleValidateHarness)
@@ -226,6 +239,26 @@ func (s *Server) handleGetWorkflowHarness(c echo.Context) error {
 	})
 }
 
+func (s *Server) handleGetWorkflowHarnessHistory(c echo.Context) error {
+	if s.workflowService == nil {
+		return writeWorkflowError(c, workflowservice.ErrUnavailable)
+	}
+
+	workflowID, err := parseUUIDPathParamValue(c, "workflowId")
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_WORKFLOW_ID", err.Error())
+	}
+
+	items, err := s.workflowService.ListWorkflowVersions(c.Request().Context(), workflowID)
+	if err != nil {
+		return writeWorkflowError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, workflowHistoryResponse{
+		History: mapWorkflowVersionResponses(items),
+	})
+}
+
 func (s *Server) handleUpdateWorkflowHarness(c echo.Context) error {
 	if s.workflowService == nil {
 		return writeWorkflowError(c, workflowservice.ErrUnavailable)
@@ -362,4 +395,17 @@ func mapHarnessResponse(item workflowservice.HarnessDocument) harnessResponse {
 		Content:    item.Content,
 		Version:    item.Version,
 	}
+}
+
+func mapWorkflowVersionResponses(items []workflowservice.VersionSummary) []workflowVersionResponse {
+	response := make([]workflowVersionResponse, 0, len(items))
+	for _, item := range items {
+		response = append(response, workflowVersionResponse{
+			ID:        item.ID.String(),
+			Version:   item.Version,
+			CreatedBy: item.CreatedBy,
+			CreatedAt: item.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	return response
 }

--- a/internal/httpapi/workflow_api_test.go
+++ b/internal/httpapi/workflow_api_test.go
@@ -310,6 +310,22 @@ func TestWorkflowRoutesCRUDHarnessStorageAndHotReload(t *testing.T) {
 		t.Fatalf("expected harness GET to read current DB version, got %+v", harnessGetResp.Harness)
 	}
 
+	historyResp := struct {
+		History []workflowVersionResponse `json:"history"`
+	}{}
+	executeJSON(
+		t,
+		server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/workflows/%s/harness/history", createResp.Workflow.ID),
+		nil,
+		http.StatusOK,
+		&historyResp,
+	)
+	if len(historyResp.History) != 2 || historyResp.History[0].Version != 2 || historyResp.History[1].Version != 1 {
+		t.Fatalf("expected workflow harness history to expose published versions, got %+v", historyResp.History)
+	}
+
 	deleteResp := struct {
 		Workflow workflowResponse `json:"workflow"`
 	}{}

--- a/internal/workflow/coverage_test.go
+++ b/internal/workflow/coverage_test.go
@@ -523,15 +523,6 @@ func TestHarnessTemplateHelpers(t *testing.T) {
 	if got := joinStatusNames([]*ent.TicketStatus{{Name: "Todo"}, {Name: "Done"}}); got != "Todo, Done" {
 		t.Fatalf("joinStatusNames() = %q", got)
 	}
-	if got := deriveDefaultBranch([]*ent.ProjectRepo{{DefaultBranch: "dev"}, repo}); got != "dev" {
-		t.Fatalf("deriveDefaultBranch(first repo) = %q", got)
-	}
-	if got := deriveDefaultBranch([]*ent.ProjectRepo{{DefaultBranch: "dev"}}); got != "dev" {
-		t.Fatalf("deriveDefaultBranch(fallback) = %q", got)
-	}
-	if got := deriveDefaultBranch(nil); got != "main" {
-		t.Fatalf("deriveDefaultBranch(default) = %q", got)
-	}
 	if got := resolveRepoPath("", "/tmp/ws", "backend"); got != "/tmp/ws/backend" {
 		t.Fatalf("resolveRepoPath() = %q", got)
 	}
@@ -709,12 +700,11 @@ More detail.
 			Dependencies:     dependencies,
 		},
 		Project: HarnessProjectData{
-			ID:            projectID.String(),
-			Name:          "OpenASE",
-			Slug:          "openase",
-			Description:   "Automation",
-			Status:        "In Progress",
-			DefaultBranch: "main",
+			ID:          projectID.String(),
+			Name:        "OpenASE",
+			Slug:        "openase",
+			Description: "Automation",
+			Status:      "In Progress",
 			Workflows: []HarnessProjectWorkflowData{{
 				Name:            "Coding",
 				Type:            "coding",
@@ -748,7 +738,7 @@ More detail.
 	contextMap := data.contextMap()
 	projectMap := contextMap["project"].(map[string]any)
 	reposMap := contextMap["repos"].([]map[string]any)
-	if projectMap["default_branch"] != "main" || reposMap[0]["name"] != "backend" {
+	if _, exists := projectMap["default_branch"]; exists || reposMap[0]["name"] != "backend" {
 		t.Fatalf("contextMap() = %+v", contextMap)
 	}
 	reposMap[0]["labels"].([]string)[0] = "changed"

--- a/internal/workflow/harness_template.go
+++ b/internal/workflow/harness_template.go
@@ -88,15 +88,14 @@ type HarnessTicketDependencyData struct {
 }
 
 type HarnessProjectData struct {
-	ID            string
-	Name          string
-	Slug          string
-	Description   string
-	Status        string
-	DefaultBranch string
-	Workflows     []HarnessProjectWorkflowData
-	Statuses      []HarnessProjectStatusData
-	Machines      []HarnessProjectMachineData
+	ID          string
+	Name        string
+	Slug        string
+	Description string
+	Status      string
+	Workflows   []HarnessProjectWorkflowData
+	Statuses    []HarnessProjectStatusData
+	Machines    []HarnessProjectMachineData
 }
 
 type HarnessProjectWorkflowData struct {
@@ -313,7 +312,6 @@ func (s *Service) BuildHarnessTemplateData(ctx context.Context, input BuildHarne
 
 	scopedRepos, repoBranchByID := mapHarnessScopedRepos(ticketItem.Edges.RepoScopes, workspace)
 	allRepos := mapHarnessAllRepos(projectItem.Edges.Repos, repoBranchByID, workspace)
-	defaultBranch := deriveDefaultBranch(projectItem.Edges.Repos)
 	projectWorkflows, err := s.mapHarnessProjectWorkflows(ctx, projectItem.Edges.Workflows)
 	if err != nil {
 		return HarnessTemplateData{}, err
@@ -339,15 +337,14 @@ func (s *Service) BuildHarnessTemplateData(ctx context.Context, input BuildHarne
 			Dependencies:     mapHarnessDependencies(ticketItem.Edges.OutgoingDependencies),
 		},
 		Project: HarnessProjectData{
-			ID:            projectItem.ID.String(),
-			Name:          projectItem.Name,
-			Slug:          projectItem.Slug,
-			Description:   projectItem.Description,
-			Status:        projectItem.Status,
-			DefaultBranch: defaultBranch,
-			Workflows:     projectWorkflows,
-			Statuses:      mapHarnessProjectStatuses(projectItem.Edges.Statuses),
-			Machines:      mapHarnessProjectMachines(input.Machine, input.AccessibleMachines),
+			ID:          projectItem.ID.String(),
+			Name:        projectItem.Name,
+			Slug:        projectItem.Slug,
+			Description: projectItem.Description,
+			Status:      projectItem.Status,
+			Workflows:   projectWorkflows,
+			Statuses:    mapHarnessProjectStatuses(projectItem.Edges.Statuses),
+			Machines:    mapHarnessProjectMachines(input.Machine, input.AccessibleMachines),
 		},
 		Repos:              scopedRepos,
 		AllRepos:           allRepos,
@@ -435,7 +432,6 @@ func HarnessVariableDictionary() []HarnessVariableGroup {
 				{Path: "project.slug", Type: "string", Description: "项目 slug", Example: "awesome-saas"},
 				{Path: "project.description", Type: "string", Description: "项目描述", Example: "A SaaS platform for..."},
 				{Path: "project.status", Type: "string", Description: "项目状态", Example: "In Progress"},
-				{Path: "project.default_branch", Type: "string", Description: "项目默认分支", Example: "main"},
 				{Path: "project.workflows", Type: "list", Description: "项目中已激活的 Workflow 列表"},
 				{Path: "project.workflows[].name", Type: "string", Description: "Workflow 名称", Example: "Coding Workflow"},
 				{Path: "project.workflows[].type", Type: "string", Description: "Workflow 类型", Example: "coding"},
@@ -585,15 +581,14 @@ func (d HarnessTemplateData) contextMap() map[string]any {
 			"dependencies":      dependencyMaps(d.Ticket.Dependencies),
 		},
 		"project": map[string]any{
-			"id":             d.Project.ID,
-			"name":           d.Project.Name,
-			"slug":           d.Project.Slug,
-			"description":    d.Project.Description,
-			"status":         d.Project.Status,
-			"default_branch": d.Project.DefaultBranch,
-			"workflows":      projectWorkflowMaps(d.Project.Workflows),
-			"statuses":       projectStatusMaps(d.Project.Statuses),
-			"machines":       projectMachineMaps(d.Project.Machines),
+			"id":          d.Project.ID,
+			"name":        d.Project.Name,
+			"slug":        d.Project.Slug,
+			"description": d.Project.Description,
+			"status":      d.Project.Status,
+			"workflows":   projectWorkflowMaps(d.Project.Workflows),
+			"statuses":    projectStatusMaps(d.Project.Statuses),
+			"machines":    projectMachineMaps(d.Project.Machines),
 		},
 		"repos":               repoMaps(d.Repos),
 		"all_repos":           repoMaps(d.AllRepos),
@@ -897,15 +892,6 @@ func normalizePlatformData(input HarnessPlatformData, projectID uuid.UUID, ticke
 		data.TicketID = ticketID.String()
 	}
 	return data
-}
-
-func deriveDefaultBranch(repos []*ent.ProjectRepo) string {
-	for _, repo := range repos {
-		if strings.TrimSpace(repo.DefaultBranch) != "" {
-			return repo.DefaultBranch
-		}
-	}
-	return "main"
 }
 
 func resolveRepoPath(workspaceDirname string, workspace string, repoName string) string {

--- a/internal/workflow/service.go
+++ b/internal/workflow/service.go
@@ -247,6 +247,35 @@ func (s *Service) projectedWorkflowHarness(ctx context.Context, workflowItem *en
 	return projectHarnessContent(version.ContentMarkdown, boundSkills)
 }
 
+func (s *Service) ListWorkflowVersions(ctx context.Context, workflowID uuid.UUID) ([]VersionSummary, error) {
+	if s == nil || s.client == nil {
+		return nil, ErrUnavailable
+	}
+
+	if _, err := s.currentWorkflowVersion(ctx, workflowID); err != nil {
+		return nil, err
+	}
+
+	items, err := s.client.WorkflowVersion.Query().
+		Where(entworkflowversion.WorkflowIDEQ(workflowID)).
+		Order(ent.Desc(entworkflowversion.FieldVersion)).
+		All(ctx)
+	if err != nil {
+		return nil, s.mapWorkflowReadError("list workflow versions", err)
+	}
+
+	result := make([]VersionSummary, 0, len(items))
+	for _, item := range items {
+		result = append(result, VersionSummary{
+			ID:        item.ID,
+			Version:   item.Version,
+			CreatedBy: item.CreatedBy,
+			CreatedAt: item.CreatedAt.UTC(),
+		})
+	}
+	return result, nil
+}
+
 func (s *Service) listWorkflowBoundSkillNames(ctx context.Context, workflowID uuid.UUID, enabledOnly bool) ([]string, error) {
 	query := s.client.WorkflowSkillBinding.Query().
 		Where(entworkflowskillbinding.WorkflowIDEQ(workflowID)).
@@ -439,6 +468,13 @@ type Workflow struct {
 type WorkflowDetail struct {
 	Workflow
 	HarnessContent string `json:"harness_content"`
+}
+
+type VersionSummary struct {
+	ID        uuid.UUID `json:"id"`
+	Version   int       `json:"version"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type HarnessDocument struct {

--- a/internal/workflow/skills.go
+++ b/internal/workflow/skills.go
@@ -18,6 +18,7 @@ import (
 	"github.com/BetterAndBetterII/openase/ent"
 	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
 	entskill "github.com/BetterAndBetterII/openase/ent/skill"
+	entskillversion "github.com/BetterAndBetterII/openase/ent/skillversion"
 	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
 	entworkflowskillbinding "github.com/BetterAndBetterII/openase/ent/workflowskillbinding"
 	"github.com/BetterAndBetterII/openase/internal/provider"
@@ -37,6 +38,7 @@ type Skill struct {
 	Name           string                 `json:"name"`
 	Description    string                 `json:"description"`
 	Path           string                 `json:"path"`
+	CurrentVersion int                    `json:"current_version"`
 	IsBuiltin      bool                   `json:"is_builtin"`
 	IsEnabled      bool                   `json:"is_enabled"`
 	CreatedBy      string                 `json:"created_by"`
@@ -57,7 +59,8 @@ type skillDocument struct {
 
 type SkillDetail struct {
 	Skill
-	Content string `json:"content"`
+	Content string           `json:"content"`
+	History []VersionSummary `json:"history"`
 }
 
 type CreateSkillInput struct {
@@ -158,6 +161,27 @@ func (s *Service) ListSkills(ctx context.Context, projectID uuid.UUID) ([]Skill,
 		return nil, fmt.Errorf("list workflow skill bindings: %w", err)
 	}
 
+	versionBySkillID := make(map[uuid.UUID]int, len(items))
+	skillIDs := make([]uuid.UUID, 0, len(items))
+	for _, item := range items {
+		skillIDs = append(skillIDs, item.ID)
+	}
+	if len(skillIDs) > 0 {
+		versions, versionErr := s.client.SkillVersion.Query().
+			Where(entskillversion.SkillIDIn(skillIDs...)).
+			Order(ent.Asc(entskillversion.FieldSkillID), ent.Desc(entskillversion.FieldVersion)).
+			All(ctx)
+		if versionErr != nil {
+			return nil, fmt.Errorf("list skill versions: %w", versionErr)
+		}
+		for _, versionItem := range versions {
+			if _, exists := versionBySkillID[versionItem.SkillID]; exists {
+				continue
+			}
+			versionBySkillID[versionItem.SkillID] = versionItem.Version
+		}
+	}
+
 	bindingsBySkillID := make(map[uuid.UUID][]SkillWorkflowBinding, len(items))
 	for _, binding := range bindings {
 		if binding.Edges.Skill == nil || binding.Edges.Workflow == nil {
@@ -181,6 +205,7 @@ func (s *Service) ListSkills(ctx context.Context, projectID uuid.UUID) ([]Skill,
 			Name:           item.Name,
 			Description:    item.Description,
 			Path:           skillContentRelativePath(item.Name),
+			CurrentVersion: versionBySkillID[item.ID],
 			IsBuiltin:      item.IsBuiltin,
 			IsEnabled:      item.IsEnabled,
 			CreatedBy:      item.CreatedBy,
@@ -214,6 +239,32 @@ func (s *Service) GetSkill(ctx context.Context, skillID uuid.UUID) (SkillDetail,
 		return SkillDetail{}, err
 	}
 	return s.buildSkillDetail(ctx, record)
+}
+
+func (s *Service) ListSkillVersions(ctx context.Context, skillID uuid.UUID) ([]VersionSummary, error) {
+	record, err := s.resolveSkillRecord(ctx, skillID)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := s.client.SkillVersion.Query().
+		Where(entskillversion.SkillIDEQ(record.skill.ID)).
+		Order(ent.Desc(entskillversion.FieldVersion)).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list skill versions: %w", err)
+	}
+
+	result := make([]VersionSummary, 0, len(items))
+	for _, item := range items {
+		result = append(result, VersionSummary{
+			ID:        item.ID,
+			Version:   item.Version,
+			CreatedBy: item.CreatedBy,
+			CreatedAt: item.CreatedAt.UTC(),
+		})
+	}
+	return result, nil
 }
 
 func (s *Service) CreateSkill(ctx context.Context, input CreateSkillInput) (SkillDetail, error) {
@@ -555,7 +606,15 @@ func (s *Service) buildSkillDetail(ctx context.Context, record resolvedSkillReco
 		if err != nil {
 			return SkillDetail{}, err
 		}
-		return SkillDetail{Skill: item, Content: versionItem.ContentMarkdown}, nil
+		history, err := s.ListSkillVersions(ctx, record.skill.ID)
+		if err != nil {
+			return SkillDetail{}, err
+		}
+		return SkillDetail{
+			Skill:   item,
+			Content: versionItem.ContentMarkdown,
+			History: history,
+		}, nil
 	}
 	return SkillDetail{}, ErrSkillNotFound
 }

--- a/web/src/lib/api/contracts.ts
+++ b/web/src/lib/api/contracts.ts
@@ -210,6 +210,9 @@ export type HarnessPayload = DeepRequired<
   ResponseFor<'/api/v1/workflows/{workflowId}/harness', 'get'>
 >
 export type HarnessDocument = HarnessPayload['harness']
+export type WorkflowHistoryPayload = DeepRequired<
+  ResponseFor<'/api/v1/workflows/{workflowId}/harness/history', 'get'>
+>
 export type HarnessVariableDictionaryPayload = DeepRequired<
   ResponseFor<'/api/v1/harness/variables', 'get'>
 >
@@ -234,6 +237,9 @@ export type Skill = ItemOf<SkillListPayload['skills']>
 export type SkillBinding = ItemOf<Skill['bound_workflows']>
 export type SkillDetailResponse = DeepRequired<ResponseFor<'/api/v1/skills/{skillId}', 'get'>>
 export type SkillDetail = SkillDetailResponse['skill']
+export type SkillHistoryPayload = DeepRequired<
+  ResponseFor<'/api/v1/skills/{skillId}/history', 'get'>
+>
 export type SkillCreateResponse = DeepRequired<
   ResponseFor<'/api/v1/projects/{projectId}/skills', 'post'>
 >

--- a/web/src/lib/api/generated/openapi.d.ts
+++ b/web/src/lib/api/generated/openapi.d.ts
@@ -1396,6 +1396,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/skills/{skillId}/history': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List published skill versions */
+    get: operations['getSkillHistory']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/skills/{skillId}/unbind': {
     parameters: {
       query?: never
@@ -1617,6 +1634,23 @@ export interface paths {
     get: operations['getWorkflowHarness']
     /** Update workflow harness content */
     put: operations['updateWorkflowHarness']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/workflows/{workflowId}/harness/history': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List published workflow harness versions */
+    get: operations['getWorkflowHarnessHistory']
+    put?: never
     post?: never
     delete?: never
     options?: never
@@ -7688,7 +7722,7 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
-          /** @description Default branch name used for mirrors and workspaces. */
+          /** @description Default branch name used when a repo scope does not provide an explicit branch override. */
           default_branch?: string
           /** @description Labels attached to the repository for workflow selection and filtering. */
           labels?: string[]
@@ -7882,7 +7916,7 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
-          /** @description Default branch name used for mirrors and workspaces. */
+          /** @description Default branch name used when a repo scope does not provide an explicit branch override. */
           default_branch?: string | null
           /** @description Labels attached to the repository for workflow selection and filtering. */
           labels?: string[] | null
@@ -8975,6 +9009,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -9045,7 +9080,7 @@ export interface operations {
           description?: string
           /** @description Whether the new skill should be enabled for runtime injection immediately. */
           is_enabled?: boolean | null
-          /** @description Project-unique skill directory name. */
+          /** @description Project-unique skill name in the control plane. */
           name?: string
         }
       }
@@ -9059,6 +9094,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -9067,6 +9108,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -10538,9 +10580,9 @@ export interface operations {
           agent_id?: string
           /** @description Ticket status IDs that mark workflow completion. */
           finish_status_ids?: string[]
-          /** @description Initial harness content written when creating the workflow. */
+          /** @description Initial harness content written into the versioned control-plane workflow record. */
           harness_content?: string
-          /** @description Repository path where the workflow harness file is stored. */
+          /** @description Logical harness path tracked by the control plane for this workflow. */
           harness_path?: string | null
           /** @description Workflow hook configuration keyed by lifecycle phase. */
           hooks?: {
@@ -11378,6 +11420,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11386,6 +11434,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -11464,6 +11513,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11472,6 +11527,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -11611,6 +11667,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11619,6 +11681,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -11687,6 +11750,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11695,6 +11764,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -11763,6 +11833,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11771,6 +11847,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -11778,6 +11855,72 @@ export interface operations {
               name?: string
               path?: string
             }
+          }
+        }
+      }
+      /** @description Bad Request response. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Not Found response. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Internal Server Error response. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+    }
+  }
+  getSkillHistory: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Skill ID. */
+        skillId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description List published skill versions response. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
           }
         }
       }
@@ -11849,6 +11992,12 @@ export interface operations {
         content: {
           'application/json': {
             content?: string
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
             skill?: {
               bound_workflows?: {
                 harness_path?: string
@@ -11857,6 +12006,7 @@ export interface operations {
               }[]
               created_at?: string
               created_by?: string
+              current_version?: number
               description?: string
               id?: string
               is_builtin?: boolean
@@ -13329,7 +13479,7 @@ export interface operations {
           agent_id?: string | null
           /** @description Ticket status IDs that mark workflow completion. */
           finish_status_ids?: string[] | null
-          /** @description Repository path where the workflow harness file is stored. */
+          /** @description Logical harness path tracked by the control plane for this workflow. */
           harness_path?: string | null
           /** @description Workflow hook configuration keyed by lifecycle phase. */
           hooks?: {
@@ -13563,6 +13713,72 @@ export interface operations {
       }
       /** @description Conflict response. */
       409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Internal Server Error response. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+    }
+  }
+  getWorkflowHarnessHistory: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Workflow ID. */
+        workflowId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description List published workflow harness versions response. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            history?: {
+              created_at?: string
+              created_by?: string
+              id?: string
+              version?: number
+            }[]
+          }
+        }
+      }
+      /** @description Bad Request response. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Not Found response. */
+      404: {
         headers: {
           [name: string]: unknown
         }

--- a/web/src/lib/api/openase.ts
+++ b/web/src/lib/api/openase.ts
@@ -13,6 +13,7 @@ import type {
   BuiltinRolePayload,
   DeleteGitHubOutboundCredentialResponse,
   HarnessPayload,
+  WorkflowHistoryPayload,
   HarnessVariableDictionaryPayload,
   HarnessValidationResponse,
   ImportGitHubOutboundCredentialResponse,
@@ -48,6 +49,7 @@ import type {
   SkillCreateResponse,
   SkillDeleteResponse,
   SkillDetailResponse,
+  SkillHistoryPayload,
   SkillRefreshResponse,
   SkillHarvestResponse,
   SkillBindingUpdateResponse,
@@ -919,6 +921,10 @@ export function getWorkflowHarness(workflowId: string) {
   return api.get<HarnessPayload>(`/api/v1/workflows/${workflowId}/harness`)
 }
 
+export function listWorkflowHarnessHistory(workflowId: string) {
+  return api.get<WorkflowHistoryPayload>(`/api/v1/workflows/${workflowId}/harness/history`)
+}
+
 export function saveWorkflowHarness(workflowId: string, content: string) {
   return api.put<HarnessPayload>(`/api/v1/workflows/${workflowId}/harness`, {
     body: { content },
@@ -954,6 +960,10 @@ export function createSkill(
 
 export function getSkill(skillId: string) {
   return api.get<SkillDetailResponse>(`/api/v1/skills/${skillId}`)
+}
+
+export function listSkillHistory(skillId: string) {
+  return api.get<SkillHistoryPayload>(`/api/v1/skills/${skillId}/history`)
 }
 
 export function updateSkill(

--- a/web/src/lib/features/settings/components/skill-settings-card.svelte
+++ b/web/src/lib/features/settings/components/skill-settings-card.svelte
@@ -6,6 +6,7 @@
     disableSkill,
     enableSkill,
     getSkill,
+    listSkillHistory,
     unbindSkill,
     updateSkill,
   } from '$lib/api/openase'
@@ -31,6 +32,9 @@
   let editing = $state(false)
   let editDescription = $state('')
   let editContent = $state('')
+  let editHistory = $state<
+    Array<{ id: string; version: number; created_by: string; created_at: string }>
+  >([])
   let busy = $state(false)
 
   function isBound(workflowId: string) {
@@ -41,11 +45,16 @@
     editing = true
     editDescription = skill.description
     editContent = ''
+    editHistory = []
     busy = true
     try {
-      const payload = await getSkill(skill.id)
+      const [payload, historyPayload] = await Promise.all([
+        getSkill(skill.id),
+        listSkillHistory(skill.id),
+      ])
       editDescription = payload.skill.description
       editContent = payload.content
+      editHistory = historyPayload.history
     } catch (caughtError) {
       editing = false
       toastStore.error(
@@ -159,6 +168,9 @@
         <Badge variant="outline" class="px-1.5 py-0.5 text-[10px] leading-none uppercase">
           {skill.is_builtin ? 'builtin' : 'custom'}
         </Badge>
+        <Badge variant="outline" class="px-1.5 py-0.5 text-[10px] leading-none">
+          Published v{skill.current_version}
+        </Badge>
         {#if !skill.is_enabled}
           <Badge
             variant="secondary"
@@ -207,7 +219,13 @@
       <DropdownMenu.Root>
         <DropdownMenu.Trigger>
           {#snippet child({ props })}
-            <Button {...props} variant="ghost" size="sm" class="size-7 p-0">
+            <Button
+              {...props}
+              variant="ghost"
+              size="sm"
+              class="size-7 p-0"
+              aria-label={`Actions for ${skill.name}`}
+            >
               <Ellipsis class="size-4" />
             </Button>
           {/snippet}
@@ -244,6 +262,26 @@
     <div class="bg-muted/40 mt-3 ml-5 space-y-3 rounded-lg border p-3">
       <Input bind:value={editDescription} placeholder="Description" class="text-sm" />
       <Textarea bind:value={editContent} class="min-h-40 font-mono text-sm" />
+      {#if editHistory.length > 0}
+        <div class="space-y-2">
+          <div class="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
+            Published versions
+          </div>
+          <div class="flex flex-wrap gap-2">
+            {#each editHistory.slice(0, 4) as item (item.id)}
+              <div class="bg-background rounded-lg border px-2.5 py-1.5 text-xs">
+                <div class="text-foreground font-medium">
+                  v{item.version}
+                  {#if item.version === skill.current_version}
+                    <span class="text-muted-foreground">· current</span>
+                  {/if}
+                </div>
+                <div class="text-muted-foreground mt-0.5">{item.created_by}</div>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
       <div class="flex justify-end gap-2">
         <Button type="button" variant="ghost" size="sm" onclick={() => (editing = false)}>
           Cancel

--- a/web/src/lib/features/settings/components/skill-settings-card.test.ts
+++ b/web/src/lib/features/settings/components/skill-settings-card.test.ts
@@ -1,0 +1,134 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Skill, Workflow } from '$lib/api/contracts'
+import SkillSettingsCard from './skill-settings-card.svelte'
+
+const {
+  bindSkill,
+  deleteSkill,
+  disableSkill,
+  enableSkill,
+  getSkill,
+  listSkillHistory,
+  unbindSkill,
+  updateSkill,
+} = vi.hoisted(() => ({
+  bindSkill: vi.fn(),
+  deleteSkill: vi.fn(),
+  disableSkill: vi.fn(),
+  enableSkill: vi.fn(),
+  getSkill: vi.fn(),
+  listSkillHistory: vi.fn(),
+  unbindSkill: vi.fn(),
+  updateSkill: vi.fn(),
+}))
+
+vi.mock('$lib/api/openase', () => ({
+  bindSkill,
+  deleteSkill,
+  disableSkill,
+  enableSkill,
+  getSkill,
+  listSkillHistory,
+  unbindSkill,
+  updateSkill,
+}))
+
+const { toastStore } = vi.hoisted(() => ({
+  toastStore: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+  toastStore,
+}))
+
+const workflows: Workflow[] = [
+  {
+    id: 'wf-1',
+    project_id: 'project-1',
+    agent_id: null,
+    name: 'Coding Workflow',
+    type: 'coding',
+    harness_path: '.openase/harnesses/coding.md',
+    hooks: {},
+    max_concurrent: 1,
+    max_retry_attempts: 1,
+    timeout_minutes: 30,
+    stall_timeout_minutes: 5,
+    version: 3,
+    is_active: true,
+    pickup_status_ids: ['todo'],
+    finish_status_ids: ['done'],
+  } as Workflow,
+]
+
+const skill: Skill = {
+  id: 'skill-1',
+  name: 'commit',
+  description: 'Create a well-formed git commit.',
+  path: '/skills/commit',
+  current_version: 2,
+  is_builtin: true,
+  is_enabled: true,
+  created_by: 'system:init',
+  created_at: '2026-03-28T12:00:00Z',
+  bound_workflows: [
+    { id: 'wf-1', name: 'Coding Workflow', harness_path: '.openase/harnesses/coding.md' },
+  ],
+} as Skill
+
+describe('SkillSettingsCard', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('shows the current published version on the collapsed card', () => {
+    const { getByText } = render(SkillSettingsCard, {
+      props: {
+        skill,
+        workflows,
+        onChanged: vi.fn(),
+      },
+    })
+
+    expect(getByText('Published v2')).toBeTruthy()
+  })
+
+  it('loads and renders skill version history when editing', async () => {
+    getSkill.mockResolvedValue({
+      skill,
+      content: '# Commit\n\nWrite a conventional commit message.',
+    })
+    listSkillHistory.mockResolvedValue({
+      history: [
+        { id: 'v2', version: 2, created_by: 'user:gary', created_at: '2026-03-28T12:00:00Z' },
+        { id: 'v1', version: 1, created_by: 'system:init', created_at: '2026-03-27T12:00:00Z' },
+      ],
+    })
+
+    const { getByText, getByRole, findByText } = render(SkillSettingsCard, {
+      props: {
+        skill,
+        workflows,
+        onChanged: vi.fn(),
+      },
+    })
+
+    await fireEvent.click(getByRole('button', { name: 'Actions for commit' }))
+    await fireEvent.click(getByText('Edit'))
+
+    expect(await findByText('Published versions')).toBeTruthy()
+    expect(await findByText('v2')).toBeTruthy()
+    expect(await findByText('user:gary')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(getSkill).toHaveBeenCalledWith('skill-1')
+      expect(listSkillHistory).toHaveBeenCalledWith('skill-1')
+    })
+  })
+})

--- a/web/src/lib/features/settings/components/skills-settings.svelte
+++ b/web/src/lib/features/settings/components/skills-settings.svelte
@@ -137,7 +137,8 @@
     <div>
       <h2 class="text-foreground text-base font-semibold">Skills Library</h2>
       <p class="text-muted-foreground mt-1 text-sm">
-        Manage reusable runtime skills, their rollout state, and workflow bindings.
+        Manage reusable control-plane skills, their published versions, rollout state, and workflow
+        bindings.
       </p>
     </div>
     {#if !loading}

--- a/web/src/lib/features/settings/components/workflow-settings.svelte
+++ b/web/src/lib/features/settings/components/workflow-settings.svelte
@@ -111,7 +111,8 @@
   <div>
     <h2 class="text-foreground text-base font-semibold">Workflow Lifecycle</h2>
     <p class="text-muted-foreground mt-1 text-sm">
-      Manage workflow agent binding, scheduling policy, activation, and deletion.
+      Manage workflow agent binding, published harness versions, scheduling policy, activation, and
+      deletion.
     </p>
   </div>
 

--- a/web/src/lib/features/tickets/components/new-ticket-dialog.svelte
+++ b/web/src/lib/features/tickets/components/new-ticket-dialog.svelte
@@ -6,6 +6,7 @@
   import { appStore } from '$lib/stores/app.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
   import { Button } from '$ui/button'
+  import { Checkbox } from '$ui/checkbox'
   import * as Dialog from '$ui/dialog'
   import { Input } from '$ui/input'
   import { Label } from '$ui/label'
@@ -39,9 +40,6 @@
   )
   const selectedWorkflowLabel = $derived(
     workflowOptions.find((option) => option.id === draft.workflowId)?.label ?? 'Unassigned',
-  )
-  const selectedRepoLabel = $derived(
-    repoOptions.find((option) => option.id === draft.repoId)?.label ?? 'Select repository',
   )
 
   $effect(() => {
@@ -100,6 +98,15 @@
       ...draft,
       [field]: value,
     }
+  }
+
+  function toggleRepoScope(repoId: string) {
+    updateDraftField(
+      'repoIds',
+      draft.repoIds.includes(repoId)
+        ? draft.repoIds.filter((id) => id !== repoId)
+        : [...draft.repoIds, repoId],
+    )
   }
 
   async function handleSubmit(event: SubmitEvent) {
@@ -233,28 +240,39 @@
       </div>
 
       {#if repoOptions.length > 1}
-        <div class="space-y-2">
-          <Label>Repository scope</Label>
-          <Select.Root
-            type="single"
-            value={draft.repoId}
-            disabled={loading || saving}
-            onValueChange={(value) => updateDraftField('repoId', value || '')}
-          >
-            <Select.Trigger class="w-full">{selectedRepoLabel}</Select.Trigger>
-            <Select.Content>
-              {#each repoOptions as option (option.id)}
-                <Select.Item value={option.id}>{option.label}</Select.Item>
-              {/each}
-            </Select.Content>
-          </Select.Root>
-          <p class="text-muted-foreground text-xs">
-            Multi-repo projects require an explicit repository scope when creating a ticket.
-          </p>
+        <div class="space-y-3">
+          <div class="space-y-1">
+            <Label>Repository scopes</Label>
+            <p class="text-muted-foreground text-xs">
+              Multi-repo projects require an explicit repo scope selection before ticket creation.
+            </p>
+          </div>
+          <div class="space-y-2 rounded-lg border p-3">
+            {#each repoOptions as option (option.id)}
+              <label
+                class="hover:bg-muted/40 flex items-start gap-3 rounded-md px-2 py-2 transition-colors"
+                for={`new-ticket-repo-${option.id}`}
+              >
+                <Checkbox
+                  id={`new-ticket-repo-${option.id}`}
+                  class="mt-0.5"
+                  checked={draft.repoIds.includes(option.id)}
+                  disabled={loading || saving}
+                  onCheckedChange={() => toggleRepoScope(option.id)}
+                />
+                <div class="min-w-0 flex-1">
+                  <div class="text-sm font-medium">{option.label}</div>
+                  <div class="text-muted-foreground text-xs">
+                    Default branch: {option.defaultBranch || 'main'}
+                  </div>
+                </div>
+              </label>
+            {/each}
+          </div>
         </div>
       {:else if repoOptions.length === 1}
         <div class="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-sm">
-          <span class="text-muted-foreground">Repository scope:</span>
+          <span class="text-muted-foreground">Repo scope:</span>
           <span class="text-foreground ml-1 font-medium">{repoOptions[0].label}</span>
         </div>
       {/if}

--- a/web/src/lib/features/tickets/new-ticket.test.ts
+++ b/web/src/lib/features/tickets/new-ticket.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { createNewTicketDraft, parseNewTicketDraft, type TicketRepoOption } from './new-ticket'
+
+const statusOptions = [{ id: 'todo', label: 'Todo' }]
+const workflowOptions = [{ id: 'coding', label: 'Coding' }]
+
+describe('new ticket repo scope parsing', () => {
+  it('auto-selects the only repository in single-repo projects', () => {
+    const repoOptions: TicketRepoOption[] = [
+      { id: 'repo-1', label: 'backend', defaultBranch: 'main' },
+    ]
+
+    const draft = createNewTicketDraft(statusOptions, workflowOptions, repoOptions)
+    const parsed = parseNewTicketDraft(
+      {
+        ...draft,
+        title: 'Ship login validation',
+      },
+      repoOptions,
+    )
+
+    expect(parsed).toEqual({
+      ok: true,
+      payload: {
+        title: 'Ship login validation',
+        priority: 'medium',
+        status_id: 'todo',
+        workflow_id: 'coding',
+        repo_scopes: [{ repo_id: 'repo-1', branch_name: 'main' }],
+      },
+    })
+  })
+
+  it('requires explicit repo scopes for multi-repo projects', () => {
+    const repoOptions: TicketRepoOption[] = [
+      { id: 'repo-1', label: 'backend', defaultBranch: 'main' },
+      { id: 'repo-2', label: 'frontend', defaultBranch: 'develop' },
+    ]
+
+    const parsed = parseNewTicketDraft(
+      {
+        ...createNewTicketDraft(statusOptions, workflowOptions, repoOptions),
+        title: 'Ship login validation',
+      },
+      repoOptions,
+    )
+
+    expect(parsed).toEqual({
+      ok: false,
+      error: 'Select at least one repository scope for this ticket.',
+    })
+  })
+
+  it('returns every explicitly selected repo scope for multi-repo projects', () => {
+    const repoOptions: TicketRepoOption[] = [
+      { id: 'repo-1', label: 'backend', defaultBranch: 'main' },
+      { id: 'repo-2', label: 'frontend', defaultBranch: 'develop' },
+      { id: 'repo-3', label: 'docs', defaultBranch: 'main' },
+    ]
+
+    const parsed = parseNewTicketDraft(
+      {
+        ...createNewTicketDraft(statusOptions, workflowOptions, repoOptions),
+        title: 'Ship login validation',
+        repoIds: ['repo-2', 'repo-1'],
+      },
+      repoOptions,
+    )
+
+    expect(parsed).toEqual({
+      ok: true,
+      payload: {
+        title: 'Ship login validation',
+        priority: 'medium',
+        status_id: 'todo',
+        workflow_id: 'coding',
+        repo_scopes: [
+          { repo_id: 'repo-1', branch_name: 'main' },
+          { repo_id: 'repo-2', branch_name: 'develop' },
+        ],
+      },
+    })
+  })
+})

--- a/web/src/lib/features/tickets/new-ticket.ts
+++ b/web/src/lib/features/tickets/new-ticket.ts
@@ -21,7 +21,7 @@ export type NewTicketDraft = {
   statusId: string
   priority: TicketPriorityOption
   workflowId: string
-  repoId: string
+  repoIds: string[]
 }
 
 export type NewTicketPayload = {
@@ -87,7 +87,7 @@ export function createNewTicketDraft(
     statusId: statusOptions[0]?.id ?? '',
     priority: 'medium',
     workflowId: workflowOptions[0]?.id ?? '',
-    repoId: repoOptions.length === 1 ? repoOptions[0].id : '',
+    repoIds: repoOptions.length === 1 ? [repoOptions[0].id] : [],
   }
 }
 
@@ -104,7 +104,7 @@ export function parseNewTicketDraft(
   }
 
   const description = draft.description.trim()
-  const repoScopes = buildRepoScopes(repoOptions, draft.repoId)
+  const repoScopes = buildRepoScopes(repoOptions, draft.repoIds)
   if ('error' in repoScopes) {
     return {
       ok: false,
@@ -127,26 +127,33 @@ export function parseNewTicketDraft(
 
 function buildRepoScopes(
   repoOptions: TicketRepoOption[],
-  selectedRepoId: string,
+  selectedRepoIds: string[],
 ): { value: NewTicketPayload['repo_scopes'] } | { error: string } {
   if (repoOptions.length === 0) {
     return { value: undefined }
   }
 
-  const selectedRepo =
-    repoOptions.length === 1
-      ? repoOptions[0]
-      : (repoOptions.find((repo) => repo.id === selectedRepoId) ?? null)
-  if (!selectedRepo) {
-    return { error: 'Select a repository for this ticket.' }
+  if (repoOptions.length === 1) {
+    const repo = repoOptions[0]
+    return {
+      value: [
+        {
+          repo_id: repo.id,
+          branch_name: repo.defaultBranch || 'main',
+        },
+      ],
+    }
+  }
+
+  const selectedRepos = repoOptions.filter((repo) => selectedRepoIds.includes(repo.id))
+  if (selectedRepos.length === 0) {
+    return { error: 'Select at least one repository scope for this ticket.' }
   }
 
   return {
-    value: [
-      {
-        repo_id: selectedRepo.id,
-        branch_name: selectedRepo.defaultBranch || 'main',
-      },
-    ],
+    value: selectedRepos.map((repo) => ({
+      repo_id: repo.id,
+      branch_name: repo.defaultBranch || 'main',
+    })),
   }
 }

--- a/web/src/lib/features/workflows/components/workflow-detail-panel.svelte
+++ b/web/src/lib/features/workflows/components/workflow-detail-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cn } from '$lib/utils'
+  import { cn, formatRelativeTime } from '$lib/utils'
   import { Input } from '$ui/input'
   import { Label } from '$ui/label'
   import { Separator } from '$ui/separator'
@@ -147,6 +147,37 @@
   />
 
   <Separator />
+
+  {#if workflow.history.length > 0}
+    <div class="bg-muted/20 space-y-2 px-4 py-3">
+      <div class="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
+        Control Plane
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-xs">
+        <span class="text-foreground rounded-full border px-2 py-0.5 font-medium">
+          Published v{workflow.version}
+        </span>
+        <span class="text-muted-foreground">{workflow.history.length} recorded version(s)</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        {#each workflow.history.slice(0, 4) as item (item.id)}
+          <div class="bg-background rounded-lg border px-2.5 py-1.5 text-xs">
+            <div class="text-foreground font-medium">
+              v{item.version}
+              {#if item.version === workflow.version}
+                <span class="text-muted-foreground">· current</span>
+              {/if}
+            </div>
+            <div class="text-muted-foreground mt-0.5">
+              {formatRelativeTime(item.createdAt)} by {item.createdBy}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <Separator />
+  {/if}
 
   <form class="flex flex-1 flex-col" onsubmit={handleSubmit}>
     <div class="flex-1 space-y-6 px-4 py-4">

--- a/web/src/lib/features/workflows/components/workflow-editor-panel.test.ts
+++ b/web/src/lib/features/workflows/components/workflow-editor-panel.test.ts
@@ -34,6 +34,7 @@ const workflowFixture = {
   lastModified: '2026-03-28T12:00:00Z',
   recentSuccessRate: 85,
   version: 3,
+  history: [],
 }
 
 const skillStatesFixture: SkillState[] = [

--- a/web/src/lib/features/workflows/components/workflow-lifecycle-sidebar.svelte
+++ b/web/src/lib/features/workflows/components/workflow-lifecycle-sidebar.svelte
@@ -35,7 +35,7 @@
     saving = true
 
     try {
-      const updated = await saveWorkflowLifecycle(workflow.id, payload, statuses)
+      const updated = await saveWorkflowLifecycle(workflow.id, payload, statuses, workflow)
       onWorkflowsChange?.(workflows.map((item) => (item.id === updated.id ? updated : item)))
       toastStore.success('Workflow updated.')
     } catch (caughtError) {

--- a/web/src/lib/features/workflows/components/workflows-page-body.test.ts
+++ b/web/src/lib/features/workflows/components/workflows-page-body.test.ts
@@ -31,6 +31,20 @@ const workflowFixture = {
   lastModified: '2026-03-28T12:00:00Z',
   recentSuccessRate: 85,
   version: 3,
+  history: [
+    {
+      id: 'wf-1-v3',
+      version: 3,
+      createdBy: 'user:manual',
+      createdAt: '2026-03-28T12:00:00Z',
+    },
+    {
+      id: 'wf-1-v2',
+      version: 2,
+      createdBy: 'user:manual',
+      createdAt: '2026-03-27T12:00:00Z',
+    },
+  ],
 }
 
 const harnessFixture = {
@@ -84,17 +98,18 @@ describe('WorkflowsPageBody', () => {
     // Note: "Coding Workflow" still appears in the editor toolbar
   })
 
-  it('opens the settings sheet when onToggleDetail is triggered', async () => {
+  it('opens the settings sheet with published workflow history', async () => {
     const { getByTitle, findByText } = render(WorkflowsPageBody, {
       props: { ...defaultProps, showDetail: false },
     })
 
     await fireEvent.click(getByTitle('Workflow settings'))
 
-    // The sheet should open showing workflow detail content
     await waitFor(() => {
       expect(findByText('Workflow Settings')).toBeTruthy()
     })
+    expect(await findByText('Published v3')).toBeTruthy()
+    expect(await findByText('2 recorded version(s)')).toBeTruthy()
   })
 
   it('shows the loading state when loading is true', () => {

--- a/web/src/lib/features/workflows/components/workflows-page.svelte
+++ b/web/src/lib/features/workflows/components/workflows-page.svelte
@@ -22,14 +22,14 @@
   import type { WorkflowRepositoryPrerequisite } from '../repository-prerequisite'
   import WorkflowsPageBody from './workflows-page-body.svelte'
   import WorkflowsPageHeaderActions from './workflows-page-header-actions.svelte'
-  let showDetail = $state(false)
-  let showCreateDialog = $state(false)
-  let showList = $state(true)
+  let showDetail = $state(false),
+    showCreateDialog = $state(false),
+    showList = $state(true)
   let loading = $state(false),
     saving = $state(false),
     validating = $state(false)
-  let loadError = $state('')
-  let prerequisite = $state<WorkflowRepositoryPrerequisite | null>(null)
+  let loadError = $state(''),
+    prerequisite = $state<WorkflowRepositoryPrerequisite | null>(null)
   let workflows = $state<WorkflowSummary[]>([]),
     selectedId = $state('')
   let harness = $state<ReturnType<typeof toHarnessContent> | null>(null),
@@ -132,9 +132,7 @@
       validationIssues = []
       return
     }
-    if (workflowId === loadedHarnessWorkflowId) {
-      return
-    }
+    if (workflowId === loadedHarnessWorkflowId) return
     let cancelled = false
     const loadHarness = async () => {
       try {
@@ -145,6 +143,9 @@
         loadedHarnessWorkflowId = workflowId
         validationIssues = []
         skillStates = payload.skillStates
+        workflows = workflows.map((workflow) =>
+          workflow.id === workflowId ? { ...workflow, history: payload.history } : workflow,
+        )
       } catch (caughtError) {
         if (cancelled) return
         toastStore.error(
@@ -159,17 +160,22 @@
   })
   async function handleSave() {
     if (!selectedId) return
+    const projectId = appStore.currentProject?.id
+    if (!projectId) return
     saving = true
     try {
       const payload = await saveWorkflowHarness(selectedId, draftHarness)
-      harness = toHarnessContent(payload.harness.content)
-      draftHarness = payload.harness.content
+      const refreshed = await loadWorkflowHarness(projectId, selectedId)
+      harness = refreshed.harness
+      draftHarness = refreshed.harness.rawContent
+      skillStates = refreshed.skillStates
       workflows = workflows.map((workflow) =>
         workflow.id === selectedId
           ? {
               ...workflow,
               harnessPath: payload.harness.path ?? workflow.harnessPath,
               version: payload.harness.version ?? workflow.version,
+              history: refreshed.history,
             }
           : workflow,
       )
@@ -218,11 +224,9 @@
       const result = skill.bound
         ? await unbindWorkflowSkills(selectedId, [skill.name])
         : await bindWorkflowSkills(selectedId, [skill.name])
-
       const newContent = result.harness.content
       harness = toHarnessContent(newContent)
       draftHarness = newContent
-
       skillStates = skillStates.map((item) =>
         item.path === skill.path ? { ...item, bound: !skill.bound } : item,
       )
@@ -250,7 +254,7 @@
 
 <PageScaffold
   title="Workflows"
-  description="Edit harnesses and manage workflow lifecycle settings."
+  description="Edit published harnesses and manage workflow lifecycle settings."
   variant="workspace"
   {actions}
 >

--- a/web/src/lib/features/workflows/components/workflows-page.test.ts
+++ b/web/src/lib/features/workflows/components/workflows-page.test.ts
@@ -97,6 +97,14 @@ const pageDataFixture = {
       lastModified: '2026-03-28T12:00:00Z',
       recentSuccessRate: 85,
       version: 3,
+      history: [
+        {
+          id: 'wf-1-v3',
+          version: 3,
+          createdBy: 'user:manual',
+          createdAt: '2026-03-28T12:00:00Z',
+        },
+      ],
     },
   ],
   selectedWorkflowId: 'wf-1',

--- a/web/src/lib/features/workflows/data.ts
+++ b/web/src/lib/features/workflows/data.ts
@@ -2,6 +2,7 @@ import {
   createWorkflow,
   getWorkflowRepositoryPrerequisite,
   getWorkflowHarness,
+  listWorkflowHarnessHistory,
   listAgents,
   listHarnessVariables,
   listBuiltinRoles,
@@ -19,6 +20,7 @@ import type {
   WorkflowAgentOption,
   WorkflowStatusOption,
   WorkflowSummary,
+  WorkflowVersionSummary,
 } from './types'
 
 export function mapWorkflowSummary(
@@ -50,7 +52,19 @@ export function mapWorkflowSummary(
     lastModified: new Date().toISOString(),
     recentSuccessRate: 0,
     version: workflow.version,
+    history: [],
   }
+}
+
+function mapWorkflowVersionHistory(
+  history: Awaited<ReturnType<typeof listWorkflowHarnessHistory>>['history'],
+): WorkflowVersionSummary[] {
+  return history.map((item) => ({
+    id: item.id,
+    version: item.version,
+    createdBy: item.created_by,
+    createdAt: item.created_at,
+  }))
 }
 
 export function mapWorkflowAgentOptions(
@@ -139,13 +153,15 @@ export async function loadWorkflowIndex(projectId: string, orgId: string, select
 }
 
 export async function loadWorkflowHarness(projectId: string, workflowId: string) {
-  const [harnessPayload, skillPayload] = await Promise.all([
+  const [harnessPayload, historyPayload, skillPayload] = await Promise.all([
     getWorkflowHarness(workflowId),
+    listWorkflowHarnessHistory(workflowId),
     listSkills(projectId),
   ])
 
   return {
     harness: toHarnessContent(harnessPayload.harness.content),
+    history: mapWorkflowVersionHistory(historyPayload.history),
     skillStates: mapSkillStates(skillPayload.skills, workflowId),
   }
 }
@@ -161,7 +177,11 @@ export async function loadWorkflowPageData(projectId: string, orgId: string, sel
   return {
     prerequisite,
     agentOptions: index.agentOptions,
-    workflows: index.workflows,
+    workflows: index.workflows.map((workflow) =>
+      workflow.id === selectedWorkflowId
+        ? { ...workflow, history: harnessPayload?.history ?? workflow.history }
+        : workflow,
+    ),
     builtinRoleContent: index.builtinRoleContent,
     providers: index.providers,
     statuses: index.statuses,
@@ -224,6 +244,7 @@ export async function createWorkflowWithBinding(
     lastModified: new Date().toISOString(),
     recentSuccessRate: 0,
     version: createdWorkflow.version,
+    history: [],
   }
 
   return {

--- a/web/src/lib/features/workflows/types.ts
+++ b/web/src/lib/features/workflows/types.ts
@@ -7,6 +7,13 @@ export type WorkflowType =
   | 'refine-harness'
   | 'custom'
 
+export type WorkflowVersionSummary = {
+  id: string
+  version: number
+  createdBy: string
+  createdAt: string
+}
+
 export type WorkflowSummary = {
   id: string
   name: string
@@ -25,6 +32,7 @@ export type WorkflowSummary = {
   lastModified: string
   recentSuccessRate: number
   version: number
+  history: WorkflowVersionSummary[]
 }
 
 export type WorkflowStatusOption = {

--- a/web/src/lib/features/workflows/workflow-management.ts
+++ b/web/src/lib/features/workflows/workflow-management.ts
@@ -7,10 +7,16 @@ export async function saveWorkflowLifecycle(
   workflowId: string,
   payload: WorkflowLifecyclePayload,
   statuses: WorkflowStatusOption[],
+  currentWorkflow?: WorkflowSummary,
 ): Promise<WorkflowSummary> {
   const response = await updateWorkflow(workflowId, payload)
   const statusNamesById = new Map(statuses.map((status) => [status.id, status.name]))
-  return mapWorkflowSummary(response.workflow, statusNamesById)
+  const nextWorkflow = mapWorkflowSummary(response.workflow, statusNamesById)
+  return {
+    ...nextWorkflow,
+    history: currentWorkflow?.history ?? nextWorkflow.history,
+    lastModified: currentWorkflow?.lastModified ?? nextWorkflow.lastModified,
+  }
 }
 
 export async function destroyWorkflow(workflowId: string) {

--- a/web/src/lib/testing/e2e/mock-api.ts
+++ b/web/src/lib/testing/e2e/mock-api.ts
@@ -28,7 +28,15 @@ type MockState = {
   statuses: Record<string, unknown>[]
   repos: Record<string, unknown>[]
   workflows: Record<string, unknown>[]
-  harnessByWorkflowId: Record<string, { content: string; path: string; version: number }>
+  harnessByWorkflowId: Record<
+    string,
+    {
+      content: string
+      path: string
+      version: number
+      history: Array<{ id: string; version: number; created_by: string; created_at: string }>
+    }
+  >
   scheduledJobs: Record<string, unknown>[]
   skills: Record<string, unknown>[]
   builtinRoles: Record<string, unknown>[]
@@ -92,6 +100,9 @@ export async function handleMockApi(request: Request, url: URL): Promise<Respons
   }
   if (segments[0] === 'workflows') {
     return handleWorkflowRoutes(request, segments)
+  }
+  if (segments[0] === 'skills') {
+    return handleSkillRoutes(request, segments)
   }
   if (segments[0] === 'scheduled-jobs') {
     return handleScheduledJobRoutes(request, segments)
@@ -245,6 +256,9 @@ async function handleProjectRoutes(request: Request, segments: string[], _url: U
           defaultHarnessContent(asString(body.name) ?? `Workflow ${mockState.counters.workflow}`),
         path: workflow.harness_path,
         version: 1,
+        history: [
+          { id: `${nextId}-v1`, version: 1, created_by: 'user:manual', created_at: nowIso },
+        ],
       }
       return jsonResponse({ workflow: clone(workflow) }, 201)
     }
@@ -450,6 +464,11 @@ async function handleWorkflowRoutes(request: Request, segments: string[]) {
   }
 
   if (segments[2] === 'harness') {
+    if (segments[3] === 'history' && request.method === 'GET') {
+      return jsonResponse({
+        history: clone(mockState.harnessByWorkflowId[workflowId].history),
+      })
+    }
     if (request.method === 'GET') {
       const harness = mockState.harnessByWorkflowId[workflowId]
       return jsonResponse({
@@ -470,6 +489,15 @@ async function handleWorkflowRoutes(request: Request, segments: string[]) {
         content,
         path: current.path,
         version: nextVersion,
+        history: [
+          {
+            id: `${workflowId}-v${nextVersion}`,
+            version: nextVersion,
+            created_by: 'user:manual',
+            created_at: nowIso,
+          },
+          ...current.history,
+        ],
       }
       workflow.version = nextVersion
       return jsonResponse({
@@ -489,7 +517,10 @@ async function handleWorkflowRoutes(request: Request, segments: string[]) {
     const binding = segments[3] === 'bind'
 
     mockState.skills = mockState.skills.map((skill) => {
-      if (!skillPaths.includes(skill.path as string)) {
+      if (
+        !skillPaths.includes(skill.path as string) &&
+        !skillPaths.includes(skill.name as string)
+      ) {
         return skill
       }
       const existing = Array.isArray(skill.bound_workflows)
@@ -513,6 +544,30 @@ async function handleWorkflowRoutes(request: Request, segments: string[]) {
   }
 
   return notFound('Mock workflow route not found.')
+}
+
+async function handleSkillRoutes(request: Request, segments: string[]) {
+  const skillId = segments[1]
+  const skill = findById(mockState.skills, skillId)
+  if (!skill) {
+    return notFound('Skill not found.')
+  }
+
+  if (segments[2] === 'history' && request.method === 'GET') {
+    return jsonResponse({
+      history: clone((skill.history as Record<string, unknown>[]) ?? []),
+    })
+  }
+
+  if (segments.length === 2 && request.method === 'GET') {
+    return jsonResponse({
+      skill: clone(skill),
+      content: skill.content,
+      history: clone((skill.history as Record<string, unknown>[]) ?? []),
+    })
+  }
+
+  return notFound('Mock skill route not found.')
 }
 
 async function handleScheduledJobRoutes(request: Request, segments: string[]) {
@@ -800,6 +855,20 @@ function createInitialState(): MockState {
       content: defaultHarnessContent('Coding Workflow'),
       path: '.openase/harnesses/coding-workflow.md',
       version: 3,
+      history: [
+        {
+          id: `${DEFAULT_WORKFLOW_ID}-v3`,
+          version: 3,
+          created_by: 'user:manual',
+          created_at: nowIso,
+        },
+        {
+          id: `${DEFAULT_WORKFLOW_ID}-v2`,
+          version: 2,
+          created_by: 'user:manual',
+          created_at: '2026-03-26T10:00:00.000Z',
+        },
+      ],
     },
   }
 
@@ -826,18 +895,49 @@ function createInitialState(): MockState {
 
   const skills = [
     {
+      id: 'skill-commit',
       project_id: PROJECT_ID,
       name: 'commit',
       description: 'Create a well-formed git commit.',
       path: '/skills/commit',
+      current_version: 2,
+      is_builtin: true,
+      is_enabled: true,
+      created_by: 'system:init',
+      created_at: nowIso,
       bound_workflows: [{ id: DEFAULT_WORKFLOW_ID }],
+      content: '# Commit\n\nCreate a well-formed git commit.',
+      history: [
+        { id: 'skill-commit-v2', version: 2, created_by: 'user:manual', created_at: nowIso },
+        {
+          id: 'skill-commit-v1',
+          version: 1,
+          created_by: 'system:init',
+          created_at: '2026-03-26T10:00:00.000Z',
+        },
+      ],
     },
     {
+      id: 'skill-deploy-openase',
       project_id: PROJECT_ID,
       name: 'deploy-openase',
       description: 'Build and redeploy OpenASE locally.',
       path: '/skills/deploy-openase',
+      current_version: 1,
+      is_builtin: false,
+      is_enabled: true,
+      created_by: 'user:manual',
+      created_at: nowIso,
       bound_workflows: [],
+      content: '# Deploy OpenASE\n\nBuild and redeploy OpenASE locally.',
+      history: [
+        {
+          id: 'skill-deploy-openase-v1',
+          version: 1,
+          created_by: 'user:manual',
+          created_at: nowIso,
+        },
+      ],
     },
   ]
 


### PR DESCRIPTION
## Summary
- remove stale primary-repo semantics from ticket creation and harness template variables
- expose workflow harness and skill published version history through control-plane APIs and frontend UX
- align workflow/skill settings copy and controls with control-plane bindings, publish state, and explicit repo scope semantics

## Validation
- `PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/workflow ./internal/httpapi -count=1`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm exec vitest run src/lib/features/tickets/new-ticket.test.ts src/lib/features/workflows/components/workflows-page.test.ts src/lib/features/workflows/components/workflow-editor-panel.test.ts src/lib/features/workflows/components/workflows-page-body.test.ts src/lib/features/settings/components/skill-settings-card.test.ts`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run check`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:/home/yuzhong/.local/go1.26.1/bin:$PATH make frontend-api-audit-check`
- `PATH=/home/yuzhong/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run ci`
- `PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest make check`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- none identified beyond existing repo-wide frontend lint warnings that already pass in CI

Closes #418
