### PR TITLE
test(ci): validate repaired self-hosted runner

### DIFF
--- a/internal/httpapi/ci_runner_smoke_test.go
+++ b/internal/httpapi/ci_runner_smoke_test.go
@@ -1,0 +1,7 @@
+package httpapi
+
+import "testing"
+
+func TestCIRunnerSmoke(t *testing.T) {
+	t.Parallel()
+}

--- a/web/src/lib/testing/ci-runner-smoke.test.ts
+++ b/web/src/lib/testing/ci-runner-smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest'
+
+describe('ci runner smoke', () => {
+  it('keeps the frontend runner path exercised', () => {
+    expect(true).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add a tiny backend smoke test to force `go_changed=true`
- add a tiny frontend smoke test to force `web_changed=true`
- validate the repaired self-hosted runner against the full CI graph without touching production logic

## Validation
- `.codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- This PR is for runner verification only and should be closed after the GitHub checks confirm the runner is healthy.
