### PR TITLE
feat(ui): unify color picker around curated status palettes (ASE-54)

### DIFF
--- a/web/src/lib/components/ui/color-picker/color-picker.svelte
+++ b/web/src/lib/components/ui/color-picker/color-picker.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { cn } from '$lib/utils'
+  import * as Popover from '$ui/popover'
+  import { ChevronDown, ChevronUp, Pipette, Check } from '@lucide/svelte'
+  import { quickPicks, expandedPalette, isPresetColor } from './palette'
+
+  let {
+    value = $bindable('#3b82f6'),
+    disabled = false,
+    class: className,
+  }: {
+    value?: string
+    disabled?: boolean
+    class?: string
+  } = $props()
+
+  let open = $state(false)
+  let showExpanded = $state(false)
+  let showCustom = $state(false)
+  let hexInput = $state('')
+
+  const normalizedValue = $derived(value.toLowerCase())
+
+  function selectColor(hex: string) {
+    value = hex.toLowerCase()
+    open = false
+    showExpanded = false
+    showCustom = false
+  }
+
+  function handleHexInput() {
+    const cleaned = hexInput.trim().toLowerCase()
+    const hex = cleaned.startsWith('#') ? cleaned : `#${cleaned}`
+    if (/^#[0-9a-f]{6}$/.test(hex)) {
+      value = hex
+      open = false
+      showExpanded = false
+      showCustom = false
+    }
+  }
+
+  function handleNativeColorChange(e: Event) {
+    const target = e.target as HTMLInputElement
+    value = target.value.toLowerCase()
+  }
+
+  function handleKeydown(hex: string, e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      selectColor(hex)
+    }
+  }
+
+  function handleOpen(isOpen: boolean) {
+    open = isOpen
+    if (isOpen) {
+      hexInput = normalizedValue
+      showExpanded = false
+      showCustom = false
+    }
+  }
+</script>
+
+<Popover.Root onOpenChange={handleOpen} bind:open>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        {disabled}
+        class={cn(
+          'focus-visible:ring-ring inline-flex size-8 shrink-0 items-center justify-center rounded border border-transparent ring-1 ring-black/10 transition-shadow hover:ring-black/20 focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        style="background-color: {normalizedValue}"
+        aria-label="Pick a color: {normalizedValue}"
+      >
+        <span class="sr-only">{normalizedValue}</span>
+      </button>
+    {/snippet}
+  </Popover.Trigger>
+
+  <Popover.Content class="w-auto min-w-0 p-3" align="start" sideOffset={6}>
+    <!-- Quick picks (always visible) -->
+    <div class="flex items-center gap-1.5" role="radiogroup" aria-label="Quick color picks">
+      {#each quickPicks as hex (hex)}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={normalizedValue === hex}
+          aria-label={hex}
+          class={cn(
+            'focus-visible:ring-ring relative size-7 shrink-0 rounded transition-all focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none',
+            normalizedValue === hex
+              ? 'ring-foreground ring-offset-background scale-110 ring-2 ring-offset-2'
+              : 'ring-1 ring-black/10 hover:scale-105 hover:ring-black/25',
+          )}
+          style="background-color: {hex}"
+          onclick={() => selectColor(hex)}
+          onkeydown={(e) => handleKeydown(hex, e)}
+        >
+          {#if normalizedValue === hex}
+            <Check
+              class="absolute inset-0 m-auto size-3.5 drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]"
+              style="color: white"
+              strokeWidth={3}
+            />
+          {/if}
+        </button>
+      {/each}
+    </div>
+
+    <!-- Expand / collapse toggle -->
+    <button
+      type="button"
+      class="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring mt-2.5 flex w-full items-center justify-center gap-1 rounded py-1 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      onclick={() => {
+        showExpanded = !showExpanded
+        if (!showExpanded) showCustom = false
+      }}
+      aria-expanded={showExpanded}
+    >
+      {#if showExpanded}
+        <ChevronUp class="size-3" />
+        Fewer colors
+      {:else}
+        <ChevronDown class="size-3" />
+        More colors
+      {/if}
+    </button>
+
+    <!-- Expanded preset grid (5 × 8) -->
+    {#if showExpanded}
+      <div class="mt-2 space-y-1" role="radiogroup" aria-label="Extended color palette">
+        {#each expandedPalette as row, rowIdx (rowIdx)}
+          <div class="flex items-center gap-1">
+            {#each row as hex (hex)}
+              <button
+                type="button"
+                role="radio"
+                aria-checked={normalizedValue === hex}
+                aria-label={hex}
+                class={cn(
+                  'focus-visible:ring-ring relative size-6 shrink-0 rounded-sm transition-all focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none',
+                  normalizedValue === hex
+                    ? 'ring-foreground ring-offset-background z-10 scale-110 ring-2 ring-offset-1'
+                    : 'ring-1 ring-black/8 hover:z-10 hover:scale-110 hover:ring-black/20',
+                )}
+                style="background-color: {hex}"
+                onclick={() => selectColor(hex)}
+                onkeydown={(e) => handleKeydown(hex, e)}
+              >
+                {#if normalizedValue === hex}
+                  <Check
+                    class="absolute inset-0 m-auto size-3 drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]"
+                    style="color: white"
+                    strokeWidth={3}
+                  />
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/each}
+      </div>
+
+      <!-- Custom color section -->
+      <div class="border-border mt-2.5 border-t pt-2.5">
+        {#if !showCustom}
+          <button
+            type="button"
+            class="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex w-full items-center justify-center gap-1.5 rounded py-1 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            onclick={() => {
+              showCustom = true
+              hexInput = normalizedValue
+            }}
+          >
+            <Pipette class="size-3" />
+            Custom color
+          </button>
+        {:else}
+          <div class="flex items-center gap-2">
+            <div
+              class="size-7 shrink-0 rounded ring-1 ring-black/10"
+              style="background-color: {normalizedValue}"
+            ></div>
+            <div class="relative flex-1">
+              <input
+                type="text"
+                bind:value={hexInput}
+                maxlength={7}
+                placeholder="#000000"
+                class="border-input bg-background text-foreground placeholder:text-muted-foreground focus-visible:ring-ring h-7 w-full rounded border px-2 font-mono text-xs focus-visible:ring-2 focus-visible:outline-none"
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') handleHexInput()
+                }}
+              />
+            </div>
+            <label
+              class="border-input bg-background hover:bg-muted inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded border transition-colors"
+            >
+              <Pipette class="text-muted-foreground size-3.5" />
+              <input
+                type="color"
+                value={normalizedValue}
+                class="sr-only"
+                onchange={handleNativeColorChange}
+              />
+            </label>
+            <button
+              type="button"
+              class="bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring h-7 shrink-0 rounded px-2.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              onclick={handleHexInput}
+            >
+              Apply
+            </button>
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Show current value if it's not a preset -->
+    {#if !isPresetColor(normalizedValue) && !showCustom}
+      <div class="border-border mt-2 flex items-center gap-1.5 border-t pt-2">
+        <div
+          class="ring-foreground ring-offset-background size-5 shrink-0 rounded-sm ring-2 ring-offset-1"
+          style="background-color: {normalizedValue}"
+        ></div>
+        <span class="text-muted-foreground font-mono text-xs">{normalizedValue}</span>
+      </div>
+    {/if}
+  </Popover.Content>
+</Popover.Root>

--- a/web/src/lib/components/ui/color-picker/index.ts
+++ b/web/src/lib/components/ui/color-picker/index.ts
@@ -1,0 +1,4 @@
+import Root from './color-picker.svelte'
+
+export { Root, Root as ColorPicker }
+export { quickPicks, expandedPalette, allPresets, allColors, isPresetColor } from './palette'

--- a/web/src/lib/components/ui/color-picker/palette.ts
+++ b/web/src/lib/components/ui/color-picker/palette.ts
@@ -1,0 +1,47 @@
+/**
+ * Curated status color palette.
+ *
+ * - `quickPicks`: 5 high-distinctiveness colors for one-click status assignment.
+ * - `expanded`: 40 colors (5 rows × 8 columns) organized by hue family,
+ *   suitable for scanning and quick selection.
+ *
+ * All values are lowercase 6-digit hex (#rrggbb).
+ */
+
+/** Five default quick-pick colors — high contrast, semantically distinct. */
+export const quickPicks: string[] = [
+  '#3b82f6', // blue — info / default / in-progress
+  '#22c55e', // green — success / done / active
+  '#f59e0b', // amber — warning / review / pending
+  '#ef4444', // red — error / blocked / urgent
+  '#8b5cf6', // violet — special / custom / deferred
+]
+
+/**
+ * 40 curated preset colors arranged as 5 rows × 8 columns.
+ * Each row follows a hue family from cool to warm, with subtle
+ * lightness/saturation variation across columns.
+ */
+export const expandedPalette: string[][] = [
+  // Row 1: Blues & Cyans
+  ['#1e3a5f', '#1e40af', '#2563eb', '#3b82f6', '#60a5fa', '#06b6d4', '#22d3ee', '#67e8f9'],
+  // Row 2: Greens & Teals
+  ['#15803d', '#16a34a', '#22c55e', '#4ade80', '#86efac', '#0d9488', '#14b8a6', '#5eead4'],
+  // Row 3: Yellows & Oranges
+  ['#92400e', '#b45309', '#d97706', '#f59e0b', '#fbbf24', '#ea580c', '#f97316', '#fb923c'],
+  // Row 4: Reds & Pinks
+  ['#991b1b', '#dc2626', '#ef4444', '#f87171', '#fca5a5', '#be185d', '#ec4899', '#f9a8d4'],
+  // Row 5: Purples & Neutrals
+  ['#4c1d95', '#6d28d9', '#8b5cf6', '#a78bfa', '#c4b5fd', '#475569', '#64748b', '#94a3b8'],
+]
+
+/** Flat list of all 40 expanded colors for lookup. */
+export const allPresets: string[] = expandedPalette.flat()
+
+/** All selectable preset colors (quick picks + expanded). */
+export const allColors: string[] = [...new Set([...quickPicks, ...allPresets])]
+
+/** Check if a hex value is one of the curated presets. */
+export function isPresetColor(hex: string): boolean {
+  return allColors.includes(hex.toLowerCase())
+}

--- a/web/src/lib/features/settings/components/status-settings-create.svelte
+++ b/web/src/lib/features/settings/components/status-settings-create.svelte
@@ -2,6 +2,7 @@
   import { ticketStatusStageOptions, type TicketStatusStage } from '$lib/features/statuses/public'
   import { Button } from '$ui/button'
   import { Checkbox } from '$ui/checkbox'
+  import { ColorPicker } from '$ui/color-picker'
   import { Input } from '$ui/input'
   import * as Select from '$ui/select'
   import Plus from '@lucide/svelte/icons/plus'
@@ -48,11 +49,7 @@
 
   <div class="space-y-3">
     <div class="flex items-center gap-2">
-      <input
-        type="color"
-        bind:value={color}
-        class="size-9 shrink-0 rounded border-0 bg-transparent p-0"
-      />
+      <ColorPicker bind:value={color} />
       <Input bind:value={name} class="h-9 flex-1 text-sm" placeholder="New status name" />
       <Select.Root
         type="single"

--- a/web/src/lib/features/settings/components/status-settings-list.svelte
+++ b/web/src/lib/features/settings/components/status-settings-list.svelte
@@ -8,6 +8,7 @@
   import { StageIcon } from '$lib/features/board/public'
   import { cn } from '$lib/utils'
   import { Button } from '$ui/button'
+  import { ColorPicker } from '$ui/color-picker'
   import { Input } from '$ui/input'
   import { Plus, X } from '@lucide/svelte'
   import StatusSettingsRow from './status-settings-row.svelte'
@@ -224,11 +225,7 @@
 
           {#if addingInStage === group.stage}
             <div class="bg-muted/30 mt-1 flex items-center gap-2 rounded-md px-2 py-2">
-              <input
-                type="color"
-                bind:value={addColor}
-                class="size-8 shrink-0 cursor-pointer rounded border-0 bg-transparent p-0"
-              />
+              <ColorPicker bind:value={addColor} />
               <Input
                 bind:value={addName}
                 class="h-8 flex-1 text-sm"

--- a/web/src/lib/features/settings/components/status-settings-row.svelte
+++ b/web/src/lib/features/settings/components/status-settings-row.svelte
@@ -7,6 +7,7 @@
   } from '$lib/features/statuses/public'
   import { Badge } from '$ui/badge'
   import { Button } from '$ui/button'
+  import { ColorPicker } from '$ui/color-picker'
   import * as DropdownMenu from '$ui/dropdown-menu'
   import { Input } from '$ui/input'
   import {
@@ -94,12 +95,7 @@
 {#if editing}
   <div class="border-border bg-muted/30 rounded-md border px-3 py-3">
     <div class="flex items-center gap-3">
-      <input
-        type="color"
-        bind:value={draft.color}
-        disabled={busy}
-        class="size-8 shrink-0 cursor-pointer rounded border-0 bg-transparent p-0 disabled:cursor-not-allowed"
-      />
+      <ColorPicker bind:value={draft.color} disabled={busy} />
       <Input
         bind:value={draft.name}
         disabled={busy}


### PR DESCRIPTION
## Summary

- **New `ColorPicker` component** (`web/src/lib/components/ui/color-picker/`) with three-tier UX:
  - **Default**: 5 quick-pick swatches (blue, green, amber, red, violet) for one-click status color assignment
  - **Expanded**: 40 curated presets in a 5×8 grid organized by hue family (blues, greens, yellows, reds, purples)
  - **Custom**: hex input + native color picker as last-resort fallback
- **Replaces all 3 native `<input type="color">` usages** in status settings (row edit, create form, inline add)
- Keyboard navigable, responsive, clear selected/hover states, ARIA radiogroup roles

Closes ASE-54

## Test plan

- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `eslint` — clean on all changed files
- [x] `prettier` — formatted
- [x] `vite build` — success
- [x] `vitest run` — same 131/152 pass rate as main (21 pre-existing failures unrelated to this change)
- [ ] Manual: open status settings, verify default 5 swatches appear instead of color wheel
- [ ] Manual: click "More colors", verify 5×8 grid renders
- [ ] Manual: click "Custom color", verify hex input and native picker work
- [ ] Manual: verify selected state (check icon, ring) on all tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)