### PR TITLE
ASE-168: add wrap toggle to workspace editor

### DIFF
--- a/web/src/lib/components/code/code-editor.svelte
+++ b/web/src/lib/components/code/code-editor.svelte
@@ -8,17 +8,19 @@
     highlightActiveLine,
     placeholder as cmPlaceholder,
   } from '@codemirror/view'
-  import { EditorState, type Extension } from '@codemirror/state'
+  import { Compartment, EditorState, type Extension } from '@codemirror/state'
   import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
   import { syntaxHighlighting, defaultHighlightStyle, bracketMatching } from '@codemirror/language'
   import { searchKeymap, highlightSelectionMatches } from '@codemirror/search'
   import { detectLanguage } from './lang'
+  import type { EditorWrapMode } from './wrap-mode'
 
   let {
     value = '',
     filePath = '',
     language = '',
     readonly = false,
+    wrapMode = 'wrap',
     placeholder = '',
     class: className = '',
     onchange,
@@ -31,6 +33,8 @@
     language?: string
     /** Read-only mode */
     readonly?: boolean
+    /** Visual line wrapping mode */
+    wrapMode?: EditorWrapMode
     /** Placeholder text when empty */
     placeholder?: string
     class?: string
@@ -41,8 +45,13 @@
   let container: HTMLDivElement
   let view: EditorView | undefined
   let suppressExternalUpdate = false
+  let languageReloadID = 0
+  let lastLang = ''
+  let lastWrapMode: EditorWrapMode = 'wrap'
 
   const lang = $derived(language || detectLanguage(filePath))
+  const languageCompartment = new Compartment()
+  const wrapCompartment = new Compartment()
 
   // Build a dark theme that matches the existing harness-editor look
   const darkTheme = EditorView.theme(
@@ -133,6 +142,10 @@
     }
   }
 
+  function buildWrapModeExtension(mode: EditorWrapMode): Extension {
+    return mode === 'wrap' ? EditorView.lineWrapping : []
+  }
+
   function buildBaseExtensions(): Extension[] {
     const exts: Extension[] = [
       lineNumbers(),
@@ -143,7 +156,6 @@
       syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
       darkTheme,
       keymap.of([...defaultKeymap, ...historyKeymap, ...searchKeymap, indentWithTab]),
-      EditorView.lineWrapping,
     ]
 
     if (placeholder) {
@@ -172,10 +184,16 @@
     view = new EditorView({
       state: EditorState.create({
         doc: value,
-        extensions: [...buildBaseExtensions(), ...langExts],
+        extensions: [
+          ...buildBaseExtensions(),
+          wrapCompartment.of(buildWrapModeExtension(wrapMode)),
+          languageCompartment.of(langExts),
+        ],
       }),
       parent: container,
     })
+    lastLang = lang
+    lastWrapMode = wrapMode
   }
 
   onMount(() => {
@@ -198,17 +216,29 @@
     })
   })
 
-  // Recreate editor when language changes
-  let lastLang = ''
   $effect(() => {
     const nextLang = lang
     if (nextLang === lastLang || !view) return
-    lastLang = nextLang
 
-    const currentDoc = view.state.doc.toString()
-    view.destroy()
-    value = currentDoc
-    void createEditor()
+    const reloadID = ++languageReloadID
+    void (async () => {
+      const langExts = await loadLanguageExtension(nextLang)
+      if (!view || reloadID !== languageReloadID) return
+      view.dispatch({
+        effects: languageCompartment.reconfigure(langExts),
+      })
+      lastLang = nextLang
+    })()
+  })
+
+  $effect(() => {
+    const nextWrapMode = wrapMode
+    if (nextWrapMode === lastWrapMode || !view) return
+
+    view.dispatch({
+      effects: wrapCompartment.reconfigure(buildWrapModeExtension(nextWrapMode)),
+    })
+    lastWrapMode = nextWrapMode
   })
 </script>
 

--- a/web/src/lib/components/code/code-editor.test.ts
+++ b/web/src/lib/components/code/code-editor.test.ts
@@ -1,0 +1,54 @@
+import { render, waitFor } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+
+import CodeEditor from './code-editor.svelte'
+
+describe('CodeEditor', () => {
+  it('switches wrap mode without recreating the editor DOM or losing content', async () => {
+    const value = Array.from({ length: 40 }, (_, index) => `line ${index} ${'x'.repeat(120)}`).join(
+      '\n',
+    )
+
+    const view = render(CodeEditor, {
+      props: {
+        value,
+        filePath: 'notes.md',
+        wrapMode: 'wrap',
+      },
+    })
+
+    await waitFor(() => expect(view.container.querySelector('.cm-editor')).not.toBeNull())
+
+    const content = view.container.querySelector('.cm-content')
+    const scroller = view.container.querySelector('.cm-scroller') as HTMLElement | null
+
+    expect(content).not.toBeNull()
+    expect(scroller).not.toBeNull()
+    expect(view.container.querySelector('.cm-lineWrapping')).not.toBeNull()
+    scroller!.scrollTop = 240
+
+    await view.rerender({
+      value,
+      filePath: 'notes.md',
+      wrapMode: 'nowrap',
+    })
+
+    await waitFor(() => expect(view.container.querySelector('.cm-lineWrapping')).toBeNull())
+    expect(view.container.querySelector('.cm-content')).toBe(content)
+    expect(view.container.querySelector('.cm-scroller')).toBe(scroller)
+    expect(scroller!.scrollTop).toBe(240)
+    expect(view.container.querySelector('.cm-content')?.textContent).toContain('line 0')
+
+    await view.rerender({
+      value,
+      filePath: 'notes.md',
+      wrapMode: 'wrap',
+    })
+
+    await waitFor(() => expect(view.container.querySelector('.cm-lineWrapping')).not.toBeNull())
+    expect(view.container.querySelector('.cm-content')).toBe(content)
+    expect(view.container.querySelector('.cm-scroller')).toBe(scroller)
+    expect(scroller!.scrollTop).toBe(240)
+    expect(view.container.querySelector('.cm-content')?.textContent).toContain('line 0')
+  })
+})

--- a/web/src/lib/components/code/diff-viewer.svelte
+++ b/web/src/lib/components/code/diff-viewer.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { cn } from '$lib/utils'
+  import type { EditorWrapMode } from './wrap-mode'
 
   let {
     diff = '',
     sourceContent = '',
+    wrapMode = 'wrap',
     class: className = '',
   }: {
     /** Raw unified diff string */
@@ -12,6 +14,8 @@
      *  the entire file with diff hunks highlighted inline instead of only the
      *  raw diff output. */
     sourceContent?: string
+    /** Visual line wrapping mode */
+    wrapMode?: EditorWrapMode
     class?: string
   } = $props()
 
@@ -176,11 +180,12 @@
 </script>
 
 <div class={cn('diff-viewer min-h-0 overflow-auto font-mono text-[13px] leading-6', className)}>
-  <div class="px-0 py-2">
+  <div class={cn('px-0 py-2', wrapMode === 'nowrap' && 'w-max min-w-full')}>
     {#each annotated as line}
       <div
         class={cn(
-          'min-h-6 px-4 whitespace-pre-wrap',
+          'min-h-6 px-4',
+          wrapMode === 'wrap' ? 'whitespace-pre-wrap' : 'whitespace-pre',
           line.kind === 'add' && 'bg-emerald-500/10 text-emerald-800 dark:text-emerald-300',
           line.kind === 'del' && 'bg-rose-500/10 text-rose-800 dark:text-rose-300',
           line.kind === 'hunk-sep' && 'bg-sky-500/8 text-[11px] text-sky-600 dark:text-sky-400',

--- a/web/src/lib/components/code/wrap-mode.ts
+++ b/web/src/lib/components/code/wrap-mode.ts
@@ -1,0 +1,32 @@
+export type EditorWrapMode = 'wrap' | 'nowrap'
+
+export const EDITOR_WRAP_MODE_STORAGE_KEY = 'openase.editor.wrap-mode'
+export const DEFAULT_EDITOR_WRAP_MODE: EditorWrapMode = 'wrap'
+
+export function parseEditorWrapMode(raw: unknown): EditorWrapMode {
+  return raw === 'nowrap' ? 'nowrap' : DEFAULT_EDITOR_WRAP_MODE
+}
+
+export function readEditorWrapMode(): EditorWrapMode {
+  if (typeof window === 'undefined') {
+    return DEFAULT_EDITOR_WRAP_MODE
+  }
+
+  try {
+    return parseEditorWrapMode(window.localStorage.getItem(EDITOR_WRAP_MODE_STORAGE_KEY)?.trim())
+  } catch {
+    return DEFAULT_EDITOR_WRAP_MODE
+  }
+}
+
+export function storeEditorWrapMode(mode: EditorWrapMode): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(EDITOR_WRAP_MODE_STORAGE_KEY, mode)
+  } catch {
+    // Ignore localStorage failures.
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { cn } from '$lib/utils'
   import { FileCode2 } from '@lucide/svelte'
-  import { CodeViewer, DiffViewer } from '$lib/components/code'
+  import { Button } from '$ui/button'
+  import { CodeEditor, DiffViewer } from '$lib/components/code'
+  import { readEditorWrapMode, storeEditorWrapMode } from '$lib/components/code/wrap-mode'
   import type {
     ProjectConversationWorkspaceFilePatch,
     ProjectConversationWorkspaceFilePreview,
@@ -30,6 +32,13 @@
     return parts.length > 1 ? parts.slice(0, -1).join('/') : ''
   })
   const hasDiff = $derived(patch?.diffKind === 'text' && !!patch.diff)
+  const showWrapToggle = $derived(hasDiff || preview?.previewKind === 'text')
+  let wrapMode = $state(readEditorWrapMode())
+
+  function toggleWrapMode() {
+    wrapMode = wrapMode === 'wrap' ? 'nowrap' : 'wrap'
+    storeEditorWrapMode(wrapMode)
+  }
 </script>
 
 <div class="flex h-full min-h-0 flex-col overflow-hidden">
@@ -74,14 +83,29 @@
           {patch.status}
         </span>
       {/if}
-      {#if preview}
-        <span class="text-muted-foreground/50 ml-auto text-[10px]">
-          {preview.mediaType} · {preview.sizeBytes} B
-        </span>
-      {/if}
-      {#if fileLoading}
-        <span class="text-muted-foreground/50 text-[10px]">Loading…</span>
-      {/if}
+      <div class="ml-auto flex items-center gap-2">
+        {#if showWrapToggle}
+          <Button
+            variant={wrapMode === 'wrap' ? 'secondary' : 'ghost'}
+            size="xs"
+            class="h-6"
+            aria-label={wrapMode === 'wrap' ? 'Disable line wrap' : 'Enable line wrap'}
+            aria-pressed={wrapMode === 'wrap'}
+            data-testid="workspace-browser-wrap-toggle"
+            onclick={toggleWrapMode}
+          >
+            {wrapMode === 'wrap' ? 'Wrap on' : 'Wrap off'}
+          </Button>
+        {/if}
+        {#if preview}
+          <span class="text-muted-foreground/50 text-[10px]">
+            {preview.mediaType} · {preview.sizeBytes} B
+          </span>
+        {/if}
+        {#if fileLoading}
+          <span class="text-muted-foreground/50 text-[10px]">Loading…</span>
+        {/if}
+      </div>
     </div>
 
     <!-- Unified content: diff or syntax-highlighted preview -->
@@ -94,6 +118,7 @@
           <DiffViewer
             diff={patch?.diff ?? ''}
             sourceContent={preview?.content ?? ''}
+            {wrapMode}
             class="h-full"
           />
         </div>
@@ -106,7 +131,13 @@
           class="h-full min-h-0 min-w-0 overflow-hidden"
           data-testid="workspace-browser-detail-scroll-frame"
         >
-          <CodeViewer code={preview.content ?? ''} filePath={selectedFilePath} class="h-full" />
+          <CodeEditor
+            value={preview.content ?? ''}
+            filePath={selectedFilePath}
+            readonly={true}
+            {wrapMode}
+            class="h-full"
+          />
         </div>
       {:else if fileLoading}
         <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { cn } from '$lib/utils'
-  import { FileCode2 } from '@lucide/svelte'
+  import { FileCode2, WrapText } from '@lucide/svelte'
   import { Button } from '$ui/button'
   import { CodeEditor, DiffViewer } from '$lib/components/code'
   import { readEditorWrapMode, storeEditorWrapMode } from '$lib/components/code/wrap-mode'
@@ -87,14 +87,14 @@
         {#if showWrapToggle}
           <Button
             variant={wrapMode === 'wrap' ? 'secondary' : 'ghost'}
-            size="xs"
-            class="h-6"
+            size="icon-xs"
             aria-label={wrapMode === 'wrap' ? 'Disable line wrap' : 'Enable line wrap'}
             aria-pressed={wrapMode === 'wrap'}
+            title={wrapMode === 'wrap' ? 'Disable line wrap' : 'Enable line wrap'}
             data-testid="workspace-browser-wrap-toggle"
             onclick={toggleWrapMode}
           >
-            {wrapMode === 'wrap' ? 'Wrap on' : 'Wrap off'}
+            <WrapText />
           </Button>
         {/if}
         {#if preview}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts
@@ -1,0 +1,87 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { EDITOR_WRAP_MODE_STORAGE_KEY } from '$lib/components/code/wrap-mode'
+
+import ProjectConversationWorkspaceBrowserDetail from './project-conversation-workspace-browser-detail.svelte'
+
+describe('ProjectConversationWorkspaceBrowserDetail', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows a wrap toggle for text previews and persists the selected mode', async () => {
+    const preview = {
+      conversationId: 'conversation-1',
+      repoPath: 'services/openase',
+      path: 'README.md',
+      sizeBytes: 64,
+      mediaType: 'text/plain',
+      previewKind: 'text' as const,
+      truncated: false,
+      content: 'alpha '.repeat(60),
+    }
+
+    const firstView = render(ProjectConversationWorkspaceBrowserDetail, {
+      props: {
+        selectedRepo: {
+          name: 'openase',
+          path: 'services/openase',
+          branch: 'feat/ase-168-wrap-toggle',
+          headCommit: '123456789abc',
+          headSummary: 'Support editor wrap toggle',
+          dirty: true,
+          filesChanged: 1,
+          added: 1,
+          removed: 0,
+        },
+        selectedFilePath: 'README.md',
+        preview,
+        patch: null,
+      },
+    })
+
+    await waitFor(() => expect(firstView.container.querySelector('.cm-editor')).not.toBeNull())
+
+    const wrapToggle = firstView.getByTestId('workspace-browser-wrap-toggle')
+    expect(wrapToggle.textContent).toContain('Wrap on')
+    expect(firstView.container.querySelector('.cm-lineWrapping')).not.toBeNull()
+
+    await fireEvent.click(wrapToggle)
+
+    await waitFor(() => expect(firstView.container.querySelector('.cm-lineWrapping')).toBeNull())
+    expect(window.localStorage.getItem(EDITOR_WRAP_MODE_STORAGE_KEY)).toBe('nowrap')
+    expect(wrapToggle.textContent).toContain('Wrap off')
+
+    firstView.unmount()
+
+    const secondView = render(ProjectConversationWorkspaceBrowserDetail, {
+      props: {
+        selectedRepo: {
+          name: 'openase',
+          path: 'services/openase',
+          branch: 'feat/ase-168-wrap-toggle',
+          headCommit: '123456789abc',
+          headSummary: 'Support editor wrap toggle',
+          dirty: true,
+          filesChanged: 1,
+          added: 1,
+          removed: 0,
+        },
+        selectedFilePath: 'README.md',
+        preview,
+        patch: null,
+      },
+    })
+
+    await waitFor(() => expect(secondView.container.querySelector('.cm-editor')).not.toBeNull())
+    expect(secondView.getByTestId('workspace-browser-wrap-toggle').textContent).toContain(
+      'Wrap off',
+    )
+    expect(secondView.container.querySelector('.cm-lineWrapping')).toBeNull()
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts
@@ -48,14 +48,16 @@ describe('ProjectConversationWorkspaceBrowserDetail', () => {
     await waitFor(() => expect(firstView.container.querySelector('.cm-editor')).not.toBeNull())
 
     const wrapToggle = firstView.getByTestId('workspace-browser-wrap-toggle')
-    expect(wrapToggle.textContent).toContain('Wrap on')
+    expect(wrapToggle.getAttribute('aria-pressed')).toBe('true')
+    expect(wrapToggle.getAttribute('aria-label')).toBe('Disable line wrap')
     expect(firstView.container.querySelector('.cm-lineWrapping')).not.toBeNull()
 
     await fireEvent.click(wrapToggle)
 
     await waitFor(() => expect(firstView.container.querySelector('.cm-lineWrapping')).toBeNull())
     expect(window.localStorage.getItem(EDITOR_WRAP_MODE_STORAGE_KEY)).toBe('nowrap')
-    expect(wrapToggle.textContent).toContain('Wrap off')
+    expect(wrapToggle.getAttribute('aria-pressed')).toBe('false')
+    expect(wrapToggle.getAttribute('aria-label')).toBe('Enable line wrap')
 
     firstView.unmount()
 
@@ -79,9 +81,9 @@ describe('ProjectConversationWorkspaceBrowserDetail', () => {
     })
 
     await waitFor(() => expect(secondView.container.querySelector('.cm-editor')).not.toBeNull())
-    expect(secondView.getByTestId('workspace-browser-wrap-toggle').textContent).toContain(
-      'Wrap off',
-    )
+    const persistedToggle = secondView.getByTestId('workspace-browser-wrap-toggle')
+    expect(persistedToggle.getAttribute('aria-pressed')).toBe('false')
+    expect(persistedToggle.getAttribute('aria-label')).toBe('Enable line wrap')
     expect(secondView.container.querySelector('.cm-lineWrapping')).toBeNull()
   })
 })

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
@@ -208,7 +208,9 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     expect(view.container.textContent).toContain('README.md')
     expect(view.container.textContent).toContain('text/plain')
     await waitFor(() =>
-      expect(view.container.querySelector('.cm-content')?.textContent ?? '').toContain('line alpha'),
+      expect(view.container.querySelector('.cm-content')?.textContent ?? '').toContain(
+        'line alpha',
+      ),
     )
     expect(view.container.querySelector('.cm-content')?.textContent ?? '').toContain('line beta')
     expect(view.getByTestId('workspace-browser-detail-panel').className).toContain(

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
@@ -207,8 +207,10 @@ describe('ProjectConversationWorkspaceBrowser', () => {
 
     expect(view.container.textContent).toContain('README.md')
     expect(view.container.textContent).toContain('text/plain')
-    expect(view.container.textContent).toContain('line alpha')
-    expect(view.container.textContent).toContain('line beta')
+    await waitFor(() =>
+      expect(view.container.querySelector('.cm-content')?.textContent ?? '').toContain('line alpha'),
+    )
+    expect(view.container.querySelector('.cm-content')?.textContent ?? '').toContain('line beta')
     expect(view.getByTestId('workspace-browser-detail-panel').className).toContain(
       'overflow-hidden',
     )
@@ -218,8 +220,9 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     expect(view.getByTestId('workspace-browser-detail-scroll-frame').className).toContain(
       'overflow-hidden',
     )
-    expect(view.container.querySelector('.code-viewer')?.className).toContain('overflow-auto')
-    expect(view.getByTestId('code-viewer-content').className).toContain('w-max')
+    expect(view.container.querySelector('.code-editor')?.className).toContain('overflow-hidden')
+    expect(view.container.querySelector('.cm-scroller')).not.toBeNull()
+    expect(view.container.querySelector('.cm-lineWrapping')).not.toBeNull()
   })
 
   it('renders git changes and opens a changed file from the status list', async () => {


### PR DESCRIPTION
## Summary
- add a wrap / nowrap toggle to the Project AI workspace file detail pane
- persist the selected wrap mode in browser local storage and restore it on reopen
- switch text previews to a read-only CodeMirror editor so wrap toggles preserve context and add focused tests for the new behavior

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/components/code/code-editor.test.ts src/lib/components/code/code-viewer.test.ts src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec svelte-check --tsconfig ./tsconfig.json`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vite build --logLevel warn`

## Risks / Follow-up
- `DiffViewer` now respects the same wrap preference, but diff rendering itself is otherwise unchanged.
- The shared wrap preference is currently browser-wide rather than scoped per project or per file type.
