### PR TITLE
refactor(machines): redesign IA and interaction model [ASE-30]

### DIFF
--- a/web/src/lib/features/machines/components/machine-editor-guidance.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-guidance.svelte
@@ -12,12 +12,68 @@
     normalizeConnectionMode,
   } from '../model'
   import type { MachineConnectionMode, MachineDraft, MachineItem } from '../types'
+  import { Monitor, Terminal, ArrowLeftRight, Radio, Check } from '@lucide/svelte'
 
-  const connectionModeOptions: MachineConnectionMode[] = [
-    'local',
-    'ssh',
-    'ws_reverse',
-    'ws_listener',
+  const connectionModeOptions: {
+    mode: MachineConnectionMode
+    icon: typeof Monitor
+    shortDesc: string
+    keyTrait: string
+  }[] = [
+    {
+      mode: 'local',
+      icon: Monitor,
+      shortDesc: 'Same host as the control plane',
+      keyTrait: 'No network overhead',
+    },
+    {
+      mode: 'ssh',
+      icon: Terminal,
+      shortDesc: 'Direct SSH to a remote host',
+      keyTrait: 'Key-based auth',
+    },
+    {
+      mode: 'ws_reverse',
+      icon: ArrowLeftRight,
+      shortDesc: 'Daemon connects back to OpenASE',
+      keyTrait: 'NAT-friendly',
+    },
+    {
+      mode: 'ws_listener',
+      icon: Radio,
+      shortDesc: 'OpenASE connects to machine endpoint',
+      keyTrait: 'Custom endpoint',
+    },
+  ]
+
+  const comparisonRows: { label: string; values: Record<MachineConnectionMode, string> }[] = [
+    {
+      label: 'Auth',
+      values: {
+        local: 'None',
+        ssh: 'SSH key',
+        ws_reverse: 'Daemon token',
+        ws_listener: 'Endpoint TLS',
+      },
+    },
+    {
+      label: 'Firewall',
+      values: {
+        local: 'N/A',
+        ssh: 'Inbound 22',
+        ws_reverse: 'Outbound only',
+        ws_listener: 'Inbound WS',
+      },
+    },
+    {
+      label: 'Setup',
+      values: {
+        local: 'Automatic',
+        ssh: 'Key + user',
+        ws_reverse: 'Install daemon',
+        ws_listener: 'Run listener',
+      },
+    },
   ]
 
   let {
@@ -37,73 +93,120 @@
   const detectedOSLabel = $derived(machineDetectedOSLabel(machine?.detected_os))
   const detectedArchLabel = $derived(machineDetectedArchLabel(machine?.detected_arch))
   const detectionSummary = $derived(machineDetectionMessage(machine, draft))
+
+  let showComparison = $state(false)
 </script>
 
 <section class="space-y-4">
-  <div>
-    <h3 class="text-foreground text-sm font-semibold">Connection mode</h3>
-    <p class="text-muted-foreground mt-1 text-xs">
-      Choose how OpenASE reaches this machine before filling transport-specific fields.
-    </p>
+  <div class="flex items-center justify-between">
+    <div>
+      <h3 class="text-foreground text-sm font-semibold">Connection mode</h3>
+      <p class="text-muted-foreground mt-0.5 text-xs">
+        How OpenASE reaches this machine.
+      </p>
+    </div>
+    <button
+      type="button"
+      class="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline transition-colors"
+      onclick={() => (showComparison = !showComparison)}
+    >
+      {showComparison ? 'Hide comparison' : 'Compare modes'}
+    </button>
   </div>
 
   <div class="grid gap-2 sm:grid-cols-2">
-    {#each connectionModeOptions as option (option)}
+    {#each connectionModeOptions as option (option.mode)}
+      {@const Icon = option.icon}
+      {@const selected = connectionMode === option.mode}
       <button
         type="button"
         class={cn(
-          'border-border bg-card hover:bg-muted/50 rounded-xl border px-4 py-3 text-left transition-colors',
-          connectionMode === option && 'border-primary bg-primary/6 ring-primary/20 ring-1',
+          'border-border bg-card hover:bg-muted/50 group relative rounded-lg border px-3.5 py-3 text-left transition-all',
+          selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
         )}
-        data-testid={`machine-connection-mode-${option}`}
-        onclick={() => onSelectMode?.(option)}
+        data-testid={`machine-connection-mode-${option.mode}`}
+        onclick={() => onSelectMode?.(option.mode)}
       >
-        <div class="flex items-center justify-between gap-2">
-          <span class="text-foreground text-sm font-medium">
-            {machineConnectionModeLabel(option)}
-          </span>
-          {#if connectionMode === option}
-            <Badge variant="secondary" class="text-[10px]">Selected</Badge>
-          {/if}
+        <div class="flex items-start gap-3">
+          <div class={cn(
+            'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
+            selected ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
+          )}>
+            <Icon class="size-4" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <span class="text-foreground text-sm font-medium">
+                {machineConnectionModeLabel(option.mode)}
+              </span>
+              {#if selected}
+                <Check class="text-primary size-3.5" />
+              {/if}
+            </div>
+            <p class="text-muted-foreground mt-0.5 text-xs leading-relaxed">{option.shortDesc}</p>
+            <span class="text-muted-foreground mt-1 inline-block text-[10px] font-medium uppercase tracking-wider">
+              {option.keyTrait}
+            </span>
+          </div>
         </div>
-        <p class="text-muted-foreground mt-1 text-xs">{machineModeGuide(option).summary}</p>
       </button>
     {/each}
   </div>
 
-  <div class="border-border bg-card space-y-3 rounded-xl border px-4 py-4">
+  {#if showComparison}
+    <div class="border-border bg-card overflow-hidden rounded-lg border">
+      <table class="w-full text-xs">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="text-muted-foreground px-3 py-2 text-left font-medium"></th>
+            {#each connectionModeOptions as option (option.mode)}
+              <th class={cn(
+                'px-3 py-2 text-center font-medium',
+                connectionMode === option.mode ? 'text-primary' : 'text-muted-foreground',
+              )}>
+                {machineConnectionModeLabel(option.mode)}
+              </th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each comparisonRows as row (row.label)}
+            <tr class="border-border/60 border-b last:border-0">
+              <td class="text-muted-foreground px-3 py-2 font-medium">{row.label}</td>
+              {#each connectionModeOptions as option (option.mode)}
+                <td class={cn(
+                  'px-3 py-2 text-center',
+                  connectionMode === option.mode ? 'text-foreground font-medium' : 'text-muted-foreground',
+                )}>
+                  {row.values[option.mode]}
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+
+  <div class="border-border bg-card rounded-lg border px-3.5 py-3">
     <div class="flex flex-wrap items-center gap-2">
-      <Badge variant="outline">{modeGuide.label}</Badge>
-      <Badge variant="outline" class={detectionBadgeClass}>
+      <Badge variant="outline" class="text-[10px]">{modeGuide.label}</Badge>
+      <Badge variant="outline" class={cn('text-[10px]', detectionBadgeClass)}>
         {detectionStatusLabel}
       </Badge>
-      <Badge variant="secondary">{detectedOSLabel}</Badge>
-      <Badge variant="secondary">{detectedArchLabel}</Badge>
+      <Badge variant="secondary" class="text-[10px]">{detectedOSLabel}</Badge>
+      <Badge variant="secondary" class="text-[10px]">{detectedArchLabel}</Badge>
     </div>
-
-    <p class="text-foreground text-sm">{detectionSummary}</p>
-
-    <dl class="grid gap-3 text-sm md:grid-cols-2">
+    <p class="text-muted-foreground mt-2 text-xs leading-relaxed">{detectionSummary}</p>
+    <div class="mt-2 grid gap-x-6 gap-y-1 text-xs sm:grid-cols-2">
       <div>
-        <dt class="text-muted-foreground text-[11px] tracking-[0.12em] uppercase">
-          Required fields
-        </dt>
-        <dd class="text-foreground mt-1">{modeGuide.requiredFields}</dd>
+        <span class="text-muted-foreground">Required:</span>
+        <span class="text-foreground ml-1">{modeGuide.requiredFields}</span>
       </div>
       <div>
-        <dt class="text-muted-foreground text-[11px] tracking-[0.12em] uppercase">Install path</dt>
-        <dd class="text-foreground mt-1">{modeGuide.installMethod}</dd>
+        <span class="text-muted-foreground">Test:</span>
+        <span class="text-foreground ml-1">{modeGuide.testSemantics}</span>
       </div>
-      <div>
-        <dt class="text-muted-foreground text-[11px] tracking-[0.12em] uppercase">
-          Connection test
-        </dt>
-        <dd class="text-foreground mt-1">{modeGuide.testSemantics}</dd>
-      </div>
-      <div>
-        <dt class="text-muted-foreground text-[11px] tracking-[0.12em] uppercase">Common errors</dt>
-        <dd class="text-foreground mt-1">{modeGuide.commonErrors}</dd>
-      </div>
-    </dl>
+    </div>
   </div>
 </section>

--- a/web/src/lib/features/machines/components/machine-editor-sheet.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-sheet.svelte
@@ -2,6 +2,7 @@
   import { Badge } from '$ui/badge'
   import { Button } from '$ui/button'
   import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '$ui/sheet'
+  import * as Tabs from '$ui/tabs'
   import MachineEditor from './machine-editor.svelte'
   import MachineHealthPanel from './machine-health-panel.svelte'
   import { machineStatusBadgeClass, machineStatusDescription, machineStatusLabel } from '../model'
@@ -41,6 +42,8 @@
     onRefreshHealth?: () => void
     onSave?: () => void
   } = $props()
+
+  let activeTab = $state('configuration')
 </script>
 
 <Sheet bind:open>
@@ -49,12 +52,12 @@
     class="flex w-full flex-col gap-0 p-0 sm:max-w-2xl"
     data-testid="machine-editor-sheet"
   >
-    <SheetHeader class="border-border border-b px-6 py-5 text-left">
+    <SheetHeader class="border-border space-y-0 border-b px-6 py-4 text-left">
       <div class="flex items-start justify-between gap-4 pr-10">
-        <div class="min-w-0 space-y-2">
+        <div class="min-w-0 space-y-1.5">
           <div class="flex flex-wrap items-center gap-2">
-            <SheetTitle>
-              {mode === 'create' ? 'Register machine' : (machine?.name ?? 'Machine configuration')}
+            <SheetTitle class="text-base">
+              {mode === 'create' ? 'Register machine' : (machine?.name ?? 'Machine')}
             </SheetTitle>
             {#if mode === 'edit' && machine}
               <Badge variant="outline" class={machineStatusBadgeClass(machine.status)}>
@@ -62,49 +65,45 @@
               </Badge>
             {/if}
           </div>
-          <SheetDescription>
+          <SheetDescription class="text-xs">
             {#if mode === 'create'}
-              Create a new machine record. Runtime status is assigned by the system after monitoring
-              starts.
+              Define identity, transport, and workspace for a new machine.
             {:else}
-              Edit SSH access and runtime configuration. System status remains read-only.
+              {machineStatusDescription(machine?.status ?? '')}
             {/if}
           </SheetDescription>
-          {#if mode === 'edit' && machine}
-            <p class="text-muted-foreground text-xs">{machineStatusDescription(machine.status)}</p>
-          {/if}
         </div>
 
         <Button size="sm" onclick={onSave} disabled={saving} data-testid="machine-save-button">
-          {saving ? 'Saving…' : mode === 'create' ? 'Create machine' : 'Save changes'}
+          {saving ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
         </Button>
       </div>
+
+      {#if mode === 'edit' && machine}
+        <div class="pt-3">
+          <Tabs.Root bind:value={activeTab}>
+            <Tabs.List variant="line">
+              <Tabs.Trigger value="configuration">Configuration</Tabs.Trigger>
+              <Tabs.Trigger value="health">Health & Status</Tabs.Trigger>
+            </Tabs.List>
+          </Tabs.Root>
+        </div>
+      {/if}
     </SheetHeader>
 
-    <div class="flex-1 overflow-y-auto px-6 py-6">
-      <div class="space-y-6">
+    <div class="flex-1 overflow-y-auto px-6 py-5">
+      {#if mode === 'create' || activeTab === 'configuration'}
         <MachineEditor {mode} {machine} {draft} {onDraftChange} />
-
-        {#if mode === 'edit' && machine}
-          <section class="border-border space-y-4 border-t pt-6">
-            <div>
-              <h3 class="text-foreground text-sm font-semibold">Runtime context</h3>
-              <p class="text-muted-foreground mt-1 text-xs">
-                Multi-level machine checks, runtime readiness, and the latest connection test
-                output.
-              </p>
-            </div>
-            <MachineHealthPanel
-              {machine}
-              {snapshot}
-              {probe}
-              loading={loadingHealth}
-              refreshing={refreshingHealth}
-              onRefresh={onRefreshHealth}
-            />
-          </section>
-        {/if}
-      </div>
+      {:else if activeTab === 'health' && machine}
+        <MachineHealthPanel
+          {machine}
+          {snapshot}
+          {probe}
+          loading={loadingHealth}
+          refreshing={refreshingHealth}
+          onRefresh={onRefreshHealth}
+        />
+      {/if}
     </div>
   </SheetContent>
 </Sheet>

--- a/web/src/lib/features/machines/components/machine-editor.svelte
+++ b/web/src/lib/features/machines/components/machine-editor.svelte
@@ -53,28 +53,21 @@
   }
 </script>
 
-<div class="space-y-6">
+<div class="space-y-5">
   {#if localMachine}
-    <div class="border-info/40 bg-info/10 rounded-xl border px-4 py-3 text-sm">
-      The local machine keeps its reserved identity. Name, host, and SSH settings stay fixed.
+    <div class="border-info/40 bg-info/10 rounded-lg border px-3.5 py-2.5 text-xs">
+      Local machine identity is reserved. Name, host, and SSH settings are fixed.
     </div>
   {/if}
 
   <MachineEditorGuidance {machine} {draft} onSelectMode={updateMode} />
 
-  <section class="space-y-4">
-    <div>
-      <h3 class="text-foreground text-sm font-semibold">Identity & network</h3>
-      <p class="text-muted-foreground mt-1 text-xs">
-        {mode === 'create'
-          ? 'Register the machine identity, transport, and advertised endpoint.'
-          : 'Update how OpenASE addresses this machine.'}
-      </p>
-    </div>
+  <section class="border-border space-y-3 border-t pt-5">
+    <h3 class="text-foreground text-sm font-semibold">Identity & network</h3>
 
-    <div class="grid gap-4 md:grid-cols-3">
-      <div class="space-y-2">
-        <Label for="machine-name">Name</Label>
+    <div class="grid gap-3 md:grid-cols-3">
+      <div class="space-y-1.5">
+        <Label for="machine-name" class="text-xs">Name</Label>
         <Input
           id="machine-name"
           value={draft.name}
@@ -83,8 +76,8 @@
         />
       </div>
 
-      <div class="space-y-2">
-        <Label for="machine-host">Host</Label>
+      <div class="space-y-1.5">
+        <Label for="machine-host" class="text-xs">Host</Label>
         <Input
           id="machine-host"
           value={draft.host}
@@ -93,8 +86,8 @@
         />
       </div>
 
-      <div class="space-y-2">
-        <Label for="machine-port">Port</Label>
+      <div class="space-y-1.5">
+        <Label for="machine-port" class="text-xs">Port</Label>
         <Input
           id="machine-port"
           value={draft.port}
@@ -104,34 +97,28 @@
     </div>
 
     {#if connectionMode === 'ws_listener'}
-      <div class="space-y-2">
-        <Label for="machine-advertised-endpoint">Advertised listener endpoint</Label>
+      <div class="space-y-1.5">
+        <Label for="machine-advertised-endpoint" class="text-xs">Listener endpoint</Label>
         <Input
           id="machine-advertised-endpoint"
           value={draft.advertisedEndpoint}
           placeholder="wss://builder.example.com/openase"
           oninput={(event) => updateField('advertisedEndpoint', event)}
         />
-        <p class="text-muted-foreground text-xs">
-          OpenASE connects to this machine-advertised websocket endpoint when running listener mode
-          checks.
+        <p class="text-muted-foreground text-[11px]">
+          WebSocket endpoint OpenASE connects to in listener mode.
         </p>
       </div>
     {/if}
   </section>
 
-  <section class="border-border space-y-4 border-t pt-6">
-    <div>
-      <h3 class="text-foreground text-sm font-semibold">Transport credentials</h3>
-      <p class="text-muted-foreground mt-1 text-xs">
-        Only the fields required by the selected connection mode stay editable here.
-      </p>
-    </div>
+  <section class="border-border space-y-3 border-t pt-5">
+    <h3 class="text-foreground text-sm font-semibold">Transport credentials</h3>
 
     {#if connectionMode === 'ssh'}
-      <div class="grid gap-4 md:grid-cols-2">
-        <div class="space-y-2">
-          <Label for="machine-ssh-user">SSH user</Label>
+      <div class="grid gap-3 md:grid-cols-2">
+        <div class="space-y-1.5">
+          <Label for="machine-ssh-user" class="text-xs">SSH user</Label>
           <Input
             id="machine-ssh-user"
             value={draft.sshUser}
@@ -140,8 +127,8 @@
           />
         </div>
 
-        <div class="space-y-2">
-          <Label for="machine-ssh-key">SSH key path</Label>
+        <div class="space-y-1.5">
+          <Label for="machine-ssh-key" class="text-xs">SSH key path</Label>
           <Input
             id="machine-ssh-key"
             value={draft.sshKeyPath}
@@ -151,48 +138,35 @@
         </div>
       </div>
     {:else}
-      <div class="border-border bg-card text-muted-foreground rounded-xl border px-4 py-3 text-sm">
+      <p class="text-muted-foreground text-xs">
         {#if connectionMode === 'local'}
-          Local machines do not use SSH credentials.
+          Local transport — no credentials needed.
         {:else if connectionMode === 'ws_reverse'}
-          Reverse websocket machines rely on daemon registration instead of SSH credentials.
+          Reverse WebSocket — daemon handles registration.
         {:else}
-          Listener websocket machines use the advertised endpoint instead of SSH credentials.
+          Listener WebSocket — uses the advertised endpoint above.
         {/if}
-      </div>
+      </p>
     {/if}
   </section>
 
-  <section class="border-border space-y-4 border-t pt-6">
-    <div>
-      <h3 class="text-foreground text-sm font-semibold">Workspace & runtime</h3>
-      <p class="text-muted-foreground mt-1 text-xs">
-        Configure where OpenASE writes workspaces and which CLI path the machine should use.
-      </p>
-    </div>
+  <section class="border-border space-y-3 border-t pt-5">
+    <h3 class="text-foreground text-sm font-semibold">Workspace & runtime</h3>
 
-    <div class="border-border bg-card space-y-3 rounded-xl border px-4 py-4">
+    <div class="border-border bg-card flex items-center gap-3 rounded-lg border px-3.5 py-2.5">
       <div class="flex flex-wrap items-center gap-2">
-        <Badge variant="outline">Recommended root</Badge>
-        <code class="bg-muted text-foreground rounded px-2 py-1 text-xs">
+        <code class="bg-muted text-foreground rounded px-1.5 py-0.5 text-xs">
           {workspaceRootRecommendation.value}
         </code>
         <Badge variant="outline" class={workspaceStateTone[workspaceRootState.kind]}>
           {workspaceRootState.label}
         </Badge>
       </div>
-      <p class="text-muted-foreground text-xs">{workspaceRootRecommendation.reason}</p>
-      {#if localMachine}
-        <p class="text-muted-foreground text-xs">
-          The local `~/.openase/workspace` shortcut stays readable in the UI and is expanded to an
-          absolute path when saved.
-        </p>
-      {/if}
     </div>
 
-    <div class="grid gap-4 md:grid-cols-2">
-      <div class="space-y-2">
-        <Label for="machine-workspace-root">Workspace root</Label>
+    <div class="grid gap-3 md:grid-cols-2">
+      <div class="space-y-1.5">
+        <Label for="machine-workspace-root" class="text-xs">Workspace root</Label>
         <Input
           id="machine-workspace-root"
           value={draft.workspaceRoot}
@@ -201,8 +175,8 @@
         />
       </div>
 
-      <div class="space-y-2">
-        <Label for="machine-agent-cli">Agent CLI path</Label>
+      <div class="space-y-1.5">
+        <Label for="machine-agent-cli" class="text-xs">Agent CLI path</Label>
         <Input
           id="machine-agent-cli"
           value={draft.agentCLIPath}
@@ -212,47 +186,42 @@
     </div>
   </section>
 
-  <section class="border-border space-y-4 border-t pt-6">
-    <div>
-      <h3 class="text-foreground text-sm font-semibold">Metadata</h3>
-      <p class="text-muted-foreground mt-1 text-xs">
-        Optional notes, routing labels, and environment variables.
-      </p>
-    </div>
+  <section class="border-border space-y-3 border-t pt-5">
+    <h3 class="text-foreground text-sm font-semibold">Metadata</h3>
 
-    <div class="space-y-2">
-      <Label for="machine-description">Description</Label>
+    <div class="space-y-1.5">
+      <Label for="machine-description" class="text-xs">Description</Label>
       <Textarea
         id="machine-description"
         value={draft.description}
-        rows={3}
+        rows={2}
         oninput={(event) => updateField('description', event)}
       />
     </div>
 
-    <div class="grid gap-4 lg:grid-cols-2">
-      <div class="space-y-2">
-        <Label for="machine-labels">Labels</Label>
+    <div class="grid gap-3 lg:grid-cols-2">
+      <div class="space-y-1.5">
+        <Label for="machine-labels" class="text-xs">Labels</Label>
         <Textarea
           id="machine-labels"
           value={draft.labels}
-          rows={4}
+          rows={3}
           placeholder="gpu, a100, europe-west"
           oninput={(event) => updateField('labels', event)}
         />
-        <p class="text-muted-foreground text-xs">Separate labels with commas or new lines.</p>
+        <p class="text-muted-foreground text-[11px]">Comma or newline separated.</p>
       </div>
 
-      <div class="space-y-2">
-        <Label for="machine-env-vars">Environment variables</Label>
+      <div class="space-y-1.5">
+        <Label for="machine-env-vars" class="text-xs">Environment variables</Label>
         <Textarea
           id="machine-env-vars"
           value={draft.envVars}
-          rows={4}
+          rows={3}
           placeholder={`CUDA_VISIBLE_DEVICES=0\nOPENASE_AGENT_HOME=/srv/openase`}
           oninput={(event) => updateField('envVars', event)}
         />
-        <p class="text-muted-foreground text-xs">One `KEY=VALUE` pair per line.</p>
+        <p class="text-muted-foreground text-[11px]">One KEY=VALUE per line.</p>
       </div>
     </div>
   </section>

--- a/web/src/lib/features/machines/components/machine-row-card.svelte
+++ b/web/src/lib/features/machines/components/machine-row-card.svelte
@@ -61,7 +61,7 @@
 <article
   data-testid={`machine-card-${machine.id}`}
   class={cn(
-    'border-border bg-card hover:bg-muted/20 hover-lift rounded-2xl border p-4 transition-colors',
+    'border-border bg-card hover:bg-muted/20 hover-lift rounded-lg border p-4 transition-colors',
     selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
   )}
 >

--- a/web/src/lib/features/machines/components/machine-workspace.svelte
+++ b/web/src/lib/features/machines/components/machine-workspace.svelte
@@ -101,7 +101,7 @@
   {:else if state === 'loading' || loading}
     <div class="space-y-3">
       {#each { length: 3 } as _}
-        <div class="border-border bg-card rounded-2xl border p-4">
+        <div class="border-border bg-card rounded-lg border p-4">
           <div class="grid gap-4 xl:grid-cols-[minmax(0,18rem)_minmax(0,1fr)_auto] xl:items-start">
             <div class="space-y-3">
               <div class="space-y-1.5">

--- a/web/src/lib/features/machines/components/machines-page-body.svelte
+++ b/web/src/lib/features/machines/components/machines-page-body.svelte
@@ -89,7 +89,7 @@
 
 <PageScaffold
   title="Machines"
-  description="Configure machine access and inspect system-managed runtime health."
+  description="Machine access, transport configuration, and runtime health."
   variant="workspace"
   {actions}
 >

--- a/web/src/lib/features/machines/components/machines-page.test.ts
+++ b/web/src/lib/features/machines/components/machines-page.test.ts
@@ -162,7 +162,7 @@ describe('MachinesPage cache behavior', () => {
     expect(await firstRender.findByTestId('machine-card-machine-1')).toBeTruthy()
 
     await openMachineDetails('machine-1')
-    expect(await firstRender.findByText('Health snapshot')).toBeTruthy()
+    expect(await firstRender.findByTestId('machine-editor-sheet')).toBeTruthy()
 
     expect(loadMachines).toHaveBeenCalledTimes(1)
     expect(loadMachineSnapshot).toHaveBeenCalledTimes(1)
@@ -171,7 +171,7 @@ describe('MachinesPage cache behavior', () => {
 
     const secondRender = render(MachinesPage)
     expect(await secondRender.findByTestId('machine-card-machine-1')).toBeTruthy()
-    expect(await secondRender.findByText('Health snapshot')).toBeTruthy()
+    expect(await secondRender.findByTestId('machine-editor-sheet')).toBeTruthy()
 
     expect(loadMachines).toHaveBeenCalledTimes(1)
     expect(loadMachineSnapshot).toHaveBeenCalledTimes(1)
@@ -182,7 +182,7 @@ describe('MachinesPage cache behavior', () => {
     expect(await firstRender.findByTestId('machine-card-machine-1')).toBeTruthy()
 
     await openMachineDetails('machine-1')
-    expect(await firstRender.findByText('Health snapshot')).toBeTruthy()
+    expect(await firstRender.findByTestId('machine-editor-sheet')).toBeTruthy()
     firstRender.unmount()
 
     markMachinesPageCacheDirty('org-1')
@@ -194,7 +194,7 @@ describe('MachinesPage cache behavior', () => {
 
     const secondRender = render(MachinesPage)
     expect(await secondRender.findByTestId('machine-card-machine-1')).toBeTruthy()
-    expect(await secondRender.findByText('Health snapshot')).toBeTruthy()
+    expect(await secondRender.findByTestId('machine-editor-sheet')).toBeTruthy()
 
     expect(loadMachines).toHaveBeenCalledTimes(2)
     expect(loadMachineSnapshot).toHaveBeenCalledTimes(1)
@@ -218,9 +218,24 @@ describe('MachinesPage cache behavior', () => {
 
     expect(await view.findByText('Connection mode')).toBeTruthy()
     expect(view.getAllByText('Detected amd64 on Linux.').length).toBeGreaterThan(0)
-    expect(view.getByText('Recommended root')).toBeTruthy()
     expect(view.getByText('/home/ubuntu/.openase/workspace')).toBeTruthy()
     expect(view.getByText('Keeping the saved workspace root override.')).toBeTruthy()
+  })
+
+  it('separates configuration and health into tabs for existing machines', async () => {
+    const view = render(MachinesPage)
+    expect(await view.findByTestId('machine-card-machine-1')).toBeTruthy()
+
+    await openMachineDetails('machine-1')
+
+    expect(await view.findByText('Configuration')).toBeTruthy()
+    expect(view.getByText('Health & Status')).toBeTruthy()
+
+    expect(view.getByText('Connection mode')).toBeTruthy()
+
+    await fireEvent.click(view.getByText('Health & Status'))
+
+    expect(await view.findByText('Health snapshot')).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Summary
- Redesign mode selector with icon-based cards, key trait labels, and a toggleable comparison table for side-by-side mode evaluation
- Separate editor sheet into Configuration and Health & Status tabs to reduce cognitive load
- Tighten copy across all editor sections for better information density
- Refine card shapes for a cleaner, more polished look
- Update and add tests for the new tabbed layout

## Test plan
- [x] `svelte-check` passes with 0 errors
- [x] All 11 machines feature tests pass (3 files)
- [x] Full suite: 20 pre-existing failures unrelated to machines; 0 new failures
- [ ] Manual review of mode selector UX and tab navigation

ASE-30

🤖 Generated with [Claude Code](https://claude.com/claude-code)