### PR TITLE
Load shared workflow guidance from markdown asset

### DIFF
--- a/internal/orchestrator/prompts/common-workflow-guidelines.md
+++ b/internal/orchestrator/prompts/common-workflow-guidelines.md
@@ -1,4 +1,4 @@
-## Workflow Execution Rules
+## Shared Workflow Execution Rules
 
 Apply these rules to every workflow execution in addition to the workflow-specific harness.
 

--- a/internal/orchestrator/prompts/common-workflow-guidelines.md
+++ b/internal/orchestrator/prompts/common-workflow-guidelines.md
@@ -1,0 +1,49 @@
+## Shared Workflow Execution Rules
+
+Apply these rules to every workflow execution in addition to the workflow-specific harness.
+
+### Scope and Boundaries
+
+- Work only on the current ticket's direct scope.
+- Do not expand the task into unrelated cleanup or broad refactors unless the ticket explicitly requires it.
+- Do not guess missing requirements, platform state, or undocumented interfaces.
+- If critical context is missing or contradictory, record the blocker and stop expanding execution.
+
+### Standard Execution Flow
+
+1. Understand the ticket goal, constraints, dependencies, and current status.
+2. Read the minimum necessary project and repository context before changing anything.
+3. Confirm the real root cause or implementation target before editing code or configuration.
+4. Make the smallest change that fully resolves the scoped task.
+5. Run the most relevant validation for the work you changed.
+6. Record meaningful progress, blockers, and outcomes back to OpenASE.
+7. Move the ticket toward the correct workflow finish state when the work is actually complete.
+
+### Validation Expectations
+
+- Prefer real validation over assumption.
+- Use existing tests when they cover the changed behavior.
+- If no relevant automated test exists, perform the smallest credible manual or command-based verification and state what was checked.
+- Do not distort the implementation just to satisfy a test harness.
+
+### Platform Writeback
+
+- Treat OpenASE as the control plane for ticket status, progress, and execution traceability.
+- Use the runtime-provided OpenASE tools and contracts for platform reads and writes.
+- Record blockers clearly with cause, impact, and the next action needed.
+- When the task completes, ensure the final result, validation, and remaining risk are reflected in the platform output.
+
+### Failure and Blocker Handling
+
+- Stop and surface the issue when requirements are unclear, permissions are insufficient, dependencies are unavailable, or the environment is broken.
+- Explain what was attempted, what remains blocked, and what additional input or change is required.
+- Avoid speculative retries that do not produce new information.
+
+### Output Contract
+
+Final execution output should make clear:
+
+- what changed or was delivered
+- what validation ran and what the result was
+- any residual risk or follow-up
+- whether the ticket is ready for the workflow's finish state

--- a/internal/orchestrator/prompts/common-workflow-guidelines.md
+++ b/internal/orchestrator/prompts/common-workflow-guidelines.md
@@ -1,49 +1,76 @@
-## Shared Workflow Execution Rules
+## Workflow Execution Rules
 
 Apply these rules to every workflow execution in addition to the workflow-specific harness.
 
+### Execution Background
+
+You are running inside the OpenASE ticket execution system in an unattended mode.
+Complete the current ticket according to its content and use the `openase-platform`
+skill and runtime-provided OpenASE contract to manipulate ticket state and advance
+execution progress.
+
+### State Clarification
+
+Tickets move through workflow status bindings. Align your behavior to the workflow's
+configured status sets:
+
+- Pickup status: the workflow's pickup status is the initiation status. A ticket in
+  a pickup status remains eligible for continued workflow execution and does not end
+  the run by itself.
+- Successful finish status: when the ticket task is actually completed, move the
+  ticket to the correct workflow finish status that represents successful completion.
+  This ends execution for the current run.
+- Blocked finish status: if the ticket reaches a truly unprogressable state, move it
+  to the workflow finish status that represents blocked or abnormal termination, if
+  such a status is provided by the workflow. Do not use a blocked finish status
+  unless the task is genuinely unable to progress further.
+
 ### Scope and Boundaries
 
-- Work only on the current ticket's direct scope.
-- Do not expand the task into unrelated cleanup or broad refactors unless the ticket explicitly requires it.
-- Do not guess missing requirements, platform state, or undocumented interfaces.
-- If critical context is missing or contradictory, record the blocker and stop expanding execution.
+- Only work within the immediate scope of the current ticket.
+- Other tickets, broad cleanup, and unrelated refactors are out of scope unless the
+  current ticket explicitly requires them.
 
 ### Standard Execution Flow
 
-1. Understand the ticket goal, constraints, dependencies, and current status.
-2. Read the minimum necessary project and repository context before changing anything.
-3. Confirm the real root cause or implementation target before editing code or configuration.
-4. Make the smallest change that fully resolves the scoped task.
-5. Run the most relevant validation for the work you changed.
-6. Record meaningful progress, blockers, and outcomes back to OpenASE.
-7. Move the ticket toward the correct workflow finish state when the work is actually complete.
+1. Understand the ticket's goals, constraints, dependencies, and current status.
+2. Run the most relevant validations on the work you changed.
+3. Record meaningful progress, blocker reasons, and results back into OpenASE.
+4. Move the ticket to the correct workflow finish status only when the work is
+   actually completed or truly blocked.
 
-### Validation Expectations
+### Information Delivery Mechanism
 
-- Prefer real validation over assumption.
-- Use existing tests when they cover the changed behavior.
-- If no relevant automated test exists, perform the smallest credible manual or command-based verification and state what was checked.
-- Do not distort the implementation just to satisfy a test harness.
+1. Do not rely on direct terminal output as the primary delivery channel. Use ticket
+   comments as the durable output channel.
+2. Ticket requirements and task inputs are delivered through the ticket content and
+   related project context.
+3. Deliverables are shipped through the code repository. Commit and push all
+   required changes before moving the ticket into a workflow finish status, or the
+   unpublished work may be lost after execution ends.
+4. Do not assume questions, pauses, or interactive waiting will receive a response.
+5. If Project Updates or an Update thread are available in the current runtime,
+   prefer that higher-visibility channel only for emergencies or severe blockers.
 
-### Platform Writeback
+### Fault and Blockage Handling
 
-- Treat OpenASE as the control plane for ticket status, progress, and execution traceability.
-- Use the runtime-provided OpenASE tools and contracts for platform reads and writes.
-- Record blockers clearly with cause, impact, and the next action needed.
-- When the task completes, ensure the final result, validation, and remaining risk are reflected in the platform output.
+- Qualifying blockers are severe permission deficiencies, severe environment
+  corruption, or a state where all reasonable methods have been tried and the ticket
+  still cannot progress. In that case, move the ticket to the blocked finish status
+  and describe the problem clearly.
+- Do not treat normal dependency setup, network-based research, repository
+  investigation, or difficult implementation work as blockers by default. Maintain
+  high autonomy and continue experimenting unless the environment is truly unable to
+  support progress.
+- Describe the operations already tried, what remains blocked, and what additional
+  input or change would be required. Avoid speculative retries that do not produce
+  new information.
 
-### Failure and Blocker Handling
+### Recommended Output Protocol
 
-- Stop and surface the issue when requirements are unclear, permissions are insufficient, dependencies are unavailable, or the environment is broken.
-- Explain what was attempted, what remains blocked, and what additional input or change is required.
-- Avoid speculative retries that do not produce new information.
+Record final execution output in ticket comments:
 
-### Output Contract
-
-Final execution output should make clear:
-
-- what changed or was delivered
-- what validation ran and what the result was
-- any residual risk or follow-up
-- whether the ticket is ready for the workflow's finish state
+- changes or deliverables
+- validations that were run and their results
+- lingering risks or follow-up issues
+- whether the ticket is ready to enter the workflow finish status

--- a/internal/orchestrator/runtime_launcher.go
+++ b/internal/orchestrator/runtime_launcher.go
@@ -1512,15 +1512,7 @@ func (l *RuntimeLauncher) buildDeveloperInstructions(
 		return "", fmt.Errorf("render workflow harness for agent launch: %w", err)
 	}
 
-	rendered = strings.TrimSpace(rendered)
-	platformContract = strings.TrimSpace(platformContract)
-	if platformContract == "" {
-		return rendered, nil
-	}
-	if rendered == "" {
-		return platformContract, nil
-	}
-	return rendered + "\n\n" + platformContract, nil
+	return composeWorkflowDeveloperInstructions(rendered, platformContract), nil
 }
 
 type runtimeLaunchContext struct {

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -257,6 +257,9 @@ Access {% for machine in accessible_machines %}{{ machine.name }}={{ machine.ssh
 	if !strings.Contains(manager.capturedThreadStart().DeveloperInstructions, "## OpenASE Platform Capability Contract") {
 		t.Fatalf("expected platform capability contract in developer instructions, got %q", manager.capturedThreadStart().DeveloperInstructions)
 	}
+	if !strings.Contains(manager.capturedThreadStart().DeveloperInstructions, "## Shared Workflow Execution Rules") {
+		t.Fatalf("expected shared workflow guidance in developer instructions, got %q", manager.capturedThreadStart().DeveloperInstructions)
+	}
 	if !strings.Contains(manager.capturedThreadStart().DeveloperInstructions, "Current principal: `ticket_agent`") {
 		t.Fatalf("expected ticket principal contract in developer instructions, got %q", manager.capturedThreadStart().DeveloperInstructions)
 	}

--- a/internal/orchestrator/workflow_prompt_guidelines.go
+++ b/internal/orchestrator/workflow_prompt_guidelines.go
@@ -1,0 +1,36 @@
+package orchestrator
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+)
+
+//go:embed prompts/common-workflow-guidelines.md
+var workflowPromptAssets embed.FS
+
+var sharedWorkflowExecutionRules = mustReadWorkflowPromptAsset("prompts/common-workflow-guidelines.md")
+
+func composeWorkflowDeveloperInstructions(renderedHarness string, platformContract string) string {
+	sections := []string{
+		strings.TrimSpace(renderedHarness),
+		sharedWorkflowExecutionRules,
+		strings.TrimSpace(platformContract),
+	}
+	nonEmpty := make([]string, 0, len(sections))
+	for _, section := range sections {
+		if section == "" {
+			continue
+		}
+		nonEmpty = append(nonEmpty, section)
+	}
+	return strings.Join(nonEmpty, "\n\n")
+}
+
+func mustReadWorkflowPromptAsset(path string) string {
+	data, err := workflowPromptAssets.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("read workflow prompt asset %q: %v", path, err))
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/orchestrator/workflow_prompt_guidelines_test.go
+++ b/internal/orchestrator/workflow_prompt_guidelines_test.go
@@ -1,0 +1,31 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComposeWorkflowDeveloperInstructionsIncludesSharedGuidance(t *testing.T) {
+	instructions := composeWorkflowDeveloperInstructions(
+		"# Workflow\n\nImplement the ticket using the current workspace.",
+		"## OpenASE Platform Capability Contract",
+	)
+
+	if !strings.Contains(instructions, "Implement the ticket using the current workspace.") {
+		t.Fatalf("expected rendered harness in instructions, got %q", instructions)
+	}
+	if !strings.Contains(instructions, "## Shared Workflow Execution Rules") {
+		t.Fatalf("expected shared workflow guidance in instructions, got %q", instructions)
+	}
+	if !strings.Contains(instructions, "## OpenASE Platform Capability Contract") {
+		t.Fatalf("expected platform contract in instructions, got %q", instructions)
+	}
+}
+
+func TestComposeWorkflowDeveloperInstructionsFallsBackToSharedGuidance(t *testing.T) {
+	instructions := composeWorkflowDeveloperInstructions("", "")
+
+	if !strings.Contains(instructions, "## Shared Workflow Execution Rules") {
+		t.Fatalf("expected shared workflow guidance without optional sections, got %q", instructions)
+	}
+}


### PR DESCRIPTION
## Summary
- move the shared workflow execution rules into a dedicated markdown asset under       `internal/orchestrator/prompts/`
- load that markdown asset in the backend runtime prompt assembly path instead of hardcoding the shared guidance in Go
- cover the new prompt composition helper and assert launched developer instructions include the shared guidance

## Validation
- `gofmt -w internal/orchestrator/runtime_launcher.go internal/orchestrator/runtime_launcher_test.go internal/orchestrator/workflow_prompt_guidelines.go internal/orchestrator/workflow_prompt_guidelines_test.go`
- `go test ./internal/orchestrator -run 'TestComposeWorkflowDeveloperInstructions|TestRuntimeLauncherRunTickTransitionsClaimedAgentToReady'`
- `make PNPM='npx --yes pnpm' openapi-check-ci`
- `env OPENASE_BACKEND_TEST_GROUP_SIZE=8 make PNPM='npx --yes pnpm' check`
- `make PNPM='npx --yes pnpm' build`
- `make PNPM='npx --yes pnpm' LINT_BASE_REV='794c3f948bd7387bf7539e440d3df0968600d0a6' lint`
- `make PNPM='npx --yes pnpm' lint-depguard`
- `make PNPM='npx --yes pnpm' lint-architecture`

## Risks / Follow-up
- the shared workflow guidance is now centralized in `internal/orchestrator/prompts/common-workflow-guidelines.md`; future wording changes there will affect every workflow runtime prompt
- the repo-local CI helper script currently assumes the git root is the workspace root, so I ran the equivalent repo-root commands directly for this nested checkout
