### PR TITLE
ASE-41: add local remote runtime container harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION ?= dev
 
 .DEFAULT_GOAL := help
 
-.PHONY: help format fmt-check test test-backend-coverage check hooks-install hooks-run openapi-generate openapi-check openapi-check-ci frontend-api-audit-check web-install web-lint web-format-check web-check web-validate web-build build build-web run doctor lint lint-all lint-depguard lint-architecture
+.PHONY: help format fmt-check test test-backend-coverage remote-runtime-container check hooks-install hooks-run openapi-generate openapi-check openapi-check-ci frontend-api-audit-check web-install web-lint web-format-check web-check web-validate web-build build build-web run doctor lint lint-all lint-depguard lint-architecture
 
 help:
 	@printf '%s\n' \
@@ -20,6 +20,7 @@ help:
 		'  make fmt-check     Fail if tracked Go files need gofmt' \
 		'  make test          Run the Go test suite' \
 		'  make test-backend-coverage Run full backend tests plus domain/core 100% coverage gate (set OPENASE_ENABLE_FULL_BACKEND_COVERAGE=true for optional overall 75%+ metric)' \
+		'  make remote-runtime-container Run the local-only docker compose harness for websocket runtime and SSH helper validation' \
 		'  make check         Run Go formatting and enforced backend coverage checks' \
 		'  make hooks-install Install Git hooks via lefthook' \
 		'  make hooks-run     Run the pre-commit hook against all files' \
@@ -66,6 +67,9 @@ test:
 
 test-backend-coverage:
 	./scripts/ci/backend_coverage.sh
+
+remote-runtime-container:
+	./scripts/ci/remote_runtime_container_harness.sh $(REMOTE_RUNTIME_CASES)
 
 check: fmt-check test-backend-coverage
 

--- a/docs/en/remote-websocket-rollout.md
+++ b/docs/en/remote-websocket-rollout.md
@@ -17,7 +17,7 @@ Run the focused transport matrix from the repo root:
 scripts/ci/remote_transport_matrix.sh
 ```
 
-The matrix currently covers:
+The fast matrix currently covers:
 
 | Scenario | Coverage |
 | --- | --- |
@@ -39,6 +39,39 @@ What each happy-path runtime case verifies:
 - agent process launch
 - output streaming or command handshake
 - cleanup or disconnect bookkeeping
+
+## Local Container Harness
+
+Use the slow local-only container harness when you need real daemon startup,
+container networking, remote filesystem permissions, SSH transport, and process
+execution instead of in-process fakes:
+
+```bash
+make remote-runtime-container
+```
+
+Run targeted cases directly when you only need one slice:
+
+```bash
+scripts/ci/remote_runtime_container_harness.sh listener
+scripts/ci/remote_runtime_container_harness.sh reverse ssh
+```
+
+The container harness:
+
+- stays out of the normal pull-request CI workflow
+- writes case logs plus compose service logs under `.artifacts/remote-runtime-container/`
+- requires Linux plus Docker Compose
+- uses `scripts/ci/remote_runtime_container.compose.yml`
+- is available in a separate manual/nightly workflow: `.github/workflows/remote-runtime-container.yml`
+
+Current container cases:
+
+| Scenario | Coverage |
+| --- | --- |
+| Direct-connect websocket runtime over a real listener container | `TestWebsocketListenerRuntimeContainerE2E` |
+| Reverse-connect websocket runtime over a real machine-agent container | `TestWebsocketReverseRuntimeContainerE2E` |
+| SSH bootstrap + diagnostics helper over a real SSH container | `TestMachineSSHHelperContainerE2E` |
 
 The runtime contract itself is now shared by both websocket topologies:
 

--- a/docs/zh/remote-websocket-rollout.md
+++ b/docs/zh/remote-websocket-rollout.md
@@ -17,7 +17,7 @@
 scripts/ci/remote_transport_matrix.sh
 ```
 
-当前矩阵覆盖：
+当前快速矩阵覆盖：
 
 | 场景 | 覆盖 |
 | --- | --- |
@@ -39,6 +39,37 @@ scripts/ci/remote_transport_matrix.sh
 - Agent 进程启动
 - 输出流或命令握手
 - 清理或断开连接记账
+
+## 本地容器 Harness
+
+当你需要验证真实的守护进程启动、容器网络、远端文件系统权限、SSH 传输和进程执行，而不是只依赖进程内 fake 时，使用慢速的本地容器 harness：
+
+```bash
+make remote-runtime-container
+```
+
+只跑指定 case 时可以直接执行：
+
+```bash
+scripts/ci/remote_runtime_container_harness.sh listener
+scripts/ci/remote_runtime_container_harness.sh reverse ssh
+```
+
+这套容器 harness：
+
+- 不会进入普通 pull request CI
+- 会把 case 日志和 compose 服务日志写到 `.artifacts/remote-runtime-container/`
+- 需要 Linux 和 Docker Compose
+- 使用 `scripts/ci/remote_runtime_container.compose.yml`
+- 提供独立的手动 / nightly workflow：`.github/workflows/remote-runtime-container.yml`
+
+当前容器 case：
+
+| 场景 | 覆盖 |
+| --- | --- |
+| 通过真实 listener 容器验证 direct-connect websocket runtime | `TestWebsocketListenerRuntimeContainerE2E` |
+| 通过真实 machine-agent 容器验证 reverse-connect websocket runtime | `TestWebsocketReverseRuntimeContainerE2E` |
+| 通过真实 SSH 容器验证 SSH bootstrap + diagnostics helper | `TestMachineSSHHelperContainerE2E` |
 
 runtime 契约本身现在由两种 WebSocket 拓扑共同验证：
 

--- a/internal/cli/machine_ssh_helper_container_test.go
+++ b/internal/cli/machine_ssh_helper_container_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	sshinfra "github.com/BetterAndBetterII/openase/internal/infra/ssh"
+	"github.com/BetterAndBetterII/openase/internal/testutil/containerharness"
+	"github.com/google/uuid"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func TestMachineSSHHelperContainerE2E(t *testing.T) {
+	containerharness.RequireContainerSuite(t)
+
+	openaseBinary := containerharness.BuiltOpenASEBinary(t)
+	privateKeyPath, authorizedKeysPath := writeSSHKeyPair(t)
+	hostPort := containerharness.FreeTCPPort(t)
+	project := containerharness.NewProject(t, containerharness.Options{
+		ProjectName: "ase41-ssh-" + strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", "")),
+		Env: map[string]string{
+			"OPENASE_TEST_SSH_AUTHORIZED_KEYS":  authorizedKeysPath,
+			"OPENASE_TEST_SSH_HELPER_HOST_PORT": fmt.Sprintf("%d", hostPort),
+		},
+	})
+	project.Up(t, nil, "ssh-helper")
+	project.WriteLogs(t, "ssh-helper-compose.log", nil, "ssh-helper")
+	containerharness.WaitForTCPPort(t, fmt.Sprintf("127.0.0.1:%d", hostPort), 20*time.Second)
+
+	ctx := context.Background()
+	machineID := uuid.New()
+	sshUser := "openase"
+	workspaceRoot := "/home/openase/workspaces"
+	agentCLIPath := "/bin/sh"
+	machine := catalogdomain.Machine{
+		ID:             machineID,
+		Name:           "reverse-ssh-helper",
+		Host:           "127.0.0.1",
+		Port:           hostPort,
+		ConnectionMode: catalogdomain.MachineConnectionModeWSReverse,
+		SSHUser:        &sshUser,
+		SSHKeyPath:     &privateKeyPath,
+		WorkspaceRoot:  &workspaceRoot,
+		AgentCLIPath:   &agentCLIPath,
+		DaemonStatus: catalogdomain.MachineDaemonStatus{
+			Registered: true,
+		},
+	}
+
+	pool := sshinfra.NewPool(t.TempDir(), sshinfra.WithTimeout(5*time.Second))
+	defer func() {
+		_ = pool.Close()
+	}()
+
+	bootstrapResult, err := runMachineSSHBootstrap(ctx, machineSSHBootstrapDeps{
+		getClient: func(ctx context.Context, item catalogdomain.Machine) (sshinfra.Client, error) {
+			return pool.Get(ctx, item)
+		},
+		issueToken: func(context.Context, uuid.UUID, time.Duration, string, string) (machineChannelTokenResponse, error) {
+			return machineChannelTokenResponse{
+				Token:           "ase_machine_test_container",
+				TokenID:         "token-container",
+				MachineID:       machineID.String(),
+				ControlPlaneURL: "http://127.0.0.1:19836",
+			}, nil
+		},
+		readLocalFile:     os.ReadFile,
+		resolveExecutable: func() (string, error) { return openaseBinary, nil },
+	}, machineSSHBootstrapInput{
+		Machine:           machine,
+		TokenTTL:          time.Hour,
+		ControlPlaneURL:   "http://127.0.0.1:19836",
+		OpenASEBinaryPath: openaseBinary,
+		HeartbeatInterval: 15 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runMachineSSHBootstrap() error = %v", err)
+	}
+
+	layout := buildMachineSSHLayout("/home/openase")
+	if bootstrapResult.RemoteBinaryPath != layout.RemoteBinaryPath {
+		t.Fatalf("RemoteBinaryPath = %q, want %q", bootstrapResult.RemoteBinaryPath, layout.RemoteBinaryPath)
+	}
+	if bootstrapResult.EnvironmentFile != layout.EnvironmentFile {
+		t.Fatalf("EnvironmentFile = %q, want %q", bootstrapResult.EnvironmentFile, layout.EnvironmentFile)
+	}
+	if bootstrapResult.TokenID != "token-container" {
+		t.Fatalf("TokenID = %q, want token-container", bootstrapResult.TokenID)
+	}
+
+	diagnosticsResult, err := runMachineSSHDiagnostics(ctx, machineSSHDiagnosticDeps{
+		getClient: func(ctx context.Context, item catalogdomain.Machine) (sshinfra.Client, error) {
+			return pool.Get(ctx, item)
+		},
+	}, machine)
+	if err != nil {
+		t.Fatalf("runMachineSSHDiagnostics() error = %v", err)
+	}
+	if len(diagnosticsResult.Issues) != 0 {
+		t.Fatalf("Diagnostics issues = %+v, want none", diagnosticsResult.Issues)
+	}
+
+	client, err := pool.Get(ctx, machine)
+	if err != nil {
+		t.Fatalf("pool.Get() error = %v", err)
+	}
+	remoteState, err := runRemoteSSHCommand(ctx, client, "sh -lc "+sshinfra.ShellQuote(strings.Join([]string{
+		"set -eu",
+		"test -x " + sshinfra.ShellQuote(layout.RemoteBinaryPath),
+		"test -w " + sshinfra.ShellQuote(workspaceRoot),
+		"test -f " + sshinfra.ShellQuote(layout.StdoutPath),
+		"cat " + sshinfra.ShellQuote(layout.EnvironmentFile),
+		"printf '\\n--SERVICE--\\n'",
+		"cat " + sshinfra.ShellQuote(layout.ServiceFile),
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("read remote ssh helper state: %v (%s)", err, strings.TrimSpace(remoteState))
+	}
+	if !strings.Contains(remoteState, `OPENASE_MACHINE_CHANNEL_TOKEN="ase_machine_test_container"`) {
+		t.Fatalf("remote env file missing channel token: %s", remoteState)
+	}
+	if !strings.Contains(remoteState, `"machine-agent" "run"`) {
+		t.Fatalf("remote service file missing machine-agent run command: %s", remoteState)
+	}
+}
+
+func writeSSHKeyPair(t *testing.T) (string, string) {
+	t.Helper()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key pair: %v", err)
+	}
+
+	privatePKCS8, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	privatePEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privatePKCS8})
+
+	sshPublicKey, err := gossh.NewPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("marshal public ssh key: %v", err)
+	}
+
+	dir := t.TempDir()
+	privateKeyPath := filepath.Join(dir, "id_ed25519")
+	authorizedKeysPath := filepath.Join(dir, "authorized_keys")
+
+	if err := os.WriteFile(privateKeyPath, privatePEM, 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	if err := os.WriteFile(authorizedKeysPath, gossh.MarshalAuthorizedKey(sshPublicKey), 0o600); err != nil {
+		t.Fatalf("write authorized_keys: %v", err)
+	}
+
+	return privateKeyPath, authorizedKeysPath
+}

--- a/internal/infra/machinetransport/runtime_contract_container_test.go
+++ b/internal/infra/machinetransport/runtime_contract_container_test.go
@@ -1,0 +1,138 @@
+package machinetransport
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
+	"github.com/BetterAndBetterII/openase/internal/testutil/containerharness"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+func TestWebsocketReverseRuntimeContainerE2E(t *testing.T) {
+	containerharness.RequireContainerSuite(t)
+
+	openaseBinary := containerharness.BuiltOpenASEBinary(t)
+	machineID := uuid.New()
+	sessionRegistry := NewReverseRuntimeRelayRegistry()
+	server := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+
+			helloEnvelope, err := readMachineEnvelopeForTest(conn)
+			if err != nil || helloEnvelope.Type != machinechanneldomain.MessageTypeHello {
+				return
+			}
+			authenticateEnvelope, err := readMachineEnvelopeForTest(conn)
+			if err != nil || authenticateEnvelope.Type != machinechanneldomain.MessageTypeAuthenticate {
+				return
+			}
+
+			sessionID := uuid.NewString()
+			sessionRegistry.Register(machineID, sessionID, func(ctx context.Context, envelope runtimecontract.Envelope) error {
+				return writeMachineEnvelopeForTest(conn, machinechanneldomain.MessageTypeRuntime, sessionID, envelope)
+			})
+			defer sessionRegistry.Remove(sessionID)
+
+			if err := writeMachineEnvelopeForTest(conn, machinechanneldomain.MessageTypeRegistered, sessionID, machinechanneldomain.Registered{
+				MachineID:                machineID.String(),
+				SessionID:                sessionID,
+				HeartbeatIntervalSeconds: 1,
+				HeartbeatTimeoutSeconds:  5,
+			}); err != nil {
+				return
+			}
+
+			for {
+				envelope, err := readMachineEnvelopeForTest(conn)
+				if err != nil {
+					return
+				}
+				switch envelope.Type {
+				case machinechanneldomain.MessageTypeHeartbeat:
+					continue
+				case machinechanneldomain.MessageTypeGoodbye:
+					return
+				case machinechanneldomain.MessageTypeRuntime:
+					runtimeEnvelope, err := runtimeEnvelopeFromMachineEnvelopeForTest(envelope)
+					if err != nil {
+						return
+					}
+					if err := sessionRegistry.Deliver(sessionID, runtimeEnvelope); err != nil {
+						return
+					}
+				default:
+					return
+				}
+			}
+		}),
+	}
+
+	// #nosec G102 -- the reverse-daemon container reaches this host listener through host-gateway.
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("listen for reverse control plane: %v", err)
+	}
+	serverPort := listener.Addr().(*net.TCPAddr).Port
+	serverErrCh := make(chan error, 1)
+	go func() {
+		serverErrCh <- server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		if err := <-serverErrCh; err != nil && err != http.ErrServerClosed {
+			t.Errorf("reverse control plane server error: %v", err)
+		}
+	})
+
+	project := containerharness.NewProject(t, containerharness.Options{
+		ProjectName: "ase41-reverse-" + strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", "")),
+		Env: map[string]string{
+			"OPENASE_TEST_OPENASE_BINARY":        openaseBinary,
+			"OPENASE_TEST_TMP_ROOT":              filepath.Clean(os.TempDir()),
+			"OPENASE_TEST_UID":                   fmt.Sprintf("%d", os.Getuid()),
+			"OPENASE_TEST_GID":                   fmt.Sprintf("%d", os.Getgid()),
+			"OPENASE_MACHINE_ID":                 machineID.String(),
+			"OPENASE_MACHINE_CHANNEL_TOKEN":      machinechanneldomain.TokenPrefix + "reverse-container",
+			"OPENASE_MACHINE_CONTROL_PLANE_URL":  fmt.Sprintf("http://host.docker.internal:%d", serverPort),
+			"OPENASE_MACHINE_HEARTBEAT_INTERVAL": "200ms",
+		},
+	})
+	project.Up(t, nil, "reverse-daemon")
+	project.WriteLogs(t, "reverse-daemon-compose.log", nil, "reverse-daemon")
+
+	waitForReverseRuntimeRegistration(t, sessionRegistry, machineID)
+
+	machine := catalogdomain.Machine{
+		ID:             machineID,
+		Name:           "reverse-container",
+		Host:           "reverse.internal",
+		ConnectionMode: catalogdomain.MachineConnectionModeWSReverse,
+		DaemonStatus: catalogdomain.MachineDaemonStatus{
+			Registered:   true,
+			SessionState: catalogdomain.MachineTransportSessionStateConnected,
+		},
+	}
+	runRuntimeContractSuite(t, machine, func(ctx context.Context) (*runtimeProtocolClient, func(error), error) {
+		client, err := sessionRegistry.client(machineID)
+		return client, func(error) {}, err
+	})
+}

--- a/internal/infra/machinetransport/runtime_contract_test.go
+++ b/internal/infra/machinetransport/runtime_contract_test.go
@@ -10,10 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -23,16 +20,15 @@ import (
 	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
 	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
+	"github.com/BetterAndBetterII/openase/internal/testutil/containerharness"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
 
 const (
-	websocketListenerContainerHelperEnv  = "OPENASE_TEST_WS_LISTENER_HELPER"
-	websocketListenerContainerPortEnv    = "OPENASE_TEST_WS_LISTENER_PORT"
-	websocketListenerContainerImage      = "debian:bookworm-slim"
-	websocketListenerContainerBinaryPath = "/openase-ws-listener.test"
-	websocketListenerContainerPort       = 19852
+	websocketListenerContainerHelperEnv = "OPENASE_TEST_WS_LISTENER_HELPER"
+	websocketListenerContainerPortEnv   = "OPENASE_TEST_WS_LISTENER_PORT"
+	websocketListenerContainerPort      = 19852
 )
 
 func TestUnifiedWebsocketRuntimeContractSuite(t *testing.T) {
@@ -142,54 +138,27 @@ func TestUnifiedWebsocketRuntimeContractSuite(t *testing.T) {
 }
 
 func TestWebsocketListenerRuntimeContainerE2E(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("docker-backed listener container e2e currently requires linux")
-	}
-
-	dockerPath := requireDockerRuntime(t)
-	ensureDockerImage(t, dockerPath, websocketListenerContainerImage)
+	containerharness.RequireContainerSuite(t)
 
 	testBinary, err := os.Executable()
 	if err != nil {
 		t.Fatalf("resolve current executable: %v", err)
 	}
 
-	hostPort := freeTCPPort(t)
-	containerName := "openase-ws-listener-" + strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", ""))
-	hostTempRoot := filepath.Clean(os.TempDir())
-	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	runArgs := []string{
-		"run", "-d", "--rm",
-		"--name", containerName,
-		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-		"-p", fmt.Sprintf("127.0.0.1:%d:%d", hostPort, websocketListenerContainerPort),
-		"-v", fmt.Sprintf("%s:%s", hostTempRoot, hostTempRoot),
-		"-v", fmt.Sprintf("%s:%s:ro", filepath.Clean(testBinary), websocketListenerContainerBinaryPath),
-		"-v", "/etc/passwd:/etc/passwd:ro",
-		"-v", "/etc/group:/etc/group:ro",
-		"-e", websocketListenerContainerHelperEnv + "=1",
-		"-e", websocketListenerContainerPortEnv + "=" + strconv.Itoa(websocketListenerContainerPort),
-		websocketListenerContainerImage,
-		"/bin/sh", "-lc",
-		fmt.Sprintf("%s -test.run '^TestWebsocketListenerRuntimeContainerHelper$' -test.timeout=0", websocketListenerContainerBinaryPath),
-	}
-	// #nosec G204 -- test uses a validated local docker CLI plus fixed test arguments.
-	output, err := exec.CommandContext(runCtx, dockerPath, runArgs...).CombinedOutput()
-	if err != nil {
-		t.Fatalf("start listener container: %v\n%s", err, strings.TrimSpace(string(output)))
-	}
-
-	t.Cleanup(func() {
-		// #nosec G204 -- test reads logs from the controlled docker test container.
-		logs, _ := exec.Command(dockerPath, "logs", containerName).CombinedOutput()
-		if t.Failed() && strings.TrimSpace(string(logs)) != "" {
-			t.Logf("listener container logs:\n%s", strings.TrimSpace(string(logs)))
-		}
-		// #nosec G204 -- test removes the controlled docker test container during cleanup.
-		_, _ = exec.Command(dockerPath, "rm", "-f", containerName).CombinedOutput()
+	hostPort := containerharness.FreeTCPPort(t)
+	project := containerharness.NewProject(t, containerharness.Options{
+		ProjectName: "ase41-listener-" + strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", "")),
+		Env: map[string]string{
+			"OPENASE_TEST_WS_LISTENER_BINARY":    filepath.Clean(testBinary),
+			"OPENASE_TEST_WS_LISTENER_HOST_PORT": fmt.Sprintf("%d", hostPort),
+			"OPENASE_TEST_WS_LISTENER_PORT":      fmt.Sprintf("%d", websocketListenerContainerPort),
+			"OPENASE_TEST_TMP_ROOT":              filepath.Clean(os.TempDir()),
+			"OPENASE_TEST_UID":                   fmt.Sprintf("%d", os.Getuid()),
+			"OPENASE_TEST_GID":                   fmt.Sprintf("%d", os.Getgid()),
+		},
 	})
+	project.Up(t, nil, "ws-listener")
+	project.WriteLogs(t, "listener-compose.log", nil, "ws-listener")
 
 	machine := testListenerMachine(fmt.Sprintf("ws://127.0.0.1:%d", hostPort), "")
 	waitForContainerListenerRuntime(t, machine)
@@ -506,41 +475,6 @@ func runtimeEnvelopeFromMachineEnvelopeForTest(envelope machinechanneldomain.Env
 	return runtimeEnvelope, nil
 }
 
-func requireDockerRuntime(t *testing.T) string {
-	t.Helper()
-
-	dockerPath, err := exec.LookPath("docker")
-	if err != nil {
-		t.Skip("docker is not available on PATH")
-	}
-	checkCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	// #nosec G204 -- test probes the local docker daemon through a controlled CLI path.
-	if output, err := exec.CommandContext(checkCtx, dockerPath, "info", "--format", "{{.ServerVersion}}").CombinedOutput(); err != nil {
-		t.Skipf("docker daemon is unavailable: %v (%s)", err, strings.TrimSpace(string(output)))
-	}
-	return dockerPath
-}
-
-func ensureDockerImage(t *testing.T, dockerPath string, image string) {
-	t.Helper()
-
-	checkCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	// #nosec G204 -- test inspects a fixed docker image name through the local docker CLI.
-	if err := exec.CommandContext(checkCtx, dockerPath, "image", "inspect", image).Run(); err == nil {
-		return
-	}
-
-	pullCtx, pullCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer pullCancel()
-	// #nosec G204 -- test pulls a fixed docker image through the local docker CLI when absent.
-	output, err := exec.CommandContext(pullCtx, dockerPath, "pull", image).CombinedOutput()
-	if err != nil {
-		t.Fatalf("pull docker image %s: %v\n%s", image, err, strings.TrimSpace(string(output)))
-	}
-}
-
 func waitForContainerListenerRuntime(t *testing.T, machine catalogdomain.Machine) {
 	t.Helper()
 
@@ -558,16 +492,4 @@ func waitForContainerListenerRuntime(t *testing.T, machine catalogdomain.Machine
 		time.Sleep(100 * time.Millisecond)
 	}
 	t.Fatalf("listener container runtime for %s did not become reachable: %v", machine.Name, lastErr)
-}
-
-func freeTCPPort(t *testing.T) int {
-	t.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen for free tcp port: %v", err)
-	}
-	defer func() { _ = listener.Close() }()
-
-	return listener.Addr().(*net.TCPAddr).Port
 }

--- a/internal/testutil/containerharness/compose.go
+++ b/internal/testutil/containerharness/compose.go
@@ -1,0 +1,321 @@
+package containerharness
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	containerSuiteEnv        = "OPENASE_RUN_REMOTE_RUNTIME_CONTAINER_TESTS"
+	composeFileEnv           = "OPENASE_TEST_REMOTE_RUNTIME_COMPOSE_FILE"
+	artifactDirEnv           = "OPENASE_REMOTE_RUNTIME_ARTIFACT_DIR"
+	openaseBinaryEnv         = "OPENASE_TEST_OPENASE_BINARY"
+	defaultArtifactDirectory = ".artifacts/remote-runtime-container"
+)
+
+type Options struct {
+	ComposeFile string
+	ArtifactDir string
+	ProjectName string
+	Env         map[string]string
+}
+
+type Project struct {
+	dockerPath   string
+	composeFile  string
+	artifactDir  string
+	projectName  string
+	repoRoot     string
+	baseEnv      map[string]string
+	startedNames []string
+}
+
+func RequireContainerSuite(t testing.TB) {
+	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("remote runtime container suite currently requires linux")
+	}
+	if strings.TrimSpace(os.Getenv(containerSuiteEnv)) != "1" {
+		t.Skipf("set %s=1 to run remote runtime container tests", containerSuiteEnv)
+	}
+}
+
+func RepoRoot(t testing.TB) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve container harness helper path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func DefaultComposeFile(t testing.TB) string {
+	t.Helper()
+
+	if value := strings.TrimSpace(os.Getenv(composeFileEnv)); value != "" {
+		return filepath.Clean(value)
+	}
+	return filepath.Join(RepoRoot(t), "scripts", "ci", "remote_runtime_container.compose.yml")
+}
+
+func ArtifactRoot(t testing.TB) string {
+	t.Helper()
+
+	if value := strings.TrimSpace(os.Getenv(artifactDirEnv)); value != "" {
+		return filepath.Clean(value)
+	}
+	return filepath.Join(RepoRoot(t), defaultArtifactDirectory)
+}
+
+func BuiltOpenASEBinary(t testing.TB) string {
+	t.Helper()
+
+	if value := strings.TrimSpace(os.Getenv(openaseBinaryEnv)); value != "" {
+		// #nosec G703 -- test-only helper accepts an explicit local binary path from the harness env.
+		info, err := os.Stat(value)
+		if err != nil {
+			t.Fatalf("stat %s: %v", value, err)
+		}
+		if info.IsDir() {
+			t.Fatalf("%s is a directory, want executable binary", value)
+		}
+		return filepath.Clean(value)
+	}
+
+	candidate := filepath.Join(RepoRoot(t), "bin", "openase")
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		t.Skipf("OpenASE binary is unavailable; build %s or set %s", candidate, openaseBinaryEnv)
+	}
+	return candidate
+}
+
+func FreeTCPPort(t testing.TB) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free tcp port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func WaitForTCPPort(t testing.TB, address string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("tcp address %s did not become reachable: %v", address, lastErr)
+}
+
+func NewProject(t testing.TB, options Options) *Project {
+	t.Helper()
+
+	dockerPath := requireDockerCompose(t)
+	composeFile := strings.TrimSpace(options.ComposeFile)
+	if composeFile == "" {
+		composeFile = DefaultComposeFile(t)
+	}
+	if _, err := os.Stat(composeFile); err != nil {
+		t.Fatalf("stat compose file %s: %v", composeFile, err)
+	}
+
+	artifactDir := strings.TrimSpace(options.ArtifactDir)
+	if artifactDir == "" {
+		artifactDir = ArtifactRoot(t)
+	}
+	if err := os.MkdirAll(artifactDir, 0o750); err != nil {
+		t.Fatalf("create artifact dir %s: %v", artifactDir, err)
+	}
+
+	projectName := strings.TrimSpace(options.ProjectName)
+	if projectName == "" {
+		projectName = "openase-" + strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", ""))
+	}
+
+	project := &Project{
+		dockerPath:  dockerPath,
+		composeFile: filepath.Clean(composeFile),
+		artifactDir: filepath.Clean(artifactDir),
+		projectName: projectName,
+		repoRoot:    RepoRoot(t),
+		baseEnv:     cloneEnv(options.Env),
+	}
+	t.Cleanup(func() {
+		project.dumpAllLogs(t)
+		project.Down(t)
+	})
+	return project
+}
+
+func (p *Project) Up(t testing.TB, extraEnv map[string]string, services ...string) {
+	t.Helper()
+
+	if len(services) == 0 {
+		t.Fatal("compose up requires at least one service")
+	}
+	if _, err := p.runCommand(context.Background(), extraEnv, append([]string{"up", "-d"}, services...)...); err != nil {
+		t.Fatalf("compose up %v: %v", services, err)
+	}
+	p.startedNames = appendUnique(p.startedNames, services...)
+}
+
+func (p *Project) Down(t testing.TB) {
+	t.Helper()
+
+	if p == nil {
+		return
+	}
+	_, _ = p.runCommand(context.Background(), nil, "down", "--remove-orphans", "-v")
+}
+
+func (p *Project) Logs(t testing.TB, extraEnv map[string]string, services ...string) string {
+	t.Helper()
+
+	args := make([]string, 0, 3+len(services))
+	args = append(args, "logs", "--no-color", "--timestamps")
+	args = append(args, services...)
+	output, err := p.runCommand(context.Background(), extraEnv, args...)
+	if err != nil {
+		return strings.TrimSpace(string(output) + "\n" + err.Error())
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func (p *Project) WriteLogs(t testing.TB, name string, extraEnv map[string]string, services ...string) string {
+	t.Helper()
+
+	if p == nil {
+		return ""
+	}
+	logs := p.Logs(t, extraEnv, services...)
+	target := filepath.Join(p.artifactDir, sanitizeArtifactName(name))
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		t.Fatalf("create artifact parent for %s: %v", target, err)
+	}
+	if err := os.WriteFile(target, []byte(logs+"\n"), 0o600); err != nil {
+		t.Fatalf("write compose logs %s: %v", target, err)
+	}
+	return target
+}
+
+func (p *Project) dumpAllLogs(t testing.TB) {
+	t.Helper()
+
+	for _, service := range p.startedNames {
+		p.WriteLogs(t, service+".log", nil, service)
+	}
+}
+
+func (p *Project) runCommand(ctx context.Context, extraEnv map[string]string, args ...string) ([]byte, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	commandArgs := make([]string, 0, 5+len(args))
+	commandArgs = append(commandArgs, "compose", "-f", p.composeFile, "-p", p.projectName)
+	commandArgs = append(commandArgs, args...)
+
+	// #nosec G204 -- container test helper invokes a validated local docker CLI with controlled compose arguments.
+	command := exec.CommandContext(ctxWithTimeout, p.dockerPath, commandArgs...)
+	command.Env = mergedEnv(os.Environ(), p.baseEnv, extraEnv)
+	command.Dir = p.repoRoot
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("%w\n%s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func requireDockerCompose(t testing.TB) string {
+	t.Helper()
+
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		t.Skip("docker is not available on PATH")
+	}
+
+	checkCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	// #nosec G204 -- helper probes the local docker compose plugin through a validated docker CLI path.
+	output, err := exec.CommandContext(checkCtx, dockerPath, "compose", "version").CombinedOutput()
+	if err != nil {
+		t.Skipf("docker compose is unavailable: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return dockerPath
+}
+
+func cloneEnv(input map[string]string) map[string]string {
+	if len(input) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(input))
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func mergedEnv(base []string, maps ...map[string]string) []string {
+	merged := make(map[string]string, len(base))
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		merged[key] = value
+	}
+	for _, input := range maps {
+		for key, value := range input {
+			merged[key] = value
+		}
+	}
+
+	result := make([]string, 0, len(merged))
+	for key, value := range merged {
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+func appendUnique(existing []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(existing))
+	for _, value := range existing {
+		seen[value] = struct{}{}
+	}
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		existing = append(existing, value)
+	}
+	return existing
+}
+
+func sanitizeArtifactName(name string) string {
+	replacer := strings.NewReplacer("/", "-", "\\", "-", " ", "-", ":", "-")
+	return replacer.Replace(strings.TrimSpace(name))
+}

--- a/scripts/ci/remote-runtime/ssh-fixture/Dockerfile
+++ b/scripts/ci/remote-runtime/ssh-fixture/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash ca-certificates openssh-server procps \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash openase \
+    && mkdir -p /run/sshd /home/openase/.ssh /home/openase/.config/systemd/user /home/openase/.openase/logs /home/openase/.openase/fake-systemd \
+    && chown -R openase:openase /home/openase
+
+COPY scripts/ci/remote-runtime/ssh-fixture/systemctl /usr/local/bin/systemctl
+COPY scripts/ci/remote-runtime/ssh-fixture/journalctl /usr/local/bin/journalctl
+COPY scripts/ci/remote-runtime/ssh-fixture/start-sshd.sh /usr/local/bin/start-sshd.sh
+
+RUN chmod +x /usr/local/bin/systemctl /usr/local/bin/journalctl /usr/local/bin/start-sshd.sh \
+    && printf '%s\n' \
+        'Port 22' \
+        'PubkeyAuthentication yes' \
+        'PasswordAuthentication no' \
+        'ChallengeResponseAuthentication no' \
+        'UsePAM no' \
+        'PermitRootLogin no' \
+        'AllowUsers openase' \
+        'AuthorizedKeysFile .ssh/authorized_keys' \
+        >> /etc/ssh/sshd_config
+
+ENTRYPOINT ["/usr/local/bin/start-sshd.sh"]

--- a/scripts/ci/remote-runtime/ssh-fixture/journalctl
+++ b/scripts/ci/remote-runtime/ssh-fixture/journalctl
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+journal_file="${HOME}/.openase/fake-systemd/journal.log"
+if [ -f "${journal_file}" ]; then
+  cat "${journal_file}"
+fi

--- a/scripts/ci/remote-runtime/ssh-fixture/start-sshd.sh
+++ b/scripts/ci/remote-runtime/ssh-fixture/start-sshd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /run/sshd /home/openase/.ssh /home/openase/.config/systemd/user /home/openase/.openase/logs /home/openase/.openase/fake-systemd
+touch /home/openase/.ssh/authorized_keys
+chmod 700 /home/openase/.ssh
+chmod 600 /home/openase/.ssh/authorized_keys
+chown -R openase:openase /home/openase/.ssh /home/openase/.config /home/openase/.openase
+
+exec /usr/sbin/sshd -D -e

--- a/scripts/ci/remote-runtime/ssh-fixture/systemctl
+++ b/scripts/ci/remote-runtime/ssh-fixture/systemctl
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+state_root="${HOME}/.openase/fake-systemd"
+journal_file="${state_root}/journal.log"
+stdout_file="${HOME}/.openase/logs/openase-machine-agent.stdout.log"
+stderr_file="${HOME}/.openase/logs/openase-machine-agent.stderr.log"
+state_file="${state_root}/openase-machine-agent.state"
+
+mkdir -p "${state_root}" "$(dirname "${stdout_file}")"
+
+command_name=""
+service_name="openase-machine-agent.service"
+for arg in "$@"; do
+  case "$arg" in
+    --user)
+      ;;
+    daemon-reload|enable|restart|is-active|show)
+      if [ -z "$command_name" ]; then
+        command_name="$arg"
+      fi
+      ;;
+    *.service)
+      service_name="$arg"
+      ;;
+  esac
+done
+
+service_file="${HOME}/.config/systemd/user/${service_name}"
+
+case "${command_name}" in
+  daemon-reload)
+    printf '%s daemon-reload\n' "$(date -u +%FT%TZ)" >> "${journal_file}"
+    exit 0
+    ;;
+  enable)
+    printf '%s enable %s\n' "$(date -u +%FT%TZ)" "${service_name}" >> "${journal_file}"
+    exit 0
+    ;;
+  restart)
+    if [ ! -f "${service_file}" ]; then
+      printf 'missing service file %s\n' "${service_file}" >&2
+      exit 1
+    fi
+    printf 'fake machine-agent restart\n' >> "${stdout_file}"
+    : > "${stderr_file}"
+    printf '%s restart %s\n' "$(date -u +%FT%TZ)" "${service_name}" >> "${journal_file}"
+    printf 'active\n' > "${state_file}"
+    exit 0
+    ;;
+  is-active)
+    if [ -f "${state_file}" ]; then
+      cat "${state_file}"
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 3
+    ;;
+  show)
+    if [ -f "${state_file}" ]; then
+      printf 'ActiveState=active\nSubState=running\n'
+    else
+      printf 'ActiveState=inactive\nSubState=dead\n'
+    fi
+    exit 0
+    ;;
+esac
+
+printf 'unsupported fake systemctl command: %s\n' "$*" >&2
+exit 1

--- a/scripts/ci/remote_runtime_container.compose.yml
+++ b/scripts/ci/remote_runtime_container.compose.yml
@@ -1,0 +1,50 @@
+services:
+  ws-listener:
+    image: debian:bookworm-slim
+    init: true
+    user: "${OPENASE_TEST_UID:-0}:${OPENASE_TEST_GID:-0}"
+    environment:
+      OPENASE_TEST_WS_LISTENER_HELPER: "1"
+      OPENASE_TEST_WS_LISTENER_PORT: "${OPENASE_TEST_WS_LISTENER_PORT:-19852}"
+    command:
+      - /bin/sh
+      - -lc
+      - exec /opt/openase/ws-listener.test -test.run '^TestWebsocketListenerRuntimeContainerHelper$' -test.timeout=0
+    volumes:
+      - "${OPENASE_TEST_WS_LISTENER_BINARY:-/tmp/ws-listener.test}:/opt/openase/ws-listener.test:ro"
+      - "${OPENASE_TEST_TMP_ROOT:-/tmp}:${OPENASE_TEST_TMP_ROOT:-/tmp}"
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+    ports:
+      - "127.0.0.1:${OPENASE_TEST_WS_LISTENER_HOST_PORT:-19852}:${OPENASE_TEST_WS_LISTENER_PORT:-19852}"
+
+  reverse-daemon:
+    image: debian:bookworm-slim
+    init: true
+    user: "${OPENASE_TEST_UID:-0}:${OPENASE_TEST_GID:-0}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      OPENASE_MACHINE_ID: "${OPENASE_MACHINE_ID:-}"
+      OPENASE_MACHINE_CHANNEL_TOKEN: "${OPENASE_MACHINE_CHANNEL_TOKEN:-}"
+      OPENASE_MACHINE_CONTROL_PLANE_URL: "${OPENASE_MACHINE_CONTROL_PLANE_URL:-}"
+      OPENASE_MACHINE_HEARTBEAT_INTERVAL: "${OPENASE_MACHINE_HEARTBEAT_INTERVAL:-200ms}"
+    command:
+      - /bin/sh
+      - -lc
+      - exec /opt/openase/openase machine-agent run --openase-binary-path /opt/openase/openase --agent-cli-path /bin/sh --reconnect-backoff 250ms
+    volumes:
+      - "${OPENASE_TEST_OPENASE_BINARY:-/tmp/openase}:/opt/openase/openase:ro"
+      - "${OPENASE_TEST_TMP_ROOT:-/tmp}:${OPENASE_TEST_TMP_ROOT:-/tmp}"
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+
+  ssh-helper:
+    build:
+      context: ../..
+      dockerfile: scripts/ci/remote-runtime/ssh-fixture/Dockerfile
+    init: true
+    ports:
+      - "127.0.0.1:${OPENASE_TEST_SSH_HELPER_HOST_PORT:-2222}:22"
+    volumes:
+      - "${OPENASE_TEST_SSH_AUTHORIZED_KEYS:-/tmp/authorized_keys}:/home/openase/.ssh/authorized_keys"

--- a/scripts/ci/remote_runtime_container_harness.sh
+++ b/scripts/ci/remote_runtime_container_harness.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ -x "$ROOT_DIR/.tooling/go/bin/go" ]; then
+  export PATH="$ROOT_DIR/.tooling/go/bin:$PATH"
+elif [ -x "$HOME/.local/go1.26.1/bin/go" ]; then
+  export PATH="$HOME/.local/go1.26.1/bin:$PATH"
+fi
+
+declare -A CASE_PKGS=(
+  [listener]="./internal/infra/machinetransport"
+  [reverse]="./internal/infra/machinetransport"
+  [ssh]="./internal/cli"
+)
+
+declare -A CASE_PATTERNS=(
+  [listener]='TestWebsocketListenerRuntimeContainerE2E$'
+  [reverse]='TestWebsocketReverseRuntimeContainerE2E$'
+  [ssh]='TestMachineSSHHelperContainerE2E$'
+)
+
+declare -A CASE_LABELS=(
+  [listener]='Direct-connect websocket runtime container e2e'
+  [reverse]='Reverse-connect websocket runtime container e2e'
+  [ssh]='SSH helper container e2e'
+)
+
+usage() {
+  cat <<'EOF'
+usage: scripts/ci/remote_runtime_container_harness.sh [listener] [reverse] [ssh]
+
+Runs the slow local-only remote runtime container harness. With no arguments,
+it runs all supported cases.
+
+Artifacts are written under:
+  .artifacts/remote-runtime-container
+
+Environment overrides:
+  OPENASE_REMOTE_RUNTIME_ARTIFACT_DIR
+  OPENASE_TEST_REMOTE_RUNTIME_COMPOSE_FILE
+  OPENASE_TEST_OPENASE_BINARY
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+ARTIFACT_DIR="${OPENASE_REMOTE_RUNTIME_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/remote-runtime-container}"
+COMPOSE_FILE="${OPENASE_TEST_REMOTE_RUNTIME_COMPOSE_FILE:-$ROOT_DIR/scripts/ci/remote_runtime_container.compose.yml}"
+OPENASE_BINARY="${OPENASE_TEST_OPENASE_BINARY:-$ROOT_DIR/bin/openase}"
+
+mkdir -p "$ARTIFACT_DIR"
+
+if [ ! -x "$OPENASE_BINARY" ]; then
+  printf 'OpenASE binary %s is missing or not executable; building it first.\n' "$OPENASE_BINARY"
+  (
+    cd "$ROOT_DIR"
+    make build
+  )
+fi
+
+export OPENASE_RUN_REMOTE_RUNTIME_CONTAINER_TESTS=1
+export OPENASE_TEST_OPENASE_BINARY="$OPENASE_BINARY"
+export OPENASE_TEST_REMOTE_RUNTIME_COMPOSE_FILE="$COMPOSE_FILE"
+export OPENASE_REMOTE_RUNTIME_ARTIFACT_DIR="$ARTIFACT_DIR"
+
+if [ "$#" -eq 0 ]; then
+  set -- listener reverse ssh
+fi
+
+run_case() {
+  local case_name="$1"
+  local label="${CASE_LABELS[$case_name]:-}"
+  local pkg="${CASE_PKGS[$case_name]:-}"
+  local pattern="${CASE_PATTERNS[$case_name]:-}"
+  local logfile="$ARTIFACT_DIR/${case_name}.go-test.log"
+
+  if [ -z "$label" ] || [ -z "$pkg" ] || [ -z "$pattern" ]; then
+    printf 'unknown case: %s\n' "$case_name" >&2
+    usage >&2
+    exit 1
+  fi
+
+  printf '\n== %s ==\n' "$label"
+  (
+    cd "$ROOT_DIR"
+    go test "$pkg" -count=1 -run "$pattern"
+  ) 2>&1 | tee "$logfile"
+}
+
+for case_name in "$@"; do
+  run_case "$case_name"
+done

--- a/scripts/ci/remote_transport_matrix.sh
+++ b/scripts/ci/remote_transport_matrix.sh
@@ -37,14 +37,19 @@ run_case \
   'TestMachineConnectWebsocketAuthFailurePublishesActivityAndMetric$'
 
 run_case \
+  "SSH bootstrap helper behavior" \
+  "./internal/cli" \
+  'TestRunMachineSSHBootstrapUploadsBinaryEnvAndService$'
+
+run_case \
+  "SSH diagnostics helper behavior" \
+  "./internal/cli" \
+  'TestRunMachineSSHDiagnosticsReportsBootstrapAndRegistrationIssues$'
+
+run_case \
   "Listener websocket runtime happy path" \
   "./internal/orchestrator" \
   'TestRuntimeLauncherLaunchesWebsocketListenerRuntimeWithHooksAndArtifactSync$'
-
-run_case \
-  "Listener websocket runtime container e2e" \
-  "./internal/infra/machinetransport" \
-  'TestWebsocketListenerRuntimeContainerE2E$'
   
 run_case \
   "Reverse websocket runtime happy path" \


### PR DESCRIPTION
## Summary
- add a docker compose-driven local harness for remote runtime validation with targeted `listener`, `reverse`, and `ssh` cases
- cover direct websocket, reverse websocket, and SSH helper behavior with real containers plus compose log/artifact capture
- document the local entrypoint and keep the fast transport matrix focused on non-container checks

## Validation
- `PATH="$HOME/.local/go1.26.1/bin:$PATH" ./scripts/ci/with_clean_openase_test_env.sh go test ./internal/infra/machinetransport ./internal/cli`
- `PATH="$HOME/.local/go1.26.1/bin:$PATH" ./scripts/ci/remote_runtime_container_harness.sh listener reverse ssh`
- `PATH="$HOME/.local/go1.26.1/bin:$PATH:$HOME/.nvm/versions/node/v22.22.1/bin" .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- the harness is intentionally local/manual and does not add a repo workflow file yet; if we want GitHub-hosted manual/nightly execution later, that should land with credentials that can update workflow paths

Closes ASE-41.
