### PR TITLE
refactor(workflow): split workflow persistence ports

### DIFF
--- a/internal/repo/workflow/contracts_test.go
+++ b/internal/repo/workflow/contracts_test.go
@@ -1,0 +1,17 @@
+package workflow_test
+
+import (
+	repository "github.com/BetterAndBetterII/openase/internal/repo/workflow"
+	workflowservice "github.com/BetterAndBetterII/openase/internal/workflow"
+)
+
+var (
+	_ workflowservice.ProjectValidationRepository    = (*repository.EntRepository)(nil)
+	_ workflowservice.WorkflowRepository             = (*repository.EntRepository)(nil)
+	_ workflowservice.WorkflowVersionRepository      = (*repository.EntRepository)(nil)
+	_ workflowservice.SkillRepository                = (*repository.EntRepository)(nil)
+	_ workflowservice.SkillVersionRepository         = (*repository.EntRepository)(nil)
+	_ workflowservice.WorkflowSkillBindingRepository = (*repository.EntRepository)(nil)
+	_ workflowservice.WorkflowRuntimeSnapshotReader  = (*repository.EntRepository)(nil)
+	_ workflowservice.HarnessTemplateDataBuilder     = (*repository.EntRepository)(nil)
+)

--- a/internal/workflow/ports.go
+++ b/internal/workflow/ports.go
@@ -8,32 +8,35 @@ import (
 	"github.com/google/uuid"
 )
 
-type Repository interface {
+type ProjectValidationRepository interface {
 	EnsureProjectExists(ctx context.Context, projectID uuid.UUID) error
 	EnsureAgentBelongsToProject(ctx context.Context, projectID uuid.UUID, agentID uuid.UUID) error
 	EnsureStatusBindingsBelongToProject(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error
 	EnsureHarnessPathAvailable(ctx context.Context, projectID uuid.UUID, harnessPath string, excludeWorkflowID uuid.UUID) error
 	StatusNames(ctx context.Context, statusIDs []uuid.UUID) ([]string, error)
+}
 
+type WorkflowRepository interface {
 	List(ctx context.Context, projectID uuid.UUID) ([]domain.Workflow, error)
 	Get(ctx context.Context, workflowID uuid.UUID) (domain.Workflow, error)
 	Create(ctx context.Context, workflow domain.Workflow, harnessContent string, createdBy string) (domain.Workflow, error)
 	Update(ctx context.Context, workflow domain.Workflow) (domain.Workflow, error)
 	Delete(ctx context.Context, workflowID uuid.UUID) (domain.Workflow, error)
+}
+
+type WorkflowVersionRepository interface {
 	CurrentWorkflowVersion(ctx context.Context, workflowID uuid.UUID) (domain.WorkflowVersionRecord, error)
 	RecordedWorkflowVersion(ctx context.Context, workflowID uuid.UUID, workflowVersionID *uuid.UUID) (domain.WorkflowVersionRecord, error)
 	ListWorkflowVersions(ctx context.Context, workflowID uuid.UUID) ([]domain.VersionSummary, error)
 	PublishWorkflowVersion(ctx context.Context, workflowID uuid.UUID, content string, createdBy string) (domain.Workflow, error)
-	ListWorkflowBoundSkillNames(ctx context.Context, workflowID uuid.UUID, enabledOnly bool) ([]string, error)
+}
 
+type SkillRepository interface {
 	EnsureBuiltinSkills(ctx context.Context, projectID uuid.UUID, now time.Time, bundles []domain.SkillBundle) error
 	ListSkills(ctx context.Context, projectID uuid.UUID) ([]domain.Skill, error)
 	Skill(ctx context.Context, skillID uuid.UUID) (domain.SkillRecord, error)
 	SkillInProject(ctx context.Context, projectID uuid.UUID, skillID uuid.UUID) (domain.SkillRecord, error)
 	SkillByName(ctx context.Context, projectID uuid.UUID, name string) (domain.SkillRecord, error)
-	CurrentSkillVersion(ctx context.Context, skillID uuid.UUID, requiredVersionID *uuid.UUID) (domain.SkillVersionRecord, error)
-	ListSkillVersions(ctx context.Context, skillID uuid.UUID) ([]domain.VersionSummary, error)
-	SkillVersionFiles(ctx context.Context, versionID uuid.UUID) ([]domain.SkillBundleFile, error)
 	SkillDetail(ctx context.Context, skillID uuid.UUID) (domain.SkillDetail, error)
 	CreateSkillBundle(
 		ctx context.Context,
@@ -46,10 +49,25 @@ type Repository interface {
 	UpdateSkillBundle(ctx context.Context, skillID uuid.UUID, bundle domain.SkillBundle, updatedAt time.Time) (domain.SkillDetail, error)
 	DeleteSkill(ctx context.Context, skillID uuid.UUID, deletedAt time.Time) error
 	SetSkillEnabled(ctx context.Context, skillID uuid.UUID, enabled bool, updatedAt time.Time) (domain.SkillDetail, error)
+}
+
+type SkillVersionRepository interface {
+	CurrentSkillVersion(ctx context.Context, skillID uuid.UUID, requiredVersionID *uuid.UUID) (domain.SkillVersionRecord, error)
+	ListSkillVersions(ctx context.Context, skillID uuid.UUID) ([]domain.VersionSummary, error)
+	SkillVersionFiles(ctx context.Context, versionID uuid.UUID) ([]domain.SkillBundleFile, error)
+}
+
+type WorkflowSkillBindingRepository interface {
+	ListWorkflowBoundSkillNames(ctx context.Context, workflowID uuid.UUID, enabledOnly bool) ([]string, error)
 	ResolveInjectedSkillNames(ctx context.Context, projectID uuid.UUID, workflowID *uuid.UUID) ([]string, error)
 	ApplyWorkflowSkillBindings(ctx context.Context, workflowID uuid.UUID, skillIDs []uuid.UUID, bind bool, content string, createdBy string) (domain.Workflow, error)
+}
 
+type WorkflowRuntimeSnapshotReader interface {
 	ResolveRuntimeSnapshot(ctx context.Context, workflowID uuid.UUID) (domain.RuntimeSnapshot, error)
 	ResolveRecordedRuntimeSnapshot(ctx context.Context, input domain.ResolveRecordedRuntimeSnapshotInput) (domain.RuntimeSnapshot, error)
+}
+
+type HarnessTemplateDataBuilder interface {
 	BuildHarnessTemplateData(ctx context.Context, input domain.BuildHarnessTemplateDataInput) (domain.HarnessTemplateData, error)
 }

--- a/internal/workflow/service.go
+++ b/internal/workflow/service.go
@@ -83,10 +83,10 @@ func projectHarnessContent(content string, skillNames []string) (string, error) 
 }
 
 func (s *Service) currentWorkflowVersion(ctx context.Context, workflowID uuid.UUID) (domain.WorkflowVersionRecord, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflowVersions == nil {
 		return domain.WorkflowVersionRecord{}, ErrUnavailable
 	}
-	return s.repo.CurrentWorkflowVersion(ctx, workflowID)
+	return s.workflowVersions.CurrentWorkflowVersion(ctx, workflowID)
 }
 
 func (s *Service) projectedWorkflowHarness(ctx context.Context, workflowItem Workflow) (string, error) {
@@ -102,17 +102,17 @@ func (s *Service) projectedWorkflowHarness(ctx context.Context, workflowItem Wor
 }
 
 func (s *Service) ListWorkflowVersions(ctx context.Context, workflowID uuid.UUID) ([]VersionSummary, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflowVersions == nil {
 		return nil, ErrUnavailable
 	}
-	return s.repo.ListWorkflowVersions(ctx, workflowID)
+	return s.workflowVersions.ListWorkflowVersions(ctx, workflowID)
 }
 
 func (s *Service) listWorkflowBoundSkillNames(ctx context.Context, workflowID uuid.UUID, enabledOnly bool) ([]string, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflowSkills == nil {
 		return nil, ErrUnavailable
 	}
-	return s.repo.ListWorkflowBoundSkillNames(ctx, workflowID, enabledOnly)
+	return s.workflowSkills.ListWorkflowBoundSkillNames(ctx, workflowID, enabledOnly)
 }
 
 func skillDescriptionFromContent(content string) (string, error) {
@@ -152,7 +152,7 @@ func (s *Service) builtinBundles() ([]domain.SkillBundle, error) {
 }
 
 func (s *Service) ensureBuiltinSkills(ctx context.Context, projectID uuid.UUID) error {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return ErrUnavailable
 	}
 	s.builtinSkillsMu.Lock()
@@ -162,21 +162,21 @@ func (s *Service) ensureBuiltinSkills(ctx context.Context, projectID uuid.UUID) 
 	if err != nil {
 		return err
 	}
-	return s.repo.EnsureBuiltinSkills(ctx, projectID, time.Now().UTC(), bundles)
+	return s.skills.EnsureBuiltinSkills(ctx, projectID, time.Now().UTC(), bundles)
 }
 
 func (s *Service) skillByName(ctx context.Context, projectID uuid.UUID, name string) (domain.SkillRecord, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return domain.SkillRecord{}, ErrUnavailable
 	}
-	return s.repo.SkillByName(ctx, projectID, name)
+	return s.skills.SkillByName(ctx, projectID, name)
 }
 
 func (s *Service) currentSkillVersion(ctx context.Context, skillID uuid.UUID, requiredVersionID *uuid.UUID) (domain.SkillVersionRecord, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skillVersions == nil {
 		return domain.SkillVersionRecord{}, ErrUnavailable
 	}
-	return s.repo.CurrentSkillVersion(ctx, skillID, requiredVersionID)
+	return s.skillVersions.CurrentSkillVersion(ctx, skillID, requiredVersionID)
 }
 
 type resolvedSkillRecord struct {
@@ -184,7 +184,7 @@ type resolvedSkillRecord struct {
 }
 
 func (s *Service) listSkillsPersistent(ctx context.Context, projectID uuid.UUID) ([]Skill, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return nil, ErrUnavailable
 	}
 	if err := s.ensureProjectExists(ctx, projectID); err != nil {
@@ -193,25 +193,25 @@ func (s *Service) listSkillsPersistent(ctx context.Context, projectID uuid.UUID)
 	if err := s.ensureBuiltinSkills(ctx, projectID); err != nil {
 		return nil, err
 	}
-	return s.repo.ListSkills(ctx, projectID)
+	return s.skills.ListSkills(ctx, projectID)
 }
 
 func (s *Service) getSkillPersistent(ctx context.Context, skillID uuid.UUID) (SkillDetail, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return SkillDetail{}, ErrUnavailable
 	}
-	return s.repo.SkillDetail(ctx, skillID)
+	return s.skills.SkillDetail(ctx, skillID)
 }
 
 func (s *Service) listSkillVersionsPersistent(ctx context.Context, skillID uuid.UUID) ([]VersionSummary, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skillVersions == nil {
 		return nil, ErrUnavailable
 	}
-	return s.repo.ListSkillVersions(ctx, skillID)
+	return s.skillVersions.ListSkillVersions(ctx, skillID)
 }
 
 func (s *Service) createSkillBundlePersistent(ctx context.Context, input CreateSkillBundleInput) (SkillDetail, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return SkillDetail{}, ErrUnavailable
 	}
 	if err := s.ensureProjectExists(ctx, input.ProjectID); err != nil {
@@ -238,7 +238,7 @@ func (s *Service) createSkillBundlePersistent(ctx context.Context, input CreateS
 	if createdBy == "" {
 		createdBy = "user:manual"
 	}
-	return s.repo.CreateSkillBundle(ctx, input, bundle, enabled, createdBy, time.Now().UTC())
+	return s.skills.CreateSkillBundle(ctx, input, bundle, enabled, createdBy, time.Now().UTC())
 }
 
 func (s *Service) updateSkillBundlePersistent(ctx context.Context, input UpdateSkillBundleInput) (SkillDetail, error) {
@@ -276,7 +276,7 @@ func (s *Service) updateSkillBundlePersistent(ctx context.Context, input UpdateS
 	if err != nil {
 		return SkillDetail{}, err
 	}
-	return s.repo.UpdateSkillBundle(ctx, record.skill.ID, bundle, time.Now().UTC())
+	return s.skills.UpdateSkillBundle(ctx, record.skill.ID, bundle, time.Now().UTC())
 }
 
 func (s *Service) deleteSkillPersistent(ctx context.Context, skillID uuid.UUID) error {
@@ -284,7 +284,7 @@ func (s *Service) deleteSkillPersistent(ctx context.Context, skillID uuid.UUID) 
 	if err != nil {
 		return err
 	}
-	return s.repo.DeleteSkill(ctx, record.skill.ID, time.Now().UTC())
+	return s.skills.DeleteSkill(ctx, record.skill.ID, time.Now().UTC())
 }
 
 func (s *Service) setSkillEnabledPersistent(ctx context.Context, skillID uuid.UUID, enabled bool) (SkillDetail, error) {
@@ -292,7 +292,7 @@ func (s *Service) setSkillEnabledPersistent(ctx context.Context, skillID uuid.UU
 	if err != nil {
 		return SkillDetail{}, err
 	}
-	return s.repo.SetSkillEnabled(ctx, record.skill.ID, enabled, time.Now().UTC())
+	return s.skills.SetSkillEnabled(ctx, record.skill.ID, enabled, time.Now().UTC())
 }
 
 func (s *Service) resolveSkillRecordForWorkflowBindingsPersistent(
@@ -303,13 +303,13 @@ func (s *Service) resolveSkillRecordForWorkflowBindingsPersistent(
 	if err != nil {
 		return resolvedSkillRecord{}, nil, err
 	}
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return resolvedSkillRecord{}, nil, ErrUnavailable
 	}
 
 	var projectID uuid.UUID
 	for index, workflowID := range workflowIDs {
-		workflowItem, err := s.repo.Get(ctx, workflowID)
+		workflowItem, err := s.workflows.Get(ctx, workflowID)
 		if err != nil {
 			return resolvedSkillRecord{}, nil, err
 		}
@@ -333,10 +333,10 @@ func (s *Service) resolveSkillRecordPersistent(
 	ctx context.Context,
 	skillID uuid.UUID,
 ) (resolvedSkillRecord, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return resolvedSkillRecord{}, ErrUnavailable
 	}
-	item, err := s.repo.Skill(ctx, skillID)
+	item, err := s.skills.Skill(ctx, skillID)
 	if err != nil {
 		return resolvedSkillRecord{}, err
 	}
@@ -348,10 +348,10 @@ func (s *Service) resolveSkillRecordInProjectPersistent(
 	projectID uuid.UUID,
 	skillID uuid.UUID,
 ) (resolvedSkillRecord, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skills == nil {
 		return resolvedSkillRecord{}, ErrUnavailable
 	}
-	item, err := s.repo.SkillInProject(ctx, projectID, skillID)
+	item, err := s.skills.SkillInProject(ctx, projectID, skillID)
 	if err != nil {
 		return resolvedSkillRecord{}, err
 	}
@@ -362,14 +362,14 @@ func (s *Service) buildSkillDetailPersistent(ctx context.Context, record resolve
 	if record.skill.ID == uuid.Nil {
 		return SkillDetail{}, ErrSkillNotFound
 	}
-	return s.repo.SkillDetail(ctx, record.skill.ID)
+	return s.skills.SkillDetail(ctx, record.skill.ID)
 }
 
 func (s *Service) skillVersionFilesPersistent(ctx context.Context, versionID uuid.UUID) ([]SkillBundleFile, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.skillVersions == nil {
 		return nil, ErrUnavailable
 	}
-	return s.repo.SkillVersionFiles(ctx, versionID)
+	return s.skillVersions.SkillVersionFiles(ctx, versionID)
 }
 
 func (s *Service) resolveInjectedSkillNamesPersistent(
@@ -377,14 +377,14 @@ func (s *Service) resolveInjectedSkillNamesPersistent(
 	projectID uuid.UUID,
 	workflowID *uuid.UUID,
 ) ([]string, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflowSkills == nil {
 		return nil, ErrUnavailable
 	}
-	return s.repo.ResolveInjectedSkillNames(ctx, projectID, workflowID)
+	return s.workflowSkills.ResolveInjectedSkillNames(ctx, projectID, workflowID)
 }
 
 func (s *Service) refreshSkillsPersistent(ctx context.Context, input RefreshSkillsInput) (RefreshSkillsResult, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflowSkills == nil {
 		return RefreshSkillsResult{}, ErrUnavailable
 	}
 	if err := s.ensureProjectExists(ctx, input.ProjectID); err != nil {
@@ -442,7 +442,7 @@ func (s *Service) updateWorkflowSkillsPersistent(
 	input UpdateWorkflowSkillsInput,
 	bind bool,
 ) (HarnessDocument, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil || s.workflowSkills == nil {
 		return HarnessDocument{}, ErrUnavailable
 	}
 
@@ -454,7 +454,7 @@ func (s *Service) updateWorkflowSkillsPersistent(
 		return HarnessDocument{}, fmt.Errorf("%w: skills must not be empty", ErrSkillInvalid)
 	}
 
-	workflowItem, err := s.repo.Get(ctx, input.WorkflowID)
+	workflowItem, err := s.workflows.Get(ctx, input.WorkflowID)
 	if err != nil {
 		return HarnessDocument{}, err
 	}
@@ -513,7 +513,7 @@ func (s *Service) updateWorkflowSkillsPersistent(
 		}
 	}
 
-	if _, err := s.repo.ApplyWorkflowSkillBindings(
+	if _, err := s.workflowSkills.ApplyWorkflowSkillBindings(
 		ctx,
 		workflowItem.ID,
 		pendingSkillIDs,
@@ -540,14 +540,47 @@ type UpdateInput = domain.UpdateInput
 
 type UpdateHarnessInput = domain.UpdateHarnessInput
 
-type Service struct {
-	repo            Repository
-	logger          *slog.Logger
-	repoRoot        string
-	builtinSkillsMu sync.Mutex
+type ServiceDependencies struct {
+	Validators       ProjectValidationRepository
+	Workflows        WorkflowRepository
+	WorkflowVersions WorkflowVersionRepository
+	Skills           SkillRepository
+	SkillVersions    SkillVersionRepository
+	WorkflowSkills   WorkflowSkillBindingRepository
+	RuntimeSnapshots WorkflowRuntimeSnapshotReader
+	HarnessTemplates HarnessTemplateDataBuilder
 }
 
-func NewService(repo Repository, logger *slog.Logger, repoRoot string) (*Service, error) {
+type serviceDependencySource interface {
+	ProjectValidationRepository
+	WorkflowRepository
+	WorkflowVersionRepository
+	SkillRepository
+	SkillVersionRepository
+	WorkflowSkillBindingRepository
+	WorkflowRuntimeSnapshotReader
+	HarnessTemplateDataBuilder
+}
+
+type Service struct {
+	validators       ProjectValidationRepository
+	workflows        WorkflowRepository
+	workflowVersions WorkflowVersionRepository
+	skills           SkillRepository
+	skillVersions    SkillVersionRepository
+	workflowSkills   WorkflowSkillBindingRepository
+	runtimeSnapshots WorkflowRuntimeSnapshotReader
+	harnessTemplates HarnessTemplateDataBuilder
+	logger           *slog.Logger
+	repoRoot         string
+	builtinSkillsMu  sync.Mutex
+}
+
+func NewService(source serviceDependencySource, logger *slog.Logger, repoRoot string) (*Service, error) {
+	return NewServiceWithDependencies(serviceDependenciesFromSource(source), logger, repoRoot)
+}
+
+func NewServiceWithDependencies(deps ServiceDependencies, logger *slog.Logger, repoRoot string) (*Service, error) {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 	}
@@ -564,12 +597,35 @@ func NewService(repo Repository, logger *slog.Logger, repoRoot string) (*Service
 	}
 
 	service := &Service{
-		repo:     repo,
-		logger:   logger.With("component", "workflow-service"),
-		repoRoot: repoRoot,
+		validators:       deps.Validators,
+		workflows:        deps.Workflows,
+		workflowVersions: deps.WorkflowVersions,
+		skills:           deps.Skills,
+		skillVersions:    deps.SkillVersions,
+		workflowSkills:   deps.WorkflowSkills,
+		runtimeSnapshots: deps.RuntimeSnapshots,
+		harnessTemplates: deps.HarnessTemplates,
+		logger:           logger.With("component", "workflow-service"),
+		repoRoot:         repoRoot,
 	}
 
 	return service, nil
+}
+
+func serviceDependenciesFromSource(source serviceDependencySource) ServiceDependencies {
+	if source == nil {
+		return ServiceDependencies{}
+	}
+	return ServiceDependencies{
+		Validators:       source,
+		Workflows:        source,
+		WorkflowVersions: source,
+		Skills:           source,
+		SkillVersions:    source,
+		WorkflowSkills:   source,
+		RuntimeSnapshots: source,
+		HarnessTemplates: source,
+	}
 }
 
 func (s *Service) Close() error {
@@ -627,21 +683,21 @@ func (s *Service) logHookConfigValidationFailure(operation string, projectID uui
 }
 
 func (s *Service) List(ctx context.Context, projectID uuid.UUID) ([]Workflow, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return nil, ErrUnavailable
 	}
 	if err := s.ensureProjectExists(ctx, projectID); err != nil {
 		return nil, err
 	}
-	return s.repo.List(ctx, projectID)
+	return s.workflows.List(ctx, projectID)
 }
 
 func (s *Service) Get(ctx context.Context, workflowID uuid.UUID) (WorkflowDetail, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return WorkflowDetail{}, ErrUnavailable
 	}
 
-	item, err := s.repo.Get(ctx, workflowID)
+	item, err := s.workflows.Get(ctx, workflowID)
 	if err != nil {
 		return WorkflowDetail{}, err
 	}
@@ -657,7 +713,7 @@ func (s *Service) Get(ctx context.Context, workflowID uuid.UUID) (WorkflowDetail
 }
 
 func (s *Service) Create(ctx context.Context, input CreateInput) (WorkflowDetail, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return WorkflowDetail{}, ErrUnavailable
 	}
 
@@ -711,7 +767,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (WorkflowDetail
 		}
 	}
 
-	item, err := s.repo.Create(ctx, Workflow{
+	item, err := s.workflows.Create(ctx, Workflow{
 		ID:                  workflowID,
 		ProjectID:           input.ProjectID,
 		AgentID:             &input.AgentID,
@@ -744,11 +800,11 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (WorkflowDetail
 }
 
 func (s *Service) Update(ctx context.Context, input UpdateInput) (WorkflowDetail, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return WorkflowDetail{}, ErrUnavailable
 	}
 
-	current, err := s.repo.Get(ctx, input.WorkflowID)
+	current, err := s.workflows.Get(ctx, input.WorkflowID)
 	if err != nil {
 		return WorkflowDetail{}, err
 	}
@@ -850,7 +906,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (WorkflowDetail
 		next.StallTimeoutMinutes = input.StallTimeoutMinutes.Value
 	}
 
-	item, err := s.repo.Update(ctx, next)
+	item, err := s.workflows.Update(ctx, next)
 	if err != nil {
 		return WorkflowDetail{}, s.mapWorkflowWriteError("update workflow", err)
 	}
@@ -867,18 +923,18 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (WorkflowDetail
 }
 
 func (s *Service) Delete(ctx context.Context, workflowID uuid.UUID) (Workflow, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return Workflow{}, ErrUnavailable
 	}
-	return s.repo.Delete(ctx, workflowID)
+	return s.workflows.Delete(ctx, workflowID)
 }
 
 func (s *Service) GetHarness(ctx context.Context, workflowID uuid.UUID) (HarnessDocument, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil {
 		return HarnessDocument{}, ErrUnavailable
 	}
 
-	item, err := s.repo.Get(ctx, workflowID)
+	item, err := s.workflows.Get(ctx, workflowID)
 	if err != nil {
 		return HarnessDocument{}, err
 	}
@@ -896,14 +952,14 @@ func (s *Service) GetHarness(ctx context.Context, workflowID uuid.UUID) (Harness
 }
 
 func (s *Service) UpdateHarness(ctx context.Context, input UpdateHarnessInput) (HarnessDocument, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil || s.workflowVersions == nil {
 		return HarnessDocument{}, ErrUnavailable
 	}
 	if err := validateHarnessForSave(input.Content); err != nil {
 		return HarnessDocument{}, err
 	}
 
-	item, err := s.repo.Get(ctx, input.WorkflowID)
+	item, err := s.workflows.Get(ctx, input.WorkflowID)
 	if err != nil {
 		return HarnessDocument{}, err
 	}
@@ -945,7 +1001,7 @@ func (s *Service) UpdateHarness(ctx context.Context, input UpdateHarnessInput) (
 		}
 	}
 
-	updated, err := s.repo.PublishWorkflowVersion(
+	updated, err := s.workflowVersions.PublishWorkflowVersion(
 		ctx,
 		item.ID,
 		sanitizedContent,
@@ -968,24 +1024,24 @@ func (s *Service) UpdateHarness(ctx context.Context, input UpdateHarnessInput) (
 }
 
 func (s *Service) ensureProjectExists(ctx context.Context, projectID uuid.UUID) error {
-	if s == nil || s.repo == nil {
+	if s == nil || s.validators == nil {
 		return ErrUnavailable
 	}
-	return s.repo.EnsureProjectExists(ctx, projectID)
+	return s.validators.EnsureProjectExists(ctx, projectID)
 }
 
 func (s *Service) ensureStatusBindingsBelongToProject(ctx context.Context, projectID uuid.UUID, statusIDs StatusBindingSet) error {
-	if s == nil || s.repo == nil {
+	if s == nil || s.validators == nil {
 		return ErrUnavailable
 	}
-	return s.repo.EnsureStatusBindingsBelongToProject(ctx, projectID, statusIDs.IDs())
+	return s.validators.EnsureStatusBindingsBelongToProject(ctx, projectID, statusIDs.IDs())
 }
 
 func (s *Service) ensureAgentBelongsToProject(ctx context.Context, projectID uuid.UUID, agentID uuid.UUID) error {
-	if s == nil || s.repo == nil {
+	if s == nil || s.validators == nil {
 		return ErrUnavailable
 	}
-	return s.repo.EnsureAgentBelongsToProject(ctx, projectID, agentID)
+	return s.validators.EnsureAgentBelongsToProject(ctx, projectID, agentID)
 }
 
 func (s *Service) resolveCreateHarnessPath(name string, rawPath *string) (string, error) {
@@ -1002,10 +1058,10 @@ func (s *Service) ensureHarnessPathAvailable(
 	harnessPath string,
 	excludeWorkflowID uuid.UUID,
 ) error {
-	if s == nil || s.repo == nil {
+	if s == nil || s.validators == nil {
 		return ErrUnavailable
 	}
-	return s.repo.EnsureHarnessPathAvailable(ctx, projectID, harnessPath, excludeWorkflowID)
+	return s.validators.EnsureHarnessPathAvailable(ctx, projectID, harnessPath, excludeWorkflowID)
 }
 
 func (s *Service) resolveHarnessContent(
@@ -1023,11 +1079,15 @@ func (s *Service) resolveHarnessContent(
 		return rawContent, nil
 	}
 
-	pickupStatuses, err := s.repo.StatusNames(ctx, pickupStatusIDs.IDs())
+	if s == nil || s.validators == nil {
+		return "", ErrUnavailable
+	}
+
+	pickupStatuses, err := s.validators.StatusNames(ctx, pickupStatusIDs.IDs())
 	if err != nil {
 		return "", err
 	}
-	finishStatuses, err := s.repo.StatusNames(ctx, finishStatusIDs.IDs())
+	finishStatuses, err := s.validators.StatusNames(ctx, finishStatusIDs.IDs())
 	if err != nil {
 		return "", err
 	}
@@ -1199,33 +1259,33 @@ func slugify(raw string) string {
 }
 
 func (s *Service) ResolveRuntimeSnapshot(ctx context.Context, workflowID uuid.UUID) (RuntimeSnapshot, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil || s.runtimeSnapshots == nil {
 		return RuntimeSnapshot{}, ErrUnavailable
 	}
 
-	workflowItem, err := s.repo.Get(ctx, workflowID)
+	workflowItem, err := s.workflows.Get(ctx, workflowID)
 	if err != nil {
 		return RuntimeSnapshot{}, err
 	}
 	if err := s.ensureBuiltinSkills(ctx, workflowItem.ProjectID); err != nil {
 		return RuntimeSnapshot{}, err
 	}
-	return s.repo.ResolveRuntimeSnapshot(ctx, workflowID)
+	return s.runtimeSnapshots.ResolveRuntimeSnapshot(ctx, workflowID)
 }
 
 func (s *Service) ResolveRecordedRuntimeSnapshot(ctx context.Context, input ResolveRecordedRuntimeSnapshotInput) (RuntimeSnapshot, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil || s.runtimeSnapshots == nil {
 		return RuntimeSnapshot{}, ErrUnavailable
 	}
 
-	workflowItem, err := s.repo.Get(ctx, input.WorkflowID)
+	workflowItem, err := s.workflows.Get(ctx, input.WorkflowID)
 	if err != nil {
 		return RuntimeSnapshot{}, err
 	}
 	if err := s.ensureBuiltinSkills(ctx, workflowItem.ProjectID); err != nil {
 		return RuntimeSnapshot{}, err
 	}
-	return s.repo.ResolveRecordedRuntimeSnapshot(ctx, input)
+	return s.runtimeSnapshots.ResolveRecordedRuntimeSnapshot(ctx, input)
 }
 
 func (s *Service) runtimeSkillFiles(ctx context.Context, versionID uuid.UUID) ([]RuntimeSkillFileSnapshot, error) {
@@ -1245,17 +1305,17 @@ func (s *Service) runtimeSkillFiles(ctx context.Context, versionID uuid.UUID) ([
 }
 
 func (s *Service) BuildHarnessTemplateData(ctx context.Context, input BuildHarnessTemplateDataInput) (HarnessTemplateData, error) {
-	if s == nil || s.repo == nil {
+	if s == nil || s.workflows == nil || s.harnessTemplates == nil {
 		return HarnessTemplateData{}, ErrUnavailable
 	}
-	workflowItem, err := s.repo.Get(ctx, input.WorkflowID)
+	workflowItem, err := s.workflows.Get(ctx, input.WorkflowID)
 	if err != nil {
 		return HarnessTemplateData{}, err
 	}
 	if err := s.ensureBuiltinSkills(ctx, workflowItem.ProjectID); err != nil {
 		return HarnessTemplateData{}, err
 	}
-	data, err := s.repo.BuildHarnessTemplateData(ctx, input)
+	data, err := s.harnessTemplates.BuildHarnessTemplateData(ctx, input)
 	if err != nil {
 		return HarnessTemplateData{}, err
 	}

--- a/internal/workflow/service_dependencies_test.go
+++ b/internal/workflow/service_dependencies_test.go
@@ -1,0 +1,453 @@
+package workflow
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	domain "github.com/BetterAndBetterII/openase/internal/domain/workflow"
+	"github.com/google/uuid"
+)
+
+type stubProjectValidationRepository struct {
+	ensureProjectExists                 func(context.Context, uuid.UUID) error
+	ensureAgentBelongsToProject         func(context.Context, uuid.UUID, uuid.UUID) error
+	ensureStatusBindingsBelongToProject func(context.Context, uuid.UUID, []uuid.UUID) error
+	ensureHarnessPathAvailable          func(context.Context, uuid.UUID, string, uuid.UUID) error
+	statusNames                         func(context.Context, []uuid.UUID) ([]string, error)
+}
+
+func (s stubProjectValidationRepository) EnsureProjectExists(ctx context.Context, projectID uuid.UUID) error {
+	if s.ensureProjectExists != nil {
+		return s.ensureProjectExists(ctx, projectID)
+	}
+	return nil
+}
+
+func (s stubProjectValidationRepository) EnsureAgentBelongsToProject(ctx context.Context, projectID uuid.UUID, agentID uuid.UUID) error {
+	if s.ensureAgentBelongsToProject != nil {
+		return s.ensureAgentBelongsToProject(ctx, projectID, agentID)
+	}
+	return nil
+}
+
+func (s stubProjectValidationRepository) EnsureStatusBindingsBelongToProject(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	if s.ensureStatusBindingsBelongToProject != nil {
+		return s.ensureStatusBindingsBelongToProject(ctx, projectID, statusIDs)
+	}
+	return nil
+}
+
+func (s stubProjectValidationRepository) EnsureHarnessPathAvailable(
+	ctx context.Context,
+	projectID uuid.UUID,
+	harnessPath string,
+	excludeWorkflowID uuid.UUID,
+) error {
+	if s.ensureHarnessPathAvailable != nil {
+		return s.ensureHarnessPathAvailable(ctx, projectID, harnessPath, excludeWorkflowID)
+	}
+	return nil
+}
+
+func (s stubProjectValidationRepository) StatusNames(ctx context.Context, statusIDs []uuid.UUID) ([]string, error) {
+	if s.statusNames != nil {
+		return s.statusNames(ctx, statusIDs)
+	}
+	return nil, nil
+}
+
+type stubWorkflowRepository struct {
+	list   func(context.Context, uuid.UUID) ([]domain.Workflow, error)
+	get    func(context.Context, uuid.UUID) (domain.Workflow, error)
+	create func(context.Context, domain.Workflow, string, string) (domain.Workflow, error)
+	update func(context.Context, domain.Workflow) (domain.Workflow, error)
+	delete func(context.Context, uuid.UUID) (domain.Workflow, error)
+}
+
+func (s stubWorkflowRepository) List(ctx context.Context, projectID uuid.UUID) ([]domain.Workflow, error) {
+	if s.list != nil {
+		return s.list(ctx, projectID)
+	}
+	return nil, nil
+}
+
+func (s stubWorkflowRepository) Get(ctx context.Context, workflowID uuid.UUID) (domain.Workflow, error) {
+	if s.get != nil {
+		return s.get(ctx, workflowID)
+	}
+	return domain.Workflow{}, nil
+}
+
+func (s stubWorkflowRepository) Create(ctx context.Context, workflow domain.Workflow, harnessContent string, createdBy string) (domain.Workflow, error) {
+	if s.create != nil {
+		return s.create(ctx, workflow, harnessContent, createdBy)
+	}
+	return domain.Workflow{}, nil
+}
+
+func (s stubWorkflowRepository) Update(ctx context.Context, workflow domain.Workflow) (domain.Workflow, error) {
+	if s.update != nil {
+		return s.update(ctx, workflow)
+	}
+	return domain.Workflow{}, nil
+}
+
+func (s stubWorkflowRepository) Delete(ctx context.Context, workflowID uuid.UUID) (domain.Workflow, error) {
+	if s.delete != nil {
+		return s.delete(ctx, workflowID)
+	}
+	return domain.Workflow{}, nil
+}
+
+type stubWorkflowVersionRepository struct {
+	current  func(context.Context, uuid.UUID) (domain.WorkflowVersionRecord, error)
+	recorded func(context.Context, uuid.UUID, *uuid.UUID) (domain.WorkflowVersionRecord, error)
+	list     func(context.Context, uuid.UUID) ([]domain.VersionSummary, error)
+	publish  func(context.Context, uuid.UUID, string, string) (domain.Workflow, error)
+}
+
+func (s stubWorkflowVersionRepository) CurrentWorkflowVersion(ctx context.Context, workflowID uuid.UUID) (domain.WorkflowVersionRecord, error) {
+	if s.current != nil {
+		return s.current(ctx, workflowID)
+	}
+	return domain.WorkflowVersionRecord{}, nil
+}
+
+func (s stubWorkflowVersionRepository) RecordedWorkflowVersion(
+	ctx context.Context,
+	workflowID uuid.UUID,
+	workflowVersionID *uuid.UUID,
+) (domain.WorkflowVersionRecord, error) {
+	if s.recorded != nil {
+		return s.recorded(ctx, workflowID, workflowVersionID)
+	}
+	return domain.WorkflowVersionRecord{}, nil
+}
+
+func (s stubWorkflowVersionRepository) ListWorkflowVersions(ctx context.Context, workflowID uuid.UUID) ([]domain.VersionSummary, error) {
+	if s.list != nil {
+		return s.list(ctx, workflowID)
+	}
+	return nil, nil
+}
+
+func (s stubWorkflowVersionRepository) PublishWorkflowVersion(
+	ctx context.Context,
+	workflowID uuid.UUID,
+	content string,
+	createdBy string,
+) (domain.Workflow, error) {
+	if s.publish != nil {
+		return s.publish(ctx, workflowID, content, createdBy)
+	}
+	return domain.Workflow{}, nil
+}
+
+type stubSkillRepository struct {
+	ensureBuiltinSkills func(context.Context, uuid.UUID, time.Time, []domain.SkillBundle) error
+	listSkills          func(context.Context, uuid.UUID) ([]domain.Skill, error)
+	skill               func(context.Context, uuid.UUID) (domain.SkillRecord, error)
+	skillInProject      func(context.Context, uuid.UUID, uuid.UUID) (domain.SkillRecord, error)
+	skillByName         func(context.Context, uuid.UUID, string) (domain.SkillRecord, error)
+	skillDetail         func(context.Context, uuid.UUID) (domain.SkillDetail, error)
+	createBundle        func(context.Context, domain.CreateSkillBundleInput, domain.SkillBundle, bool, string, time.Time) (domain.SkillDetail, error)
+	updateBundle        func(context.Context, uuid.UUID, domain.SkillBundle, time.Time) (domain.SkillDetail, error)
+	deleteSkill         func(context.Context, uuid.UUID, time.Time) error
+	setSkillEnabled     func(context.Context, uuid.UUID, bool, time.Time) (domain.SkillDetail, error)
+}
+
+func (s stubSkillRepository) EnsureBuiltinSkills(ctx context.Context, projectID uuid.UUID, now time.Time, bundles []domain.SkillBundle) error {
+	if s.ensureBuiltinSkills != nil {
+		return s.ensureBuiltinSkills(ctx, projectID, now, bundles)
+	}
+	return nil
+}
+
+func (s stubSkillRepository) ListSkills(ctx context.Context, projectID uuid.UUID) ([]domain.Skill, error) {
+	if s.listSkills != nil {
+		return s.listSkills(ctx, projectID)
+	}
+	return nil, nil
+}
+
+func (s stubSkillRepository) Skill(ctx context.Context, skillID uuid.UUID) (domain.SkillRecord, error) {
+	if s.skill != nil {
+		return s.skill(ctx, skillID)
+	}
+	return domain.SkillRecord{}, nil
+}
+
+func (s stubSkillRepository) SkillInProject(ctx context.Context, projectID uuid.UUID, skillID uuid.UUID) (domain.SkillRecord, error) {
+	if s.skillInProject != nil {
+		return s.skillInProject(ctx, projectID, skillID)
+	}
+	return domain.SkillRecord{}, nil
+}
+
+func (s stubSkillRepository) SkillByName(ctx context.Context, projectID uuid.UUID, name string) (domain.SkillRecord, error) {
+	if s.skillByName != nil {
+		return s.skillByName(ctx, projectID, name)
+	}
+	return domain.SkillRecord{}, nil
+}
+
+func (s stubSkillRepository) SkillDetail(ctx context.Context, skillID uuid.UUID) (domain.SkillDetail, error) {
+	if s.skillDetail != nil {
+		return s.skillDetail(ctx, skillID)
+	}
+	return domain.SkillDetail{}, nil
+}
+
+func (s stubSkillRepository) CreateSkillBundle(
+	ctx context.Context,
+	input domain.CreateSkillBundleInput,
+	bundle domain.SkillBundle,
+	enabled bool,
+	createdBy string,
+	now time.Time,
+) (domain.SkillDetail, error) {
+	if s.createBundle != nil {
+		return s.createBundle(ctx, input, bundle, enabled, createdBy, now)
+	}
+	return domain.SkillDetail{}, nil
+}
+
+func (s stubSkillRepository) UpdateSkillBundle(
+	ctx context.Context,
+	skillID uuid.UUID,
+	bundle domain.SkillBundle,
+	updatedAt time.Time,
+) (domain.SkillDetail, error) {
+	if s.updateBundle != nil {
+		return s.updateBundle(ctx, skillID, bundle, updatedAt)
+	}
+	return domain.SkillDetail{}, nil
+}
+
+func (s stubSkillRepository) DeleteSkill(ctx context.Context, skillID uuid.UUID, deletedAt time.Time) error {
+	if s.deleteSkill != nil {
+		return s.deleteSkill(ctx, skillID, deletedAt)
+	}
+	return nil
+}
+
+func (s stubSkillRepository) SetSkillEnabled(ctx context.Context, skillID uuid.UUID, enabled bool, updatedAt time.Time) (domain.SkillDetail, error) {
+	if s.setSkillEnabled != nil {
+		return s.setSkillEnabled(ctx, skillID, enabled, updatedAt)
+	}
+	return domain.SkillDetail{}, nil
+}
+
+type stubRuntimeSnapshotReader struct {
+	resolve         func(context.Context, uuid.UUID) (domain.RuntimeSnapshot, error)
+	resolveRecorded func(context.Context, domain.ResolveRecordedRuntimeSnapshotInput) (domain.RuntimeSnapshot, error)
+}
+
+func (s stubRuntimeSnapshotReader) ResolveRuntimeSnapshot(ctx context.Context, workflowID uuid.UUID) (domain.RuntimeSnapshot, error) {
+	if s.resolve != nil {
+		return s.resolve(ctx, workflowID)
+	}
+	return domain.RuntimeSnapshot{}, nil
+}
+
+func (s stubRuntimeSnapshotReader) ResolveRecordedRuntimeSnapshot(
+	ctx context.Context,
+	input domain.ResolveRecordedRuntimeSnapshotInput,
+) (domain.RuntimeSnapshot, error) {
+	if s.resolveRecorded != nil {
+		return s.resolveRecorded(ctx, input)
+	}
+	return domain.RuntimeSnapshot{}, nil
+}
+
+type stubHarnessTemplateDataBuilder struct {
+	build func(context.Context, domain.BuildHarnessTemplateDataInput) (domain.HarnessTemplateData, error)
+}
+
+func (s stubHarnessTemplateDataBuilder) BuildHarnessTemplateData(
+	ctx context.Context,
+	input domain.BuildHarnessTemplateDataInput,
+) (domain.HarnessTemplateData, error) {
+	if s.build != nil {
+		return s.build(ctx, input)
+	}
+	return domain.HarnessTemplateData{}, nil
+}
+
+func newServiceWithTestDependencies(t *testing.T, deps ServiceDependencies) *Service {
+	t.Helper()
+
+	service, err := NewServiceWithDependencies(
+		deps,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewServiceWithDependencies() error = %v", err)
+	}
+	return service
+}
+
+func TestServiceListWorkflowVersionsUsesWorkflowVersionSlice(t *testing.T) {
+	workflowID := uuid.New()
+	want := []domain.VersionSummary{{ID: uuid.New(), Version: 3, CreatedBy: "tester"}}
+	service := newServiceWithTestDependencies(t, ServiceDependencies{
+		WorkflowVersions: stubWorkflowVersionRepository{
+			list: func(_ context.Context, gotWorkflowID uuid.UUID) ([]domain.VersionSummary, error) {
+				if gotWorkflowID != workflowID {
+					t.Fatalf("workflow id = %s, want %s", gotWorkflowID, workflowID)
+				}
+				return want, nil
+			},
+		},
+	})
+
+	got, err := service.ListWorkflowVersions(context.Background(), workflowID)
+	if err != nil {
+		t.Fatalf("ListWorkflowVersions() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Version != want[0].Version || got[0].CreatedBy != want[0].CreatedBy {
+		t.Fatalf("ListWorkflowVersions() = %+v", got)
+	}
+}
+
+func TestServiceListSkillsUsesSkillSlices(t *testing.T) {
+	projectID := uuid.New()
+	want := []domain.Skill{{ID: uuid.New(), Name: "skill-one"}}
+	service := newServiceWithTestDependencies(t, ServiceDependencies{
+		Validators: stubProjectValidationRepository{
+			ensureProjectExists: func(_ context.Context, gotProjectID uuid.UUID) error {
+				if gotProjectID != projectID {
+					t.Fatalf("project id = %s, want %s", gotProjectID, projectID)
+				}
+				return nil
+			},
+		},
+		Skills: stubSkillRepository{
+			ensureBuiltinSkills: func(_ context.Context, gotProjectID uuid.UUID, _ time.Time, bundles []domain.SkillBundle) error {
+				if gotProjectID != projectID {
+					t.Fatalf("builtin project id = %s, want %s", gotProjectID, projectID)
+				}
+				if len(bundles) == 0 {
+					t.Fatal("expected builtin skill bundles")
+				}
+				return nil
+			},
+			listSkills: func(_ context.Context, gotProjectID uuid.UUID) ([]domain.Skill, error) {
+				if gotProjectID != projectID {
+					t.Fatalf("list project id = %s, want %s", gotProjectID, projectID)
+				}
+				return want, nil
+			},
+		},
+	})
+
+	got, err := service.ListSkills(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("ListSkills() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "skill-one" {
+		t.Fatalf("ListSkills() = %+v", got)
+	}
+}
+
+func TestServiceResolveRuntimeSnapshotUsesRuntimeSlices(t *testing.T) {
+	workflowID := uuid.New()
+	projectID := uuid.New()
+	want := domain.RuntimeSnapshot{
+		Workflow: domain.RuntimeWorkflowSnapshot{WorkflowID: workflowID, Version: 2},
+	}
+	service := newServiceWithTestDependencies(t, ServiceDependencies{
+		Workflows: stubWorkflowRepository{
+			get: func(_ context.Context, gotWorkflowID uuid.UUID) (domain.Workflow, error) {
+				if gotWorkflowID != workflowID {
+					t.Fatalf("workflow id = %s, want %s", gotWorkflowID, workflowID)
+				}
+				return domain.Workflow{ID: workflowID, ProjectID: projectID}, nil
+			},
+		},
+		Skills: stubSkillRepository{
+			ensureBuiltinSkills: func(_ context.Context, gotProjectID uuid.UUID, _ time.Time, bundles []domain.SkillBundle) error {
+				if gotProjectID != projectID {
+					t.Fatalf("builtin project id = %s, want %s", gotProjectID, projectID)
+				}
+				if len(bundles) == 0 {
+					t.Fatal("expected builtin skill bundles")
+				}
+				return nil
+			},
+		},
+		RuntimeSnapshots: stubRuntimeSnapshotReader{
+			resolve: func(_ context.Context, gotWorkflowID uuid.UUID) (domain.RuntimeSnapshot, error) {
+				if gotWorkflowID != workflowID {
+					t.Fatalf("runtime workflow id = %s, want %s", gotWorkflowID, workflowID)
+				}
+				return want, nil
+			},
+		},
+	})
+
+	got, err := service.ResolveRuntimeSnapshot(context.Background(), workflowID)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeSnapshot() error = %v", err)
+	}
+	if got.Workflow.WorkflowID != want.Workflow.WorkflowID || got.Workflow.Version != want.Workflow.Version {
+		t.Fatalf("ResolveRuntimeSnapshot() = %+v", got)
+	}
+}
+
+func TestServiceBuildHarnessTemplateDataUsesTemplateSlices(t *testing.T) {
+	workflowID := uuid.New()
+	projectID := uuid.New()
+	ticketID := uuid.New()
+	want := domain.HarnessTemplateData{
+		Ticket:   domain.HarnessTicketData{ID: ticketID.String(), Identifier: "ASE-9"},
+		Workflow: domain.HarnessWorkflowData{Name: "coding"},
+	}
+	service := newServiceWithTestDependencies(t, ServiceDependencies{
+		Workflows: stubWorkflowRepository{
+			get: func(_ context.Context, gotWorkflowID uuid.UUID) (domain.Workflow, error) {
+				if gotWorkflowID != workflowID {
+					t.Fatalf("workflow id = %s, want %s", gotWorkflowID, workflowID)
+				}
+				return domain.Workflow{ID: workflowID, ProjectID: projectID}, nil
+			},
+		},
+		Skills: stubSkillRepository{
+			ensureBuiltinSkills: func(_ context.Context, gotProjectID uuid.UUID, _ time.Time, bundles []domain.SkillBundle) error {
+				if gotProjectID != projectID {
+					t.Fatalf("builtin project id = %s, want %s", gotProjectID, projectID)
+				}
+				if len(bundles) == 0 {
+					t.Fatal("expected builtin skill bundles")
+				}
+				return nil
+			},
+		},
+		HarnessTemplates: stubHarnessTemplateDataBuilder{
+			build: func(_ context.Context, input domain.BuildHarnessTemplateDataInput) (domain.HarnessTemplateData, error) {
+				if input.WorkflowID != workflowID {
+					t.Fatalf("builder workflow id = %s, want %s", input.WorkflowID, workflowID)
+				}
+				if input.TicketID != ticketID {
+					t.Fatalf("builder ticket id = %s, want %s", input.TicketID, ticketID)
+				}
+				return want, nil
+			},
+		},
+	})
+
+	got, err := service.BuildHarnessTemplateData(context.Background(), BuildHarnessTemplateDataInput{
+		WorkflowID: workflowID,
+		TicketID:   ticketID,
+	})
+	if err != nil {
+		t.Fatalf("BuildHarnessTemplateData() error = %v", err)
+	}
+	if got.Ticket.Identifier != want.Ticket.Identifier || got.Workflow.Name != want.Workflow.Name {
+		t.Fatalf("BuildHarnessTemplateData() = %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- split `internal/workflow` persistence ports into focused workflow, skill, binding, runtime, template, and validation interfaces
- refactor `workflow.Service` to store those dependency slices explicitly instead of routing everything through one omnibus repo field
- add compile-time contract assertions plus focused dependency-slice tests for workflow, skill, runtime snapshot, and harness template paths

## Validation
- `python3 scripts/ci/architecture_guard.py`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/workflow ./internal/repo/workflow -count=1`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest PATH=/home/yuzhong/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run 'Test.*(Workflow|Skill)' -count=1`
- `OPENASE_PGTEST_SHARED_ROOT=/home/yuzhong/.cache/openase/pgtest .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- `internal/repo/workflow/repo.go` still contains multiple capability implementations in one concrete type; this PR narrows the contracts and service wiring first without changing persistence behavior.

Closes #491.
