### PR TITLE
ASE-165 Guard human/platform route suffix alignment

### DIFF
--- a/internal/builtin/skills/openase-platform/SKILL.md
+++ b/internal/builtin/skills/openase-platform/SKILL.md
@@ -137,7 +137,9 @@ When the principal is `ticket_agent`:
 When the principal is `project_conversation`:
 
 - Treat this as a project-scoped conversation runtime, not a ticket runtime.
-- Use project-scoped ticket mutation routes when `tickets.update` is granted.
+- Use the canonical ticket mutation routes when `tickets.update` is granted;
+  project scope still comes from the token claims even though the suffix stays
+  aligned with the human control plane.
 - Do not assume current-ticket comment/update/report-usage endpoints are
   available.
 - Ticket-runtime-only routes can reject this principal kind even when
@@ -298,8 +300,8 @@ Capabilities:
 - At least one update field is required
 
 In `project_conversation` runtimes, do not assume the current-ticket variant is
-available. Prefer project-scoped ticket mutation routes or the typed command
-shape exposed by the current runtime contract.
+available. Prefer the canonical ticket mutation routes exposed by the typed
+command shape in the current runtime contract.
 
 ### 4. Record usage / cost
 

--- a/internal/cli/platform.go
+++ b/internal/cli/platform.go
@@ -946,10 +946,6 @@ func (platform platformContext) hasScope(scope string) bool {
 	return slicesContains(platform.scopes, strings.TrimSpace(scope))
 }
 
-func (platform platformContext) useProjectScopedTicketUpdate() bool {
-	return platform.hasScope("tickets.update")
-}
-
 func (platform platformContext) parseTicketListInput(raw ticketListInput) (ticketListInput, error) {
 	projectID := strings.TrimSpace(firstNonEmpty(raw.projectID, platform.projectID))
 	if projectID == "" {
@@ -1372,15 +1368,7 @@ func (client platformClient) updateTicket(ctx context.Context, platform platform
 		payload["archived"] = input.archived
 	}
 
-	path := "/tickets/" + url.PathEscape(input.ticketID)
-	if platform.useProjectScopedTicketUpdate() {
-		if strings.TrimSpace(platform.projectID) == "" {
-			return nil, fmt.Errorf("project id is required via --project-id or OPENASE_PROJECT_ID for project-scoped ticket updates")
-		}
-		path = "/projects/" + url.PathEscape(platform.projectID) + "/tickets/" + url.PathEscape(input.ticketID)
-	}
-
-	return client.doJSON(ctx, platform, http.MethodPatch, path, payload)
+	return client.doJSON(ctx, platform, http.MethodPatch, "/tickets/"+url.PathEscape(input.ticketID), payload)
 }
 
 func (client platformClient) reportTicketUsage(ctx context.Context, platform platformContext, input ticketReportUsageInput) ([]byte, error) {

--- a/internal/cli/platform_test.go
+++ b/internal/cli/platform_test.go
@@ -390,8 +390,8 @@ func TestTicketUpdateCommandFallsBackToCurrentTicketEnv(t *testing.T) {
 		t.Fatalf("ExecuteContext returned error: %v", err)
 	}
 
-	if path != "/projects/project-123/tickets/ticket-9" {
-		t.Fatalf("expected project-scoped ticket path, got %q", path)
+	if path != "/tickets/ticket-9" {
+		t.Fatalf("expected canonical ticket path, got %q", path)
 	}
 	if payload["description"] != "updated" {
 		t.Fatalf("unexpected update payload: %+v", payload)
@@ -425,8 +425,8 @@ func TestTicketUpdateCommandAcceptsStatusName(t *testing.T) {
 		t.Fatalf("ExecuteContext returned error: %v", err)
 	}
 
-	if path != "/projects/project-123/tickets/ticket-9" {
-		t.Fatalf("expected project-scoped ticket path, got %q", path)
+	if path != "/tickets/ticket-9" {
+		t.Fatalf("expected canonical ticket path, got %q", path)
 	}
 	if payload["status_name"] != "Done" {
 		t.Fatalf("unexpected update payload: %+v", payload)
@@ -468,8 +468,8 @@ func TestTicketUpdateCommandSupportsExpandedPatchSurface(t *testing.T) {
 		t.Fatalf("ExecuteContext returned error: %v", err)
 	}
 
-	if path != "/projects/project-123/tickets/ticket-9" {
-		t.Fatalf("expected project-scoped ticket path, got %q", path)
+	if path != "/tickets/ticket-9" {
+		t.Fatalf("expected canonical ticket path, got %q", path)
 	}
 	for key, want := range map[string]any{
 		"priority":         "high",
@@ -711,7 +711,7 @@ func TestTicketUpdateCommandUsesCurrentTicketRouteWithoutProjectScope(t *testing
 	}
 }
 
-func TestTicketUpdateCommandUsesProjectScopedRouteWhenTicketsUpdateScopePresent(t *testing.T) {
+func TestTicketUpdateCommandUsesCanonicalRouteWhenTicketsUpdateScopePresent(t *testing.T) {
 	var method string
 	var path string
 	var payload map[string]any
@@ -742,8 +742,8 @@ func TestTicketUpdateCommandUsesProjectScopedRouteWhenTicketsUpdateScopePresent(
 	if method != http.MethodPatch {
 		t.Fatalf("expected PATCH, got %s", method)
 	}
-	if path != "/projects/project-123/tickets/ticket-456" {
-		t.Fatalf("expected project-scoped update path, got %q", path)
+	if path != "/tickets/ticket-456" {
+		t.Fatalf("expected canonical update path, got %q", path)
 	}
 	if payload["status_name"] != "Done" {
 		t.Fatalf("unexpected ticket update payload: %+v", payload)

--- a/internal/httpapi/agent_platform_api.go
+++ b/internal/httpapi/agent_platform_api.go
@@ -26,10 +26,9 @@ func (s *Server) registerAgentPlatformRoutes(api *echo.Group) {
 	api.GET("/projects/:projectId/workflows", s.handleAgentListProjectWorkflows)
 	api.GET("/projects/:projectId/updates", s.handleAgentListProjectUpdates)
 	api.POST("/projects/:projectId/tickets", s.handleAgentCreateTicket)
-	api.PATCH("/projects/:projectId/tickets/:ticketId", s.handleAgentUpdateProjectTicket)
 	api.POST("/projects/:projectId/updates", s.handleAgentCreateProjectUpdateThread)
 	api.GET("/tickets/:ticketId", s.handleAgentGetOwnTicket)
-	api.PATCH("/tickets/:ticketId", s.handleAgentUpdateOwnTicket)
+	api.PATCH("/tickets/:ticketId", s.handleAgentUpdateTicket)
 	api.GET("/tickets/:ticketId/comments", s.handleAgentListOwnTicketComments)
 	api.POST("/tickets/:ticketId/comments", s.handleAgentCreateOwnTicketComment)
 	api.PATCH("/tickets/:ticketId/comments/:commentId", s.handleAgentUpdateOwnTicketComment)
@@ -217,50 +216,14 @@ func (s *Server) handleAgentGetOwnTicket(c echo.Context) error {
 	})
 }
 
-func (s *Server) handleAgentUpdateOwnTicket(c echo.Context) error {
+func (s *Server) handleAgentUpdateTicket(c echo.Context) error {
 	if s.ticketService == nil {
 		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	claims, current, ok := s.requireAgentOwnTicket(c, agentplatform.ScopeTicketsUpdateSelf)
+	claims, current, ok := s.requireAgentTicketUpdate(c)
 	if !ok {
 		return nil
-	}
-	if current.ProjectID != claims.ProjectID {
-		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
-	}
-
-	return s.handleAgentTicketUpdate(c, claims, current)
-}
-
-func (s *Server) handleAgentUpdateProjectTicket(c echo.Context) error {
-	if s.ticketService == nil {
-		return writeTicketError(c, ticketservice.ErrUnavailable)
-	}
-
-	claims, ok := requireAgentScope(c, agentplatform.ScopeTicketsUpdate)
-	if !ok {
-		return nil
-	}
-
-	projectID, err := parseProjectID(c)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_PROJECT_ID", err.Error())
-	}
-	if claims.ProjectID != projectID {
-		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
-	}
-
-	ticketID, err := parseTicketID(c)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_TICKET_ID", err.Error())
-	}
-	current, err := s.ticketService.Get(c.Request().Context(), ticketID)
-	if err != nil {
-		return writeTicketError(c, err)
-	}
-	if current.ProjectID != projectID {
-		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
 	return s.handleAgentTicketUpdate(c, claims, current)
@@ -817,6 +780,43 @@ func (s *Server) requireAgentOwnTicket(c echo.Context, scope agentplatform.Scope
 	current, err := s.ticketService.Get(c.Request().Context(), ticketID)
 	if err != nil {
 		_ = writeTicketError(c, err)
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	return claims, current, true
+}
+
+func (s *Server) requireAgentTicketUpdate(c echo.Context) (agentplatform.Claims, ticketservice.Ticket, bool) {
+	claims, ok := requireAgentAnyScope(c, agentplatform.ScopeTicketsUpdateSelf, agentplatform.ScopeTicketsUpdate)
+	if !ok {
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	ticketID, err := parseTicketID(c)
+	if err != nil {
+		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_TICKET_ID", err.Error())
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	current, err := s.ticketService.Get(c.Request().Context(), ticketID)
+	if err != nil {
+		_ = writeTicketError(c, err)
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+	if current.ProjectID != claims.ProjectID {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	if claims.HasScope(agentplatform.ScopeTicketsUpdate) {
+		return claims, current, true
+	}
+	if !claims.IsTicketAgent() {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PRINCIPAL_KIND_FORBIDDEN", "project conversation principals cannot access ticket-runtime-only endpoints")
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+	if claims.TicketID != ticketID {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_TICKET_FORBIDDEN", "agent token can only access its current ticket")
 		return agentplatform.Claims{}, ticketservice.Ticket{}, false
 	}
 

--- a/internal/httpapi/agent_platform_api_test.go
+++ b/internal/httpapi/agent_platform_api_test.go
@@ -319,18 +319,6 @@ func TestAgentPlatformTicketRoutesRespectScopesAndBoundaries(t *testing.T) {
 	if forbiddenRec.Code != http.StatusForbidden {
 		t.Fatalf("expected updating another ticket to return 403, got %d: %s", forbiddenRec.Code, forbiddenRec.Body.String())
 	}
-	projectScopedForbiddenRec := performJSONRequestWithHeaders(
-		t,
-		server,
-		http.MethodPatch,
-		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s", projectID, currentTicketID),
-		`{"description":"should fail"}`,
-		map[string]string{echo.HeaderAuthorization: "Bearer " + issued.Token, echo.HeaderContentType: echo.MIMEApplicationJSON},
-	)
-	if projectScopedForbiddenRec.Code != http.StatusForbidden {
-		t.Fatalf("expected project-scoped ticket update without tickets.update to return 403, got %d: %s", projectScopedForbiddenRec.Code, projectScopedForbiddenRec.Body.String())
-	}
-
 	forbiddenCommentRec := performJSONRequestWithHeaders(
 		t,
 		server,
@@ -666,7 +654,7 @@ func TestAgentPlatformProjectConversationTokenRejectsTicketOnlyRoutes(t *testing
 		t,
 		server,
 		http.MethodPatch,
-		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s", projectID, currentTicketID),
+		fmt.Sprintf("/api/v1/platform/tickets/%s", currentTicketID),
 		map[string]any{
 			"status_name": "In Progress",
 		},
@@ -675,7 +663,7 @@ func TestAgentPlatformProjectConversationTokenRejectsTicketOnlyRoutes(t *testing
 		&updateResp,
 	)
 	if updateResp.Ticket.StatusName != "In Progress" || updateResp.Ticket.CreatedBy != "project-conversation:"+conversationID.String() {
-		t.Fatalf("unexpected project-scoped update payload: %+v", updateResp.Ticket)
+		t.Fatalf("unexpected canonical ticket update payload: %+v", updateResp.Ticket)
 	}
 
 	forbiddenRec := performJSONRequestWithHeaders(
@@ -1171,11 +1159,8 @@ func TestAgentPlatformRouteErrorMappingsAndInvalidPayloads(t *testing.T) {
 	}{
 		{name: "list invalid project", method: http.MethodGet, target: "/api/v1/platform/projects/not-a-uuid/tickets", wantStatus: http.StatusBadRequest, wantBody: "INVALID_PROJECT_ID"},
 		{name: "create invalid request", method: http.MethodPost, target: fmt.Sprintf("/api/v1/platform/projects/%s/tickets", projectID), body: `{"title":"   "}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_REQUEST"},
-		{name: "project update invalid project", method: http.MethodPatch, target: fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s", "not-a-uuid", currentTicketID), body: `{"description":"nope"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_PROJECT_ID"},
-		{name: "project update invalid ticket", method: http.MethodPatch, target: fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s", projectID, "not-a-uuid"), body: `{"description":"nope"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_TICKET_ID"},
 		{name: "update invalid ticket", method: http.MethodPatch, target: "/api/v1/platform/tickets/not-a-uuid", body: `{"description":"nope"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_TICKET_ID"},
 		{name: "update invalid status", method: http.MethodPatch, target: fmt.Sprintf("/api/v1/platform/tickets/%s", currentTicketID), body: `{"status_id":"not-a-uuid"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_REQUEST"},
-		{name: "project update invalid status", method: http.MethodPatch, target: fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s", projectID, currentTicketID), body: `{"status_id":"not-a-uuid"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_REQUEST"},
 		{name: "report usage invalid ticket", method: http.MethodPost, target: "/api/v1/platform/tickets/not-a-uuid/usage", body: `{"input_tokens":1}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_TICKET_ID"},
 		{name: "report usage invalid request", method: http.MethodPost, target: fmt.Sprintf("/api/v1/platform/tickets/%s/usage", currentTicketID), body: `{}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_REQUEST"},
 		{name: "update project invalid project", method: http.MethodPatch, target: "/api/v1/platform/projects/not-a-uuid", body: `{"description":"x"}`, wantStatus: http.StatusBadRequest, wantBody: "INVALID_PROJECT_ID"},

--- a/internal/httpapi/agent_platform_expanded_api.go
+++ b/internal/httpapi/agent_platform_expanded_api.go
@@ -13,7 +13,7 @@ import (
 
 func (s *Server) registerExpandedAgentPlatformRoutes(api *echo.Group) {
 	api.GET("/projects/:projectId/activity", s.handleAgentListActivityEvents)
-	api.POST("/projects/:projectId/agents/:agentId/interrupt", s.handleAgentInterruptProjectAgent)
+	api.POST("/agents/:agentId/interrupt", s.handleAgentInterruptProjectAgent)
 	api.GET("/projects/:projectId/statuses", s.handleAgentListTicketStatuses)
 	api.POST("/projects/:projectId/statuses", s.handleAgentCreateTicketStatus)
 	api.POST("/projects/:projectId/statuses/reset", s.handleAgentResetTicketStatuses)
@@ -86,16 +86,6 @@ func (s *Server) requireAgentProjectAgentAnyScope(c echo.Context, scopes ...agen
 		return domain.Agent{}, false
 	}
 
-	projectID, err := parseProjectID(c)
-	if err != nil {
-		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_PROJECT_ID", err.Error())
-		return domain.Agent{}, false
-	}
-	if claims.ProjectID != projectID {
-		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
-		return domain.Agent{}, false
-	}
-
 	agentID, err := parseUUIDPathParamValue(c, "agentId")
 	if err != nil {
 		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_AGENT_ID", err.Error())
@@ -106,7 +96,7 @@ func (s *Server) requireAgentProjectAgentAnyScope(c echo.Context, scopes ...agen
 		_ = writeCatalogError(c, err)
 		return domain.Agent{}, false
 	}
-	if item.ProjectID != projectID {
+	if item.ProjectID != claims.ProjectID {
 		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 		return domain.Agent{}, false
 	}

--- a/internal/httpapi/route_alignment_test.go
+++ b/internal/httpapi/route_alignment_test.go
@@ -1,0 +1,118 @@
+package httpapi
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/BetterAndBetterII/openase/internal/agentplatform"
+	catalogservice "github.com/BetterAndBetterII/openase/internal/service/catalog"
+	"github.com/labstack/echo/v4"
+)
+
+// Shared platform resources must keep the same suffix as the human control
+// plane. This guard enforces canonical resource naming without merging the two
+// auth entrypoints: human-only routes can stay human-only, and explicit
+// platform-only runtime helpers stay in the exclusion list below.
+var platformRouteAlignmentExclusions = map[routeSignature]string{
+	{
+		method: http.MethodPost,
+		suffix: "/tickets/:ticketId/usage",
+	}: "platform-only runtime usage reporting helper; no human control-plane parity required",
+}
+
+type routeSignature struct {
+	method string
+	suffix string
+}
+
+func TestPlatformRoutesShareCanonicalResourceSuffixes(t *testing.T) {
+	t.Parallel()
+
+	echoServer := echo.New()
+	server := &Server{
+		echo:          echoServer,
+		agentPlatform: &agentplatform.Service{},
+		catalog: catalogservice.Services{
+			OrganizationService: authorizationRouteCoverageOrganizationService{},
+		},
+	}
+
+	api := echoServer.Group("/api/v1")
+	public := api.Group("")
+	protected := api.Group("")
+	registrar := routeRegistrar{server: server, api: api}
+	registrar.registerPublicAPIRoutes(public)
+	registrar.registerProtectedAPIRoutes(protected)
+
+	humanRoutes := make(map[routeSignature]struct{})
+	platformRoutes := make(map[routeSignature]struct{})
+	usedExclusions := make(map[routeSignature]struct{})
+
+	for _, route := range echoServer.Routes() {
+		if route.Method == http.MethodHead || route.Method == http.MethodOptions {
+			continue
+		}
+		switch route.Method {
+		case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		default:
+			continue
+		}
+		switch {
+		case strings.HasPrefix(route.Path, "/api/v1/platform/"):
+			signature := routeSignature{
+				method: route.Method,
+				suffix: strings.TrimPrefix(route.Path, "/api/v1/platform"),
+			}
+			platformRoutes[signature] = struct{}{}
+		case strings.HasPrefix(route.Path, "/api/v1/"):
+			signature := routeSignature{
+				method: route.Method,
+				suffix: strings.TrimPrefix(route.Path, "/api/v1"),
+			}
+			humanRoutes[signature] = struct{}{}
+		}
+	}
+
+	var missing []string
+	for signature := range platformRoutes {
+		if _, excluded := platformRouteAlignmentExclusions[signature]; excluded {
+			usedExclusions[signature] = struct{}{}
+			continue
+		}
+		if _, ok := humanRoutes[signature]; ok {
+			continue
+		}
+		missing = append(
+			missing,
+			signature.method+" /api/v1/platform"+signature.suffix+" -> expected "+signature.method+" /api/v1"+signature.suffix,
+		)
+	}
+
+	var staleExclusions []string
+	for signature, rationale := range platformRouteAlignmentExclusions {
+		if _, ok := usedExclusions[signature]; ok {
+			continue
+		}
+		staleExclusions = append(
+			staleExclusions,
+			signature.method+" /api/v1/platform"+signature.suffix+" ("+rationale+")",
+		)
+	}
+
+	slices.Sort(missing)
+	slices.Sort(staleExclusions)
+	if len(missing) > 0 || len(staleExclusions) > 0 {
+		if len(missing) > 0 {
+			t.Fatalf(
+				"platform routes must keep canonical human suffixes for shared resources:\n%s",
+				strings.Join(missing, "\n"),
+			)
+		}
+		t.Fatalf(
+			"platform route alignment exclusions are stale:\n%s",
+			strings.Join(staleExclusions, "\n"),
+		)
+	}
+}

--- a/scripts/ci/architecture_guard.py
+++ b/scripts/ci/architecture_guard.py
@@ -5,19 +5,27 @@ This script enforces dependency direction using package-prefix checks and an
 explicit temporary-debt allowlist. The allowlist is intentionally narrow:
 each exception is tied to one file and one forbidden import prefix so CI
 blocks new drift while existing debt is paid down incrementally.
+
+It also runs a route-suffix parity guard for the shared human vs platform HTTP
+surface. That guard preserves canonical resource suffixes without requiring the
+two entrypoints to merge authentication models or expose identical route sets.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import re
+import shutil
+import subprocess
 import sys
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 IMPORT_RE = re.compile(r'"([^"]+)"')
 GO_IMPORT_ROOT = "github.com/BetterAndBetterII/openase/"
+ROUTE_ALIGNMENT_TEST = "TestPlatformRoutesShareCanonicalResourceSuffixes"
 
 
 def go_import_prefix(path_prefix: str) -> str:
@@ -185,6 +193,51 @@ def parse_imports(path: Path) -> list[str]:
     return IMPORT_RE.findall(path.read_text())
 
 
+def resolve_go_binary() -> str:
+    tooling_go = REPO_ROOT / ".tooling/go/bin/go"
+    if tooling_go.exists():
+        return str(tooling_go)
+
+    path_go = shutil.which("go")
+    if path_go:
+        return path_go
+
+    fallback_go = Path.home() / ".local/go1.26.1/bin/go"
+    if fallback_go.exists():
+        return str(fallback_go)
+
+    return "go"
+
+
+def run_route_alignment_guard() -> int:
+    command = [
+        resolve_go_binary(),
+        "test",
+        "./internal/httpapi",
+        "-run",
+        f"^{ROUTE_ALIGNMENT_TEST}$",
+        "-count=1",
+    ]
+    env = os.environ.copy()
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 0:
+        print("Route suffix alignment guard passed.")
+        return 0
+
+    print("Route suffix alignment guard failed:", file=sys.stderr)
+    if completed.stdout.strip():
+        print(completed.stdout.rstrip(), file=sys.stderr)
+    if completed.stderr.strip():
+        print(completed.stderr.rstrip(), file=sys.stderr)
+    return completed.returncode
+
+
 def main() -> int:
     violations: list[str] = []
     used_exceptions: set[tuple[str, str]] = set()
@@ -258,7 +311,7 @@ def main() -> int:
         for key in sorted(used_exceptions):
             entry = all_exceptions[key]
             print(f"  - {entry.path} -> {entry.import_prefix} ({entry.rationale})")
-    return 0
+    return run_route_alignment_guard()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- canonicalize shared platform ticket update and agent interrupt routes so they keep the same suffixes as the human control plane
- add a registered-route suffix alignment test and wire it into `scripts/ci/architecture_guard.py`
- update CLI/platform tests and builtin `openase-platform` guidance to match the canonical route contract

## Validation
- `PATH=$PWD/.tooling/go/bin:$HOME/.local/go1.26.1/bin:$PATH go test ./internal/cli -run 'TestTicketUpdateCommand' -count=1`
- `OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest PATH=$PWD/.tooling/go/bin:$HOME/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run 'TestPlatformRoutesShareCanonicalResourceSuffixes|TestAgentPlatformRoutesForProjectConversationPrincipal|TestAgentPlatformRoutesErrorMappingsAndScopeEnforcement|TestAgentPlatformTicketRoutesForCurrentTicket' -count=1`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PWD/.tooling/go/bin:$HOME/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- platform-only usage reporting stays explicitly excluded from parity enforcement; if a human counterpart is introduced later, the exclusion should be removed and the guard will flag it as stale
