### PR TITLE
Add reverse websocket lifecycle CI coverage

### DIFF
--- a/internal/infra/machinetransport/reverse_runtime_relay_test.go
+++ b/internal/infra/machinetransport/reverse_runtime_relay_test.go
@@ -52,10 +52,58 @@ func TestReverseRuntimeRelayRemoveDisconnectsManagedSessions(t *testing.T) {
 
 	registry.Remove("session-a")
 
-	if _, err := registry.client(machineID); err == nil {
-		t.Fatal("expected removed reverse runtime session to become unavailable")
+	if _, err := registry.client(machineID); !errors.Is(err, ErrTransportUnavailable) {
+		t.Fatalf("expected removed reverse runtime session to report transport unavailable, got %v", err)
 	}
 	if err := managedSession.Wait(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled after reverse runtime disconnect, got %v", err)
+	}
+}
+
+func TestReverseRuntimeRelayRemoveStaleSessionKeepsReplacementClientConnected(t *testing.T) {
+	t.Parallel()
+
+	registry := NewReverseRuntimeRelayRegistry()
+	machineID := uuid.New()
+
+	registry.Register(machineID, "session-a", func(context.Context, runtimecontract.Envelope) error { return nil })
+	firstClient := registry.sessions["session-a"]
+	if firstClient == nil {
+		t.Fatal("expected first reverse runtime client to be registered")
+	}
+
+	firstManagedSession := newRuntimeManagedClientSession(context.Background(), firstClient, func(error) {})
+	firstClient.registerSession("process-old", firstManagedSession)
+
+	registry.Register(machineID, "session-b", func(context.Context, runtimecontract.Envelope) error { return nil })
+
+	replacementClient, err := registry.client(machineID)
+	if err != nil {
+		t.Fatalf("expected replacement reverse runtime client to stay available, got %v", err)
+	}
+	replacementManagedSession := newRuntimeManagedClientSession(context.Background(), replacementClient, func(error) {})
+	replacementClient.registerSession("process-new", replacementManagedSession)
+
+	registry.Remove("session-a")
+
+	currentClient, err := registry.client(machineID)
+	if err != nil {
+		t.Fatalf("expected stale session removal to keep replacement client available, got %v", err)
+	}
+	if currentClient != replacementClient {
+		t.Fatalf("expected replacement client to remain current, got current=%p replacement=%p", currentClient, replacementClient)
+	}
+	select {
+	case <-replacementManagedSession.waitDone:
+		t.Fatal("expected replacement managed session to remain active after removing stale session")
+	default:
+	}
+	if err := firstManagedSession.Wait(); err == nil || !strings.Contains(err.Error(), "reverse runtime session replaced") {
+		t.Fatalf("expected original managed session to fail with replacement error, got %v", err)
+	}
+
+	registry.Remove("session-b")
+	if err := replacementManagedSession.Wait(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected replacement managed session to cancel only after removing current session, got %v", err)
 	}
 }

--- a/internal/infra/machinetransport/websocket_transport_test.go
+++ b/internal/infra/machinetransport/websocket_transport_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -391,6 +392,10 @@ func startReverseRuntimeTransportFixture(t *testing.T) reverseRuntimeTransportFi
 	}))
 
 	participantCtx, cancelParticipant := context.WithCancel(context.Background())
+	var disconnectOnce sync.Once
+	disconnect := func() {
+		disconnectOnce.Do(cancelParticipant)
+	}
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- runReverseRuntimeParticipant(participantCtx, server.URL, machineID)
@@ -399,7 +404,7 @@ func startReverseRuntimeTransportFixture(t *testing.T) reverseRuntimeTransportFi
 	waitForReverseRuntimeRegistration(t, relay, machineID)
 
 	t.Cleanup(func() {
-		cancelParticipant()
+		disconnect()
 		if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
 			t.Errorf("reverse runtime participant returned error: %v", err)
 		}
@@ -422,7 +427,7 @@ func startReverseRuntimeTransportFixture(t *testing.T) reverseRuntimeTransportFi
 			reverseRelay: relay,
 		},
 		relay:      relay,
-		disconnect: cancelParticipant,
+		disconnect: disconnect,
 	}
 }
 

--- a/internal/infra/machinetransport/websocket_transport_test.go
+++ b/internal/infra/machinetransport/websocket_transport_test.go
@@ -391,6 +391,7 @@ func startReverseRuntimeTransportFixture(t *testing.T) reverseRuntimeTransportFi
 		}
 	}))
 
+	//nolint:gosec // The fixture returns disconnect and also calls it from t.Cleanup.
 	participantCtx, cancelParticipant := context.WithCancel(context.Background())
 	var disconnectOnce sync.Once
 	disconnect := func() {

--- a/internal/infra/machinetransport/websocket_transport_test.go
+++ b/internal/infra/machinetransport/websocket_transport_test.go
@@ -2,7 +2,10 @@ package machinetransport
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -12,11 +15,13 @@ import (
 	"time"
 
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
 	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
 	"github.com/BetterAndBetterII/openase/internal/infra/machineprobe"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
 	"github.com/BetterAndBetterII/openase/internal/provider"
 	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 )
 
 func TestWebsocketListenerTransportProbeAndReachability(t *testing.T) {
@@ -143,6 +148,82 @@ func TestWebsocketListenerTransportPrepareWorkspaceAndSyncArtifacts(t *testing.T
 	}
 }
 
+func TestWebsocketReverseTransportPrepareWorkspaceKeepsSessionAvailableWithoutInjectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	fixture := startReverseRuntimeTransportFixture(t)
+
+	workspaceRoot := t.TempDir()
+	request, err := workspaceinfra.ParseSetupRequest(workspaceinfra.SetupInput{
+		WorkspaceRoot:    workspaceRoot,
+		OrganizationSlug: "acme",
+		ProjectSlug:      "reverse-test",
+		AgentName:        "agent",
+		TicketIdentifier: "ase-166",
+	})
+	if err != nil {
+		t.Fatalf("ParseSetupRequest() error = %v", err)
+	}
+
+	workspaceItem, err := fixture.transport.PrepareWorkspace(context.Background(), fixture.machine, request)
+	if err != nil {
+		t.Fatalf("expected reverse workspace_prepare to succeed without injected disconnect, got %v", err)
+	}
+	if _, err := os.Stat(workspaceItem.Path); err != nil {
+		t.Fatalf("prepared reverse workspace %s missing: %v", workspaceItem.Path, err)
+	}
+
+	if _, err := fixture.relay.client(fixture.machine.ID); err != nil {
+		t.Fatalf("expected reverse session to stay registered after successful workspace_prepare, got %v", err)
+	}
+
+	commandSession, err := fixture.transport.OpenCommandSession(context.Background(), fixture.machine)
+	if err != nil {
+		t.Fatalf("OpenCommandSession() after workspace_prepare error = %v", err)
+	}
+	output, err := commandSession.CombinedOutput("printf reverse-after-prepare")
+	if err != nil {
+		t.Fatalf("CombinedOutput() after workspace_prepare error = %v", err)
+	}
+	if string(output) != "reverse-after-prepare" {
+		t.Fatalf("expected reverse session to keep serving requests after workspace_prepare, got %q", string(output))
+	}
+}
+
+func TestWebsocketReverseTransportPrepareWorkspaceFailsAfterInjectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	fixture := startReverseRuntimeTransportFixture(t)
+	fixture.disconnect()
+	waitForReverseRuntimeDisconnect(t, fixture.relay, fixture.machine.ID)
+
+	request, err := workspaceinfra.ParseSetupRequest(workspaceinfra.SetupInput{
+		WorkspaceRoot:    t.TempDir(),
+		OrganizationSlug: "acme",
+		ProjectSlug:      "reverse-test",
+		AgentName:        "agent",
+		TicketIdentifier: "ase-166",
+	})
+	if err != nil {
+		t.Fatalf("ParseSetupRequest() error = %v", err)
+	}
+
+	_, err = fixture.transport.PrepareWorkspace(context.Background(), fixture.machine, request)
+	if err == nil {
+		t.Fatal("expected reverse workspace_prepare to fail after injected disconnect")
+	}
+	var prepareErr *workspaceinfra.PrepareError
+	if !errors.As(err, &prepareErr) {
+		t.Fatalf("expected workspace prepare error classification after injected disconnect, got %T %v", err, err)
+	}
+	if prepareErr.Stage != workspaceinfra.PrepareFailureStageTransport {
+		t.Fatalf("expected transport-stage prepare failure after injected disconnect, got %+v", prepareErr)
+	}
+	if !errors.Is(err, ErrTransportUnavailable) {
+		t.Fatalf("expected injected disconnect to surface transport unavailable semantics, got %v", err)
+	}
+}
+
 func TestWebsocketListenerTransportStartProcess(t *testing.T) {
 	t.Parallel()
 
@@ -238,4 +319,122 @@ func websocketURL(raw string) string {
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+type reverseRuntimeTransportFixture struct {
+	machine    domain.Machine
+	transport  websocketTransport
+	relay      *ReverseRuntimeRelayRegistry
+	disconnect func()
+}
+
+func startReverseRuntimeTransportFixture(t *testing.T) reverseRuntimeTransportFixture {
+	t.Helper()
+
+	machineID := uuid.New()
+	relay := NewReverseRuntimeRelayRegistry()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		helloEnvelope, err := readMachineEnvelopeForTest(conn)
+		if err != nil || helloEnvelope.Type != machinechanneldomain.MessageTypeHello {
+			return
+		}
+		authenticateEnvelope, err := readMachineEnvelopeForTest(conn)
+		if err != nil || authenticateEnvelope.Type != machinechanneldomain.MessageTypeAuthenticate {
+			return
+		}
+
+		sessionID := uuid.NewString()
+		relay.Register(machineID, sessionID, func(ctx context.Context, envelope runtimecontract.Envelope) error {
+			return writeMachineEnvelopeForTest(conn, machinechanneldomain.MessageTypeRuntime, sessionID, envelope)
+		})
+		defer relay.Remove(sessionID)
+
+		if err := writeMachineEnvelopeForTest(conn, machinechanneldomain.MessageTypeRegistered, sessionID, machinechanneldomain.Registered{
+			MachineID:                machineID.String(),
+			SessionID:                sessionID,
+			HeartbeatIntervalSeconds: 1,
+			HeartbeatTimeoutSeconds:  5,
+		}); err != nil {
+			return
+		}
+
+		for {
+			envelope, err := readMachineEnvelopeForTest(conn)
+			if err != nil {
+				return
+			}
+			switch envelope.Type {
+			case machinechanneldomain.MessageTypeHeartbeat:
+				continue
+			case machinechanneldomain.MessageTypeGoodbye:
+				return
+			case machinechanneldomain.MessageTypeRuntime:
+				runtimeEnvelope, err := runtimeEnvelopeFromMachineEnvelopeForTest(envelope)
+				if err != nil {
+					return
+				}
+				if err := relay.Deliver(sessionID, runtimeEnvelope); err != nil {
+					return
+				}
+			default:
+				return
+			}
+		}
+	}))
+
+	participantCtx, cancelParticipant := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runReverseRuntimeParticipant(participantCtx, server.URL, machineID)
+	}()
+
+	waitForReverseRuntimeRegistration(t, relay, machineID)
+
+	t.Cleanup(func() {
+		cancelParticipant()
+		if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
+			t.Errorf("reverse runtime participant returned error: %v", err)
+		}
+		server.Close()
+	})
+
+	return reverseRuntimeTransportFixture{
+		machine: domain.Machine{
+			ID:             machineID,
+			Name:           "reverse-01",
+			Host:           "reverse.internal",
+			ConnectionMode: domain.MachineConnectionModeWSReverse,
+			DaemonStatus: domain.MachineDaemonStatus{
+				Registered:   true,
+				SessionState: domain.MachineTransportSessionStateConnected,
+			},
+		},
+		transport: websocketTransport{
+			mode:         domain.MachineConnectionModeWSReverse,
+			reverseRelay: relay,
+		},
+		relay:      relay,
+		disconnect: cancelParticipant,
+	}
+}
+
+func waitForReverseRuntimeDisconnect(t *testing.T, relay *ReverseRuntimeRelayRegistry, machineID uuid.UUID) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := relay.client(machineID); errors.Is(err, ErrTransportUnavailable) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("reverse runtime session for machine %s stayed registered after injected disconnect", machineID)
 }

--- a/internal/machinechannel/session_registry_test.go
+++ b/internal/machinechannel/session_registry_test.go
@@ -95,3 +95,42 @@ func TestSessionRegistryCloseAllClosesRegisteredSessions(t *testing.T) {
 		t.Fatalf("expected second CloseAll call to be empty, got %+v", extra)
 	}
 }
+
+func TestSessionRegistryRemoveStaleSessionKeepsReplacementRegistered(t *testing.T) {
+	now := time.Date(2026, time.April, 4, 16, 0, 0, 0, time.UTC)
+	registry := NewSessionRegistry(30 * time.Second)
+	machineID := uuid.New()
+
+	firstCloser := &stubSessionCloser{}
+	registry.Register(machineID, "session-1", now, firstCloser)
+
+	secondCloser := &stubSessionCloser{}
+	current, replaced := registry.Register(machineID, "session-2", now.Add(5*time.Second), secondCloser)
+	if replaced == nil || replaced.SessionID != "session-1" {
+		t.Fatalf("expected session-2 registration to replace session-1, got %+v", replaced)
+	}
+	if current.SessionID != "session-2" {
+		t.Fatalf("expected session-2 to become current registration, got %+v", current)
+	}
+
+	if removed, ok := registry.Remove("session-1"); ok {
+		t.Fatalf("expected removing stale session-1 to be ignored, got %+v", removed)
+	}
+
+	heartbeatAt := now.Add(10 * time.Second)
+	snapshot, ok := registry.Heartbeat("session-2", heartbeatAt)
+	if !ok {
+		t.Fatal("expected session-2 heartbeat to succeed after removing stale session-1")
+	}
+	if snapshot.SessionID != "session-2" || !snapshot.LastHeartbeatAt.Equal(heartbeatAt.UTC()) {
+		t.Fatalf("expected session-2 heartbeat snapshot at %s, got %+v", heartbeatAt.UTC(), snapshot)
+	}
+
+	currentSnapshot, ok := registry.Snapshot(machineID)
+	if !ok || currentSnapshot.SessionID != "session-2" {
+		t.Fatalf("expected machine snapshot to keep session-2, got %+v ok=%t", currentSnapshot, ok)
+	}
+	if len(secondCloser.reasons) != 0 {
+		t.Fatalf("expected current session closer to stay untouched, got %+v", secondCloser.reasons)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic stale-session lifecycle coverage for the machine-channel registry and reverse runtime relay
- add reverse websocket transport tests that prove `workspace_prepare` keeps the session usable when no fault is injected
- add explicit injected-disconnect coverage for the `prepare before disconnect -> transport-stage failure` path

## Validation
- `go test ./internal/machinechannel ./internal/infra/machinetransport -run 'Test(SessionRegistryRemoveStaleSessionKeepsReplacementRegistered|ReverseRuntimeRelay|WebsocketReverseTransportPrepareWorkspace|WebsocketListenerTransportPrepareWorkspaceAndSyncArtifacts)'`
- `go test ./internal/orchestrator -run 'TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync'`
- `OPENASE_GO_TEST_PROGRESS_MODE=json go test ./internal/machinechannel ./internal/infra/machinetransport ./internal/orchestrator`
- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH" .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- covers the deterministic pre-prepare disconnect path; a mid-prepare drop or reconnect-resume path can be added later if runtime behavior changes or needs deeper recovery coverage
