### PR TITLE
ASE-40: redesign remote machine setup around topology

### DIFF
--- a/web/src/lib/features/machines/components/machine-editor-guidance.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-guidance.svelte
@@ -7,20 +7,13 @@
     machineDetectionBadgeClass,
     machineDetectionMessage,
     machineDetectionStatusLabel,
-    machineExecutionGuide,
-    machineExecutionModeLabel,
     machineModeGuide,
     machineReachabilityLabel,
-    normalizeExecutionMode,
     normalizeReachabilityMode,
   } from '../model'
-  import type {
-    MachineDraft,
-    MachineExecutionMode,
-    MachineItem,
-    MachineReachabilityMode,
-  } from '../types'
-  import { Monitor, ArrowLeftRight, Radio, Cpu, Cable, Check } from '@lucide/svelte'
+  import { buildMachineSetupGuide } from '../machine-setup'
+  import type { MachineDraft, MachineItem, MachineReachabilityMode } from '../types'
+  import { Monitor, ArrowLeftRight, Radio, Check } from '@lucide/svelte'
 
   const reachabilityOptions: {
     mode: MachineReachabilityMode
@@ -48,40 +41,34 @@
     },
   ]
 
-  const directConnectExecutionOptions: MachineExecutionMode[] = ['websocket']
-
   let {
     machine,
     draft,
     onSelectReachability,
-    onSelectExecution,
   }: {
     machine: MachineItem | null
     draft: MachineDraft
     onSelectReachability?: (mode: MachineReachabilityMode) => void
-    onSelectExecution?: (mode: MachineExecutionMode) => void
   } = $props()
 
   const reachabilityMode = $derived(
     normalizeReachabilityMode(draft.reachabilityMode, draft.host, machine?.connection_mode),
   )
-  const executionMode = $derived(
-    normalizeExecutionMode(draft.executionMode, draft.host, machine?.connection_mode),
-  )
   const reachabilityGuide = $derived(machineModeGuide(reachabilityMode))
-  const executionGuide = $derived(machineExecutionGuide(executionMode))
   const detectionStatusLabel = $derived(machineDetectionStatusLabel(machine?.detection_status))
   const detectionBadgeClass = $derived(machineDetectionBadgeClass(machine?.detection_status))
   const detectedOSLabel = $derived(machineDetectedOSLabel(machine?.detected_os))
   const detectedArchLabel = $derived(machineDetectedArchLabel(machine?.detected_arch))
   const detectionSummary = $derived(machineDetectionMessage(machine, draft))
+  const setupGuide = $derived(buildMachineSetupGuide({ machine, draft }))
 </script>
 
 <section class="space-y-4">
   <div>
-    <h3 class="text-foreground text-sm font-semibold">Reachability mode</h3>
+    <h3 class="text-foreground text-sm font-semibold">Connection topology</h3>
     <p class="text-muted-foreground mt-0.5 text-xs">
-      Separate how OpenASE reaches the machine from how runtime execution is currently carried.
+      Choose how OpenASE reaches the machine. Setup commands and helper flows follow from that
+      topology.
     </p>
   </div>
 
@@ -128,66 +115,11 @@
     {/each}
   </div>
 
-  {#if reachabilityMode === 'direct_connect'}
-    <div class="space-y-2">
-      <div>
-        <h4 class="text-foreground text-xs font-semibold tracking-wide uppercase">
-          Execution path
-        </h4>
-        <p class="text-muted-foreground mt-0.5 text-xs">
-          Websocket is the runtime model. SSH remains available only as a bootstrap and diagnostics
-          helper.
-        </p>
-      </div>
-      <div class="grid gap-2 sm:grid-cols-2">
-        {#each directConnectExecutionOptions as option (option)}
-          {@const selected = executionMode === option}
-          <button
-            type="button"
-            class={cn(
-              'border-border bg-card hover:bg-muted/50 rounded-lg border px-3.5 py-3 text-left transition-all',
-              selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
-            )}
-            data-testid={`machine-execution-mode-${option}`}
-            onclick={() => onSelectExecution?.(option)}
-          >
-            <div class="flex items-start gap-3">
-              <div
-                class={cn(
-                  'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
-                  selected ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
-                )}
-              >
-                {#if option === 'websocket'}
-                  <Cable class="size-4" />
-                {:else}
-                  <Cpu class="size-4" />
-                {/if}
-              </div>
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-2">
-                  <span class="text-foreground text-sm font-medium">
-                    {machineExecutionModeLabel(option)}
-                  </span>
-                  {#if selected}
-                    <Check class="text-primary size-3.5" />
-                  {/if}
-                </div>
-                <p class="text-muted-foreground mt-0.5 text-xs leading-relaxed">
-                  {machineExecutionGuide(option).summary}
-                </p>
-              </div>
-            </div>
-          </button>
-        {/each}
-      </div>
-    </div>
-  {/if}
-
   <div class="border-border bg-card rounded-lg border px-3.5 py-3">
     <div class="flex flex-wrap items-center gap-2">
       <Badge variant="outline" class="text-[10px]">{reachabilityGuide.label}</Badge>
-      <Badge variant="outline" class="text-[10px]">{executionGuide.label}</Badge>
+      <Badge variant="outline" class="text-[10px]">{setupGuide.runtimeLabel}</Badge>
+      <Badge variant="outline" class="text-[10px]">{setupGuide.helperLabel}</Badge>
       <Badge variant="outline" class={cn('text-[10px]', detectionBadgeClass)}>
         {detectionStatusLabel}
       </Badge>
@@ -201,9 +133,44 @@
         <span class="text-foreground ml-1">{reachabilityGuide.requiredFields}</span>
       </div>
       <div>
-        <span class="text-muted-foreground">Test:</span>
-        <span class="text-foreground ml-1">{reachabilityGuide.testSemantics}</span>
+        <span class="text-muted-foreground">State:</span>
+        <span class="text-foreground ml-1">{setupGuide.stateSummary}</span>
       </div>
     </div>
   </div>
+
+  <div class="grid gap-3 lg:grid-cols-2">
+    <div class="border-border bg-card rounded-lg border px-3.5 py-3">
+      <div class="space-y-1">
+        <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
+        <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.runtimeSummary}</p>
+      </div>
+      <div class="mt-3 space-y-1">
+        <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
+        <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.helperSummary}</p>
+      </div>
+    </div>
+
+    <div class="border-border bg-card rounded-lg border px-3.5 py-3">
+      <p class="text-foreground text-sm font-medium">Next step guidance</p>
+      <ul class="text-muted-foreground mt-2 space-y-1.5 text-xs leading-relaxed">
+        {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
+          <li>{step}</li>
+        {/each}
+      </ul>
+    </div>
+  </div>
+
+  {#if setupGuide.commands.length > 0}
+    <div class="grid gap-3">
+      {#each setupGuide.commands as command (command.title)}
+        <div class="border-border bg-card rounded-lg border px-3.5 py-3">
+          <p class="text-foreground text-sm font-medium">{command.title}</p>
+          <p class="text-muted-foreground mt-1 text-xs leading-relaxed">{command.description}</p>
+          <pre
+            class="bg-muted/60 text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 text-xs whitespace-pre-wrap">{command.command}</pre>
+        </div>
+      {/each}
+    </div>
+  {/if}
 </section>

--- a/web/src/lib/features/machines/components/machine-editor-sheet.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-sheet.svelte
@@ -67,7 +67,7 @@
           </div>
           <SheetDescription class="text-xs">
             {#if mode === 'create'}
-              Define identity, transport, and workspace for a new machine.
+              Define identity, topology, helper access, and workspace for a new machine.
             {:else}
               {machineStatusDescription(machine?.status ?? '')}
             {/if}
@@ -84,7 +84,7 @@
           <Tabs.Root bind:value={activeTab}>
             <Tabs.List variant="line">
               <Tabs.Trigger value="configuration">Configuration</Tabs.Trigger>
-              <Tabs.Trigger value="health">Health & Status</Tabs.Trigger>
+              <Tabs.Trigger value="health">Health, Setup & Status</Tabs.Trigger>
             </Tabs.List>
           </Tabs.Root>
         </div>

--- a/web/src/lib/features/machines/components/machine-editor.svelte
+++ b/web/src/lib/features/machines/components/machine-editor.svelte
@@ -14,7 +14,6 @@
   import type {
     MachineDraft,
     MachineDraftField,
-    MachineExecutionMode,
     MachineItem,
     MachineReachabilityMode,
     WorkspaceRootState,
@@ -55,10 +54,6 @@
   function updateReachability(mode: MachineReachabilityMode) {
     onDraftChange?.('reachabilityMode', mode)
   }
-
-  function updateExecution(mode: MachineExecutionMode) {
-    onDraftChange?.('executionMode', mode)
-  }
 </script>
 
 <div class="space-y-5">
@@ -68,15 +63,10 @@
     </div>
   {/if}
 
-  <MachineEditorGuidance
-    {machine}
-    {draft}
-    onSelectReachability={updateReachability}
-    onSelectExecution={updateExecution}
-  />
+  <MachineEditorGuidance {machine} {draft} onSelectReachability={updateReachability} />
 
   <section class="border-border space-y-3 border-t pt-5">
-    <h3 class="text-foreground text-sm font-semibold">Identity & reachability</h3>
+    <h3 class="text-foreground text-sm font-semibold">Identity & connection</h3>
 
     <div class="grid gap-3 md:grid-cols-3">
       <div class="space-y-1.5">
@@ -111,7 +101,9 @@
 
     {#if reachabilityMode === 'direct_connect' && executionMode === 'websocket'}
       <div class="space-y-1.5">
-        <Label for="machine-advertised-endpoint" class="text-xs">Listener endpoint</Label>
+        <Label for="machine-advertised-endpoint" class="text-xs"
+          >Direct-connect listener endpoint</Label
+        >
         <Input
           id="machine-advertised-endpoint"
           value={draft.advertisedEndpoint}
@@ -119,14 +111,15 @@
           oninput={(event) => updateField('advertisedEndpoint', event)}
         />
         <p class="text-muted-foreground text-[11px]">
-          WebSocket endpoint OpenASE connects to for direct-connect execution.
+          OpenASE dials this websocket listener when the control plane can reach the machine
+          directly.
         </p>
       </div>
     {/if}
   </section>
 
   <section class="border-border space-y-3 border-t pt-5">
-    <h3 class="text-foreground text-sm font-semibold">SSH helper</h3>
+    <h3 class="text-foreground text-sm font-semibold">SSH helper lane</h3>
 
     {#if localMachine}
       <p class="text-muted-foreground text-xs">Local execution does not use SSH helper access.</p>
@@ -154,14 +147,14 @@
       </div>
       <p class="text-muted-foreground text-xs">
         {#if executionMode === 'ssh_compat'}
-          Legacy record detected. Resave this machine as websocket execution, then keep SSH only for
-          bootstrap or diagnostics.
+          Legacy record detected. Add the listener endpoint, then resave this machine so SSH drops
+          back to a helper-only lane.
         {:else if reachabilityMode === 'reverse_connect'}
-          Optional SSH helper access for bootstrap, diagnostics, or emergency repair. Runtime
-          execution stays on the reverse websocket daemon.
+          Optional helper access for assisted daemon bootstrap, diagnostics, or emergency repair.
+          Runtime execution stays on the reverse-connect daemon.
         {:else}
-          Optional SSH helper access for bootstrap, diagnostics, or emergency repair. Runtime
-          execution stays on the websocket listener above.
+          Optional helper access for quick bootstrap, diagnostics, or emergency repair. Runtime
+          execution stays on the direct-connect listener above.
         {/if}
       </p>
     {/if}

--- a/web/src/lib/features/machines/components/machine-health-header.svelte
+++ b/web/src/lib/features/machines/components/machine-health-header.svelte
@@ -7,11 +7,10 @@
     machineDetectedArchLabel,
     machineDetectedOSLabel,
     machineDetectionBadgeClass,
-    machineDetectionMessage,
     machineDetectionStatusLabel,
-    machineExecutionModeLabel,
     machineReachabilityLabel,
   } from '../model'
+  import { buildMachineSetupGuide } from '../machine-setup'
   import type { MachineItem, MachineSnapshot } from '../types'
 
   let {
@@ -27,6 +26,8 @@
     refreshing?: boolean
     onRefresh?: () => void
   } = $props()
+
+  const setupGuide = $derived(buildMachineSetupGuide({ machine, snapshot }))
 </script>
 
 <div class="flex items-start justify-between gap-3">
@@ -45,7 +46,8 @@
     {#if machine}
       <div class="flex flex-wrap items-center gap-2">
         <Badge variant="outline">{machineReachabilityLabel(machine.reachability_mode)}</Badge>
-        <Badge variant="outline">{machineExecutionModeLabel(machine.execution_mode)}</Badge>
+        <Badge variant="outline">{setupGuide.runtimeLabel}</Badge>
+        <Badge variant="outline">{setupGuide.helperLabel}</Badge>
         <Badge variant="secondary">{machineDetectedOSLabel(machine.detected_os)}</Badge>
         <Badge variant="secondary">{machineDetectedArchLabel(machine.detected_arch)}</Badge>
         <Badge variant="outline" class={machineDetectionBadgeClass(machine.detection_status)}>
@@ -53,14 +55,14 @@
         </Badge>
       </div>
       <p class="text-muted-foreground max-w-2xl text-xs">
-        {machineDetectionMessage(machine)}
+        {setupGuide.stateSummary}
       </p>
       <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-[11px]">
-        {#if machine.execution_mode === 'websocket' && machine.reachability_mode === 'direct_connect' && machine.advertised_endpoint}
+        {#if machine.reachability_mode === 'direct_connect' && machine.advertised_endpoint}
           <span class="truncate font-mono">{machine.advertised_endpoint}</span>
         {/if}
-        {#if machine.reachability_mode !== 'local'}
-          <span>session {machine.daemon_status?.session_state ?? 'unknown'}</span>
+        {#if machine.reachability_mode === 'reverse_connect'}
+          <span>{setupGuide.stateLabel}</span>
         {/if}
       </div>
     {/if}

--- a/web/src/lib/features/machines/components/machine-health-panel-view.ts
+++ b/web/src/lib/features/machines/components/machine-health-panel-view.ts
@@ -1,4 +1,5 @@
 import { formatRelativeTime } from '$lib/utils'
+import { friendlyTransportLabel } from '../machine-setup'
 import type { MachineCLIStatus, MachineSnapshot } from '../types'
 
 export type HealthStatCard = {
@@ -54,7 +55,7 @@ export function buildStatCards(snapshot: MachineSnapshot): HealthStatCard[] {
             : 'Unavailable',
       meta: snapshot.monitor.l1?.latencyMs
         ? `${snapshot.monitor.l1.latencyMs.toFixed(0)} ms`
-        : (snapshot.transport ?? 'No transport'),
+        : friendlyTransportLabel(snapshot.transport),
     },
     {
       label: 'CPU',

--- a/web/src/lib/features/machines/components/machine-health-panel.svelte
+++ b/web/src/lib/features/machines/components/machine-health-panel.svelte
@@ -3,6 +3,7 @@
   import { formatRelativeTime } from '$lib/utils'
   import { Badge } from '$ui/badge'
   import type { MachineItem, MachineProbeResult, MachineSnapshot } from '../types'
+  import { buildMachineSetupGuide } from '../machine-setup'
   import type { TruthyState } from './machine-health-panel-view'
   import {
     buildAuditRows,
@@ -55,6 +56,7 @@
   const statCards = $derived(snapshot ? buildStatCards(snapshot) : [])
   const runtimeRows = $derived(snapshot?.agentEnvironment ?? [])
   const auditRows = $derived(snapshot ? buildAuditRows(snapshot) : [])
+  const setupGuide = $derived(buildMachineSetupGuide({ machine, snapshot }))
 </script>
 
 <div class="space-y-4">
@@ -67,6 +69,53 @@
       No monitor snapshot is available for this machine yet.
     </div>
   {:else}
+    <div class="border-border bg-card rounded-xl border">
+      <div class="border-border flex items-center justify-between border-b px-4 py-3">
+        <div>
+          <h4 class="text-foreground text-sm font-semibold">Setup guidance</h4>
+          <p class="text-muted-foreground mt-1 text-xs">{setupGuide.topologySummary}</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{setupGuide.topologyLabel}</Badge>
+          <Badge variant="outline">{setupGuide.stateLabel}</Badge>
+        </div>
+      </div>
+
+      <div class="grid gap-3 px-4 py-4 lg:grid-cols-3">
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
+          <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.runtimeSummary}</p>
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
+          <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.helperSummary}</p>
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">Next steps</p>
+          <ul class="text-muted-foreground space-y-1.5 text-xs leading-relaxed">
+            {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
+              <li>{step}</li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+
+      {#if setupGuide.commands.length > 0}
+        <div class="border-border grid gap-3 border-t px-4 py-4">
+          {#each setupGuide.commands as command (command.title)}
+            <div class="rounded-lg border border-dashed px-3.5 py-3">
+              <p class="text-foreground text-sm font-medium">{command.title}</p>
+              <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+                {command.description}
+              </p>
+              <pre
+                class="bg-muted/60 text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 text-xs whitespace-pre-wrap">{command.command}</pre>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
       {#each statCards as card (card.label)}
         <div class="border-border bg-card rounded-xl border px-4 py-3">

--- a/web/src/lib/features/machines/components/machine-list.svelte
+++ b/web/src/lib/features/machines/components/machine-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Badge } from '$ui/badge'
   import { cn, formatRelativeTime } from '$lib/utils'
+  import { buildMachineSetupGuide } from '../machine-setup'
   import type { MachineItem } from '../types'
 
   let {
@@ -26,9 +27,8 @@
     return statusColors[status] ?? 'bg-slate-500'
   }
 
-  function transportOf(machine: MachineItem) {
-    const transport = machine.resources.transport
-    return typeof transport === 'string' && transport.trim() ? transport : null
+  function runtimeState(machine: MachineItem) {
+    return buildMachineSetupGuide({ machine }).stateLabel
   }
 </script>
 
@@ -76,7 +76,7 @@
         </div>
 
         <div class="text-muted-foreground mt-3 flex items-center justify-between text-xs">
-          <span>{transportOf(machine) ?? 'No transport yet'}</span>
+          <span>{runtimeState(machine)}</span>
           <span>
             {#if machine.last_heartbeat_at}
               {formatRelativeTime(machine.last_heartbeat_at)}

--- a/web/src/lib/features/machines/components/machine-probe-card.svelte
+++ b/web/src/lib/features/machines/components/machine-probe-card.svelte
@@ -7,6 +7,7 @@
     machineDetectionBadgeClass,
     machineDetectionStatusLabel,
   } from '../model'
+  import { friendlyTransportLabel } from '../machine-setup'
   import type { MachineProbeResult } from '../types'
 
   let { probe }: { probe: MachineProbeResult } = $props()
@@ -20,7 +21,7 @@
         {formatRelativeTime(probe.checked_at)}
       </p>
       <div class="flex flex-wrap items-center gap-2">
-        <Badge variant="outline">{probe.transport}</Badge>
+        <Badge variant="outline">{friendlyTransportLabel(probe.transport)}</Badge>
         <Badge variant="secondary">{machineDetectedOSLabel(probe.detected_os)}</Badge>
         <Badge variant="secondary">{machineDetectedArchLabel(probe.detected_arch)}</Badge>
         <Badge variant="outline" class={machineDetectionBadgeClass(probe.detection_status)}>

--- a/web/src/lib/features/machines/components/machine-row-card.svelte
+++ b/web/src/lib/features/machines/components/machine-row-card.svelte
@@ -11,10 +11,10 @@
     machineDetectedOSLabel,
     machineDetectionBadgeClass,
     machineDetectionStatusLabel,
-    machineExecutionModeLabel,
     machineReachabilityLabel,
     parseMachineSnapshot,
   } from '../model'
+  import { buildMachineSetupGuide } from '../machine-setup'
   import type { MachineItem } from '../types'
 
   const dotColorClass: Record<StatusDot['color'], string> = {
@@ -49,12 +49,12 @@
   const snapshot = $derived(parseMachineSnapshot(machine.resources))
   const localMachine = $derived(isLocalMachine(machine))
   const reachabilityLabel = $derived(machineReachabilityLabel(machine.reachability_mode))
-  const executionLabel = $derived(machineExecutionModeLabel(machine.execution_mode))
   const platformLabel = $derived(
     `${machineDetectedOSLabel(machine.detected_os)} / ${machineDetectedArchLabel(machine.detected_arch)}`,
   )
   const detectionLabel = $derived(machineDetectionStatusLabel(machine.detection_status))
   const detectionBadgeClass = $derived(machineDetectionBadgeClass(machine.detection_status))
+  const setupGuide = $derived(buildMachineSetupGuide({ machine, snapshot }))
 
   const statusDots = $derived.by((): StatusDot[] => buildStatusDots(machine, snapshot))
   const resourceBars = $derived.by(() => buildResourceBars(snapshot))
@@ -81,7 +81,8 @@
         </p>
         <div class="mt-2 flex flex-wrap items-center gap-1.5">
           <Badge variant="outline" class="text-[10px]">{reachabilityLabel}</Badge>
-          <Badge variant="outline" class="text-[10px]">{executionLabel}</Badge>
+          <Badge variant="outline" class="text-[10px]">{setupGuide.runtimeLabel}</Badge>
+          <Badge variant="outline" class="text-[10px]">{setupGuide.stateLabel}</Badge>
           <Badge variant="secondary" class="text-[10px]">{platformLabel}</Badge>
           <Badge variant="outline" class={cn('text-[10px]', detectionBadgeClass)}>
             {detectionLabel}

--- a/web/src/lib/features/machines/components/machines-page-body.svelte
+++ b/web/src/lib/features/machines/components/machines-page-body.svelte
@@ -89,7 +89,7 @@
 
 <PageScaffold
   title="Machines"
-  description="Machine access, transport configuration, and runtime health."
+  description="Machine topology, helper setup flows, and runtime health."
   variant="workspace"
   {actions}
 >

--- a/web/src/lib/features/machines/components/machines-page.test.ts
+++ b/web/src/lib/features/machines/components/machines-page.test.ts
@@ -212,17 +212,20 @@ describe('MachinesPage cache behavior', () => {
     })
   })
 
-  it('shows connection mode, detection status, and workspace guidance in the machine editor', async () => {
+  it('shows topology-driven setup guidance and workspace guidance in the machine editor', async () => {
     const view = render(MachinesPage)
 
     expect(await view.findByText('Linux / amd64')).toBeTruthy()
     expect(view.getByText('Direct Connect')).toBeTruthy()
-    expect(view.getByText('SSH Compat')).toBeTruthy()
+    expect(view.getByText('Legacy SSH runtime')).toBeTruthy()
     expect(view.getByText('Detected')).toBeTruthy()
 
     await openMachineDetails('machine-1')
 
-    expect(await view.findByText('Reachability mode')).toBeTruthy()
+    expect(await view.findByText('Connection topology')).toBeTruthy()
+    expect(view.getByText('Next step guidance')).toBeTruthy()
+    expect(view.getByText('SSH quick setup')).toBeTruthy()
+    expect(view.getByText('Migration needed')).toBeTruthy()
     expect(view.getAllByText('Detected amd64 on Linux.').length).toBeGreaterThan(0)
     expect(view.getByText('/home/ubuntu/.openase/workspace')).toBeTruthy()
     expect(view.getByText('Keeping the saved workspace root override.')).toBeTruthy()
@@ -235,13 +238,14 @@ describe('MachinesPage cache behavior', () => {
     await openMachineDetails('machine-1')
 
     expect(await view.findByText('Configuration')).toBeTruthy()
-    expect(view.getByText('Health & Status')).toBeTruthy()
+    expect(view.getByText('Health, Setup & Status')).toBeTruthy()
 
-    expect(view.getByText('Reachability mode')).toBeTruthy()
+    expect(view.getByText('Connection topology')).toBeTruthy()
 
-    await fireEvent.click(view.getByText('Health & Status'))
+    await fireEvent.click(view.getByText('Health, Setup & Status'))
 
     expect(await view.findByText('Health snapshot')).toBeTruthy()
+    expect(view.getByText('Setup guidance')).toBeTruthy()
   })
 })
 

--- a/web/src/lib/features/machines/machine-guidance.ts
+++ b/web/src/lib/features/machines/machine-guidance.ts
@@ -40,7 +40,7 @@ const machineModeGuides: Record<MachineReachabilityMode, MachineModeGuide> = {
   },
   reverse_connect: {
     mode: 'reverse_connect',
-    label: 'Reverse Connect',
+    label: 'Machine Dials Out',
     summary: 'The machine daemon dials out and carries native websocket runtime execution.',
     requiredFields:
       'Machine identity, daemon registration, and a workspace root the daemon can access.',

--- a/web/src/lib/features/machines/machine-setup-format.ts
+++ b/web/src/lib/features/machines/machine-setup-format.ts
@@ -1,0 +1,49 @@
+export function buildSSHHelperPreview(input: {
+  host: string | null | undefined
+  sshUser: string | null | undefined
+  sshKeyPath: string | null | undefined
+}): string | null {
+  const host = (input.host ?? '').trim()
+  const sshUser = (input.sshUser ?? '').trim()
+  if (!host || !sshUser || host.toLowerCase() === 'local') {
+    return null
+  }
+
+  const sshKeyPath = (input.sshKeyPath ?? '').trim()
+  const keyArg = sshKeyPath ? ` -i ${sshKeyPath}` : ''
+  return `ssh${keyArg} ${sshUser}@${host}`
+}
+
+export function friendlyTransportLabel(value: string | null | undefined): string {
+  switch ((value ?? '').trim()) {
+    case 'local':
+      return 'Local runtime'
+    case 'ssh':
+      return 'SSH helper path'
+    case 'ws_listener':
+      return 'Direct-connect listener'
+    case 'ws_reverse':
+      return 'Reverse-connect daemon'
+    default:
+      return value?.trim() ? value.trim() : 'Unknown transport'
+  }
+}
+
+export function normalizeSessionState(value: string | null | undefined): string {
+  const raw = (value ?? '').trim()
+  if (!raw) return 'unknown'
+  return raw
+}
+
+export function humanizeSessionState(value: string): string {
+  switch (value) {
+    case 'connected':
+      return 'Connected'
+    case 'disconnected':
+      return 'Disconnected'
+    case 'unavailable':
+      return 'Unavailable'
+    default:
+      return 'Unknown'
+  }
+}

--- a/web/src/lib/features/machines/machine-setup.test.ts
+++ b/web/src/lib/features/machines/machine-setup.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Machine } from '$lib/api/contracts'
+import { buildMachineSetupGuide, friendlyTransportLabel } from './machine-setup'
+
+function machineFixture(overrides: Partial<Machine> = {}): Machine {
+  return {
+    id: 'machine-1',
+    organization_id: 'org-1',
+    name: 'GPU Builder',
+    host: 'builder.internal',
+    port: 22,
+    reachability_mode: 'direct_connect',
+    execution_mode: 'ssh_compat',
+    execution_capabilities: ['probe'],
+    ssh_helper_enabled: true,
+    ssh_helper_required: true,
+    connection_mode: 'ssh',
+    transport_capabilities: ['probe'],
+    ssh_user: 'ubuntu',
+    ssh_key_path: '/keys/id_ed25519',
+    advertised_endpoint: null,
+    daemon_status: {
+      registered: false,
+      last_registered_at: null,
+      current_session_id: null,
+      session_state: 'unknown',
+    },
+    detected_os: 'linux',
+    detected_arch: 'amd64',
+    detection_status: 'ok',
+    detection_message: 'Detected amd64 on Linux.',
+    channel_credential: {
+      kind: 'none',
+      token_id: null,
+      certificate_id: null,
+    },
+    description: '',
+    labels: [],
+    status: 'online',
+    workspace_root: '/home/ubuntu/.openase/workspace',
+    agent_cli_path: '/usr/local/bin/openase-agent',
+    env_vars: [],
+    resources: {},
+    last_heartbeat_at: null,
+    created_at: '2026-04-02T09:00:00Z',
+    updated_at: '2026-04-02T10:00:00Z',
+    ...overrides,
+  } as Machine
+}
+
+describe('machine setup guidance', () => {
+  it('surfaces legacy ssh migration and helper quick setup for direct-connect records', () => {
+    const guide = buildMachineSetupGuide({
+      machine: machineFixture(),
+    })
+
+    expect(guide.runtimeLabel).toBe('Legacy SSH runtime')
+    expect(guide.helperLabel).toBe('SSH helper required')
+    expect(guide.stateLabel).toBe('Migration needed')
+    expect(guide.nextSteps).toContain('Expose the machine listener endpoint and save it here.')
+    expect(guide.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'SSH quick setup',
+          command: 'ssh -i /keys/id_ed25519 ubuntu@builder.internal',
+        }),
+        expect.objectContaining({
+          title: 'Control-plane connection test',
+          command: 'openase machine test machine-1',
+        }),
+      ]),
+    )
+  })
+
+  it('builds a self-serve reverse-connect command path and optional ssh bootstrap', () => {
+    const guide = buildMachineSetupGuide({
+      machine: machineFixture({
+        reachability_mode: 'reverse_connect',
+        execution_mode: 'websocket',
+        connection_mode: 'ws_reverse',
+        ssh_helper_required: false,
+        daemon_status: {
+          registered: false,
+          last_registered_at: null,
+          current_session_id: null,
+          session_state: 'unknown',
+        },
+      }),
+    })
+
+    expect(guide.topologyLabel).toBe('Machine dials out to OpenASE')
+    expect(guide.runtimeLabel).toBe('Reverse-connect daemon')
+    expect(guide.stateLabel).toBe('Waiting for daemon registration')
+    expect(guide.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: '1. Issue a machine channel token on the control plane',
+          command: 'openase machine issue-channel-token --machine-id machine-1 --format shell',
+        }),
+        expect.objectContaining({
+          title: '2. Paste those exports on the remote machine and start the daemon',
+          command: 'openase machine-agent run',
+        }),
+        expect.objectContaining({
+          title: 'Optional SSH bootstrap',
+          command: 'openase machine ssh-bootstrap machine-1',
+        }),
+        expect.objectContaining({
+          title: 'SSH diagnostics',
+          command: 'openase machine ssh-diagnostics machine-1',
+        }),
+      ]),
+    )
+  })
+
+  it('maps raw transport names to user-facing runtime labels', () => {
+    expect(friendlyTransportLabel('ws_listener')).toBe('Direct-connect listener')
+    expect(friendlyTransportLabel('ws_reverse')).toBe('Reverse-connect daemon')
+    expect(friendlyTransportLabel('ssh')).toBe('SSH helper path')
+  })
+})

--- a/web/src/lib/features/machines/machine-setup.ts
+++ b/web/src/lib/features/machines/machine-setup.ts
@@ -1,0 +1,299 @@
+import type { Machine } from '$lib/api/contracts'
+import type { MachineDraft, MachineSnapshot } from './types'
+import { normalizeExecutionMode, normalizeReachabilityMode } from './machine-guidance'
+import {
+  buildSSHHelperPreview,
+  humanizeSessionState,
+  normalizeSessionState,
+} from './machine-setup-format'
+
+export { buildSSHHelperPreview, friendlyTransportLabel } from './machine-setup-format'
+
+export type MachineSetupCommand = {
+  title: string
+  description: string
+  command: string
+}
+
+export type MachineSetupGuide = {
+  topologyLabel: string
+  topologySummary: string
+  runtimeLabel: string
+  runtimeSummary: string
+  helperLabel: string
+  helperSummary: string
+  stateLabel: string
+  stateSummary: string
+  nextSteps: string[]
+  commands: MachineSetupCommand[]
+}
+
+type MachineLike = Pick<
+  Machine,
+  | 'id'
+  | 'host'
+  | 'ssh_user'
+  | 'ssh_key_path'
+  | 'advertised_endpoint'
+  | 'reachability_mode'
+  | 'execution_mode'
+  | 'connection_mode'
+  | 'ssh_helper_enabled'
+  | 'ssh_helper_required'
+  | 'daemon_status'
+>
+
+type DraftLike = Pick<
+  MachineDraft,
+  'host' | 'sshUser' | 'sshKeyPath' | 'advertisedEndpoint' | 'reachabilityMode' | 'executionMode'
+>
+
+export function buildMachineSetupGuide(input: {
+  machine: MachineLike | null
+  draft?: DraftLike | null
+  snapshot?: MachineSnapshot | null
+}): MachineSetupGuide {
+  const machine = input.machine
+  const draft = input.draft
+  const snapshot = input.snapshot ?? null
+
+  const host = draft?.host ?? machine?.host ?? ''
+  const reachabilityMode = normalizeReachabilityMode(
+    draft?.reachabilityMode ?? machine?.reachability_mode,
+    host,
+    machine?.connection_mode,
+  )
+  const executionMode = normalizeExecutionMode(
+    draft?.executionMode ?? machine?.execution_mode,
+    host,
+    machine?.connection_mode,
+  )
+  const sshUser = (draft?.sshUser ?? machine?.ssh_user ?? '').trim()
+  const sshKeyPath = (draft?.sshKeyPath ?? machine?.ssh_key_path ?? '').trim()
+  const advertisedEndpoint = (
+    draft?.advertisedEndpoint ??
+    machine?.advertised_endpoint ??
+    ''
+  ).trim()
+  const sshPreview = buildSSHHelperPreview({
+    host,
+    sshUser,
+    sshKeyPath,
+  })
+
+  if (reachabilityMode === 'local') {
+    return {
+      topologyLabel: 'Local control-plane host',
+      topologySummary: 'OpenASE runs on the same host, so no remote bootstrap path is needed.',
+      runtimeLabel: 'Local process runtime',
+      runtimeSummary: 'Commands execute directly on the control-plane machine.',
+      helperLabel: 'SSH helper unused',
+      helperSummary: 'Local machines do not use SSH helper access.',
+      stateLabel: snapshot?.checkedAt ? 'Local checks recorded' : 'Waiting for local checks',
+      stateSummary: snapshot?.checkedAt
+        ? 'The latest snapshot reflects the local host.'
+        : 'Run checks to confirm the local runtime environment.',
+      nextSteps: [
+        'Confirm the workspace root and agent CLI path on this host.',
+        'Run checks after local toolchain changes to refresh runtime health.',
+      ],
+      commands: [],
+    }
+  }
+
+  if (reachabilityMode === 'reverse_connect') {
+    return buildReverseConnectGuide(machine, snapshot, sshPreview)
+  }
+
+  return buildDirectConnectGuide({
+    machine,
+    executionMode,
+    advertisedEndpoint,
+    snapshot,
+    sshPreview,
+  })
+}
+
+function buildDirectConnectGuide(input: {
+  machine: MachineLike | null
+  executionMode: string
+  advertisedEndpoint: string
+  snapshot: MachineSnapshot | null
+  sshPreview: string | null
+}): MachineSetupGuide {
+  const { machine, executionMode, advertisedEndpoint, snapshot, sshPreview } = input
+  const nextSteps: string[] = []
+  const commands: MachineSetupCommand[] = []
+
+  let runtimeLabel = 'Listener runtime'
+  let runtimeSummary =
+    'The control plane opens a websocket connection to the machine’s advertised listener endpoint.'
+  let helperLabel = sshPreview ? 'SSH helper available' : 'No SSH helper saved'
+  let helperSummary = sshPreview
+    ? 'Use SSH only for quick bootstrap, diagnostics, or emergency repair.'
+    : 'Add an SSH user and key path if you want a helper lane for bootstrap or diagnostics.'
+  let stateLabel = 'Waiting for listener'
+  let stateSummary =
+    'Add the listener endpoint, then run a connection test so OpenASE can verify reachability.'
+
+  if (executionMode === 'ssh_compat' || machine?.ssh_helper_required) {
+    runtimeLabel = 'Legacy SSH runtime'
+    runtimeSummary =
+      'This record still uses the old SSH execution lane. Migrate it to a direct-connect listener and keep SSH only as a helper.'
+    helperLabel = 'SSH helper required'
+    helperSummary =
+      'This machine still depends on SSH compatibility until the listener migration is complete.'
+    stateLabel = 'Migration needed'
+    stateSummary =
+      'Save a listener endpoint and resave the machine so runtime execution moves onto the direct-connect websocket path.'
+    nextSteps.push(
+      'Expose the machine listener endpoint and save it here.',
+      'Resave the machine so OpenASE switches runtime execution off the legacy SSH lane.',
+    )
+  } else if (!advertisedEndpoint) {
+    nextSteps.push('Add the direct-connect listener endpoint before running connection checks.')
+  } else {
+    const reachability = snapshot?.monitor.l1?.reachable
+    stateLabel =
+      reachability === true
+        ? 'Listener healthy'
+        : reachability === false
+          ? 'Listener checks failing'
+          : 'Listener configured'
+    stateSummary =
+      reachability === true
+        ? 'The listener endpoint is saved and recent reachability checks succeeded.'
+        : reachability === false
+          ? 'The listener endpoint is saved, but the latest reachability check failed.'
+          : 'The listener endpoint is saved. Run a connection test to verify it from the control plane.'
+    nextSteps.push('Run a connection test from OpenASE to verify the listener path end to end.')
+  }
+
+  if (sshPreview) {
+    nextSteps.push(
+      'Use the SSH helper lane for bootstrap or repair, then return here to rerun checks.',
+    )
+    commands.push({
+      title: 'SSH quick setup',
+      description:
+        'Open a helper session on the machine to install or repair OpenASE before retesting.',
+      command: sshPreview,
+    })
+  } else {
+    nextSteps.push(
+      'Optional: add SSH helper credentials if you want a direct bootstrap and diagnostics path.',
+    )
+  }
+
+  if (machine?.id) {
+    commands.push({
+      title: 'Control-plane connection test',
+      description: 'Verify that OpenASE can reach the advertised direct-connect path.',
+      command: `openase machine test ${machine.id}`,
+    })
+  }
+
+  return {
+    topologyLabel: 'Control plane connects directly',
+    topologySummary: 'Choose this when OpenASE can dial the machine over the network.',
+    runtimeLabel,
+    runtimeSummary,
+    helperLabel,
+    helperSummary,
+    stateLabel,
+    stateSummary,
+    nextSteps,
+    commands,
+  }
+}
+
+function buildReverseConnectGuide(
+  machine: MachineLike | null,
+  snapshot: MachineSnapshot | null,
+  sshPreview: string | null,
+): MachineSetupGuide {
+  const sessionState = normalizeSessionState(machine?.daemon_status?.session_state)
+  const sessionConnected = sessionState === 'connected'
+  const registered = Boolean(machine?.daemon_status?.registered)
+  const nextSteps: string[] = []
+  const commands: MachineSetupCommand[] = [
+    {
+      title: '1. Issue a machine channel token on the control plane',
+      description: 'Copy the exported OPENASE_MACHINE_* values from this command.',
+      command: `openase machine issue-channel-token --machine-id ${machine?.id ?? '<saved-machine-id>'} --format shell`,
+    },
+    {
+      title: '2. Paste those exports on the remote machine and start the daemon',
+      description:
+        'Run this after pasting the exported environment variables onto the remote host.',
+      command: 'openase machine-agent run',
+    },
+  ]
+
+  if (machine?.id && sshPreview) {
+    commands.push({
+      title: 'Optional SSH bootstrap',
+      description:
+        'Upload the OpenASE binary and install the reverse-connect user service over SSH.',
+      command: `openase machine ssh-bootstrap ${machine.id}`,
+    })
+    commands.push({
+      title: 'SSH diagnostics',
+      description:
+        'Inspect bootstrap, service, workspace, and daemon registration health over the helper lane.',
+      command: `openase machine ssh-diagnostics ${machine.id}`,
+    })
+  }
+
+  if (!registered) {
+    nextSteps.push(
+      'Issue a machine channel token, paste the exported OPENASE_MACHINE_* variables on the remote host, and start `openase machine-agent run`.',
+    )
+  } else if (!sessionConnected) {
+    nextSteps.push(
+      `The machine is registered but the current daemon session is ${humanizeSessionState(sessionState).toLowerCase()}. Restart the daemon or rerun bootstrap to reconnect it.`,
+    )
+  } else {
+    nextSteps.push('The daemon is connected. Run checks to confirm runtime and tooling readiness.')
+  }
+
+  if (sshPreview) {
+    nextSteps.push(
+      'Use the SSH bootstrap helper if you want OpenASE to install or refresh the daemon service for you.',
+    )
+  } else {
+    nextSteps.push(
+      'Add SSH helper credentials if you want an assisted bootstrap and diagnostics lane.',
+    )
+  }
+  if (snapshot?.monitor.l4?.checkedAt || snapshot?.monitor.l5?.checkedAt) {
+    nextSteps.push(
+      'Review the health panel below for runtime and tooling readiness after the daemon connects.',
+    )
+  }
+
+  return {
+    topologyLabel: 'Machine dials out to OpenASE',
+    topologySummary:
+      'Choose this when the machine can reach the control plane but cannot accept direct inbound control-plane connections.',
+    runtimeLabel: 'Reverse-connect daemon',
+    runtimeSummary:
+      'Runtime execution rides on the machine-agent websocket session instead of an advertised listener endpoint.',
+    helperLabel: sshPreview ? 'SSH bootstrap available' : 'No SSH bootstrap helper saved',
+    helperSummary: sshPreview
+      ? 'SSH remains optional. Use it when you want OpenASE to upload the binary and install the daemon service for you.'
+      : 'Self-serve daemon startup works without SSH. Add helper credentials only if you want assisted bootstrap and diagnostics.',
+    stateLabel: sessionConnected
+      ? 'Daemon connected'
+      : registered
+        ? `Daemon ${humanizeSessionState(sessionState)}`
+        : 'Waiting for daemon registration',
+    stateSummary: sessionConnected
+      ? 'The control plane currently sees an active reverse-connect daemon session.'
+      : registered
+        ? `The machine is registered, but the current daemon session is ${humanizeSessionState(sessionState).toLowerCase()}.`
+        : 'The control plane has not seen an active reverse-connect daemon registration for this machine yet.',
+    nextSteps,
+    commands,
+  }
+}


### PR DESCRIPTION
## Summary
- redesign machine configuration and detail views around connection topology, helper lanes, and next-step guidance instead of raw transport names
- add direct-connect SSH quick setup previews plus reverse-connect self-serve command paths and daemon state guidance
- cover the new topology-driven status and setup flows with machine feature tests

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/machines/model.test.ts src/lib/features/machines/machine-setup.test.ts src/lib/features/machines/components/machine-health-panel-view.test.ts src/lib/features/machines/components/machines-page.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec svelte-check --tsconfig ./tsconfig.json`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec eslint --quiet src/lib/features/machines/components/machine-editor-guidance.svelte src/lib/features/machines/components/machine-editor-sheet.svelte src/lib/features/machines/components/machine-editor.svelte src/lib/features/machines/components/machine-health-header.svelte src/lib/features/machines/components/machine-health-panel-view.ts src/lib/features/machines/components/machine-health-panel.svelte src/lib/features/machines/components/machine-list.svelte src/lib/features/machines/components/machine-probe-card.svelte src/lib/features/machines/components/machine-row-card.svelte src/lib/features/machines/components/machines-page-body.svelte src/lib/features/machines/components/machines-page.test.ts src/lib/features/machines/machine-guidance.ts src/lib/features/machines/machine-setup.ts src/lib/features/machines/machine-setup-format.ts src/lib/features/machines/machine-setup.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- none beyond the broader remote runtime rollout tracked separately under ASE-42
