### PR TITLE
feat(chat): add multi-tab Project AI workspace file editor

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5554,6 +5554,11 @@
                         },
                         "type": "array"
                       },
+                      "conversation_id": {
+                        "description": "Conversation ID for the focused workspace file surface.",
+                        "nullable": true,
+                        "type": "string"
+                      },
                       "harness_path": {
                         "description": "Harness path for the focused workflow.",
                         "nullable": true,
@@ -5575,7 +5580,7 @@
                         "type": "boolean"
                       },
                       "kind": {
-                        "description": "Focused surface kind. Supported values are workflow, skill, ticket, and machine.",
+                        "description": "Focused surface kind. Supported values are workflow, skill, ticket, machine, and workspace_file.",
                         "type": "string"
                       },
                       "machine_host": {
@@ -5879,6 +5884,16 @@
                         "description": "Workflow type currently in focus.",
                         "nullable": true,
                         "type": "string"
+                      },
+                      "workspace_file_path": {
+                        "description": "Repo-relative file path for the focused workspace file.",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "workspace_repo_path": {
+                        "description": "Workspace-relative repo path for the focused workspace file.",
+                        "nullable": true,
+                        "type": "string"
                       }
                     },
                     "type": "object"
@@ -5886,6 +5901,33 @@
                   "message": {
                     "description": "User message content appended as the next project conversation turn.",
                     "type": "string"
+                  },
+                  "workspace_file_draft": {
+                    "description": "Optional request-scoped unsaved workspace file draft context for the active turn.",
+                    "nullable": true,
+                    "properties": {
+                      "content": {
+                        "description": "Full unsaved draft content for the active workspace file.",
+                        "type": "string"
+                      },
+                      "encoding": {
+                        "description": "Normalized draft encoding. V1 supports utf-8 only.",
+                        "type": "string"
+                      },
+                      "line_ending": {
+                        "description": "Requested line ending style for the unsaved draft context.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Repo-relative file path for the unsaved draft.",
+                        "type": "string"
+                      },
+                      "repo_path": {
+                        "description": "Workspace-relative repo path for the unsaved draft.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
                   }
                 },
                 "type": "object"
@@ -6458,6 +6500,12 @@
                         "conversation_id": {
                           "type": "string"
                         },
+                        "encoding": {
+                          "type": "string"
+                        },
+                        "line_ending": {
+                          "type": "string"
+                        },
                         "media_type": {
                           "type": "string"
                         },
@@ -6467,7 +6515,13 @@
                         "preview_kind": {
                           "type": "string"
                         },
+                        "read_only_reason": {
+                          "type": "string"
+                        },
                         "repo_path": {
+                          "type": "string"
+                        },
+                        "revision": {
                           "type": "string"
                         },
                         "size_bytes": {
@@ -6475,6 +6529,9 @@
                           "type": "integer"
                         },
                         "truncated": {
+                          "type": "boolean"
+                        },
+                        "writable": {
                           "type": "boolean"
                         }
                       },
@@ -6579,6 +6636,193 @@
           }
         },
         "summary": "Read a project conversation workspace file preview",
+        "tags": [
+          "chat"
+        ]
+      },
+      "put": {
+        "operationId": "saveProjectConversationWorkspaceFile",
+        "parameters": [
+          {
+            "description": "Stable OpenASE conversation ID.",
+            "in": "path",
+            "name": "conversationId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "base_revision": {
+                    "description": "Opaque saved-file revision token the client last loaded. Saves reject stale revisions with 409 Conflict.",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Complete replacement text content for the file save request.",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "description": "Normalized text encoding for the save request. V1 supports utf-8 only.",
+                    "type": "string"
+                  },
+                  "line_ending": {
+                    "description": "Requested line ending style to preserve when writing the file.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Repo-relative existing file path to update inside the conversation workspace.",
+                    "type": "string"
+                  },
+                  "repo_path": {
+                    "description": "Workspace-relative repo path chosen from the workspace metadata response.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Save one project conversation workspace file request body.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "file": {
+                      "properties": {
+                        "conversation_id": {
+                          "type": "string"
+                        },
+                        "encoding": {
+                          "type": "string"
+                        },
+                        "line_ending": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "repo_path": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "string"
+                        },
+                        "size_bytes": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Save one project conversation workspace file response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found response."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Internal Server Error response."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Service Unavailable response."
+          }
+        },
+        "summary": "Save one project conversation workspace file",
         "tags": [
           "chat"
         ]

--- a/internal/chat/project_conversation_service.go
+++ b/internal/chat/project_conversation_service.go
@@ -454,6 +454,28 @@ func (s *ProjectConversationService) StartTurn(
 	message string,
 	focus *ProjectConversationFocus,
 ) (domain.Turn, error) {
+	return s.startTurn(ctx, userID, conversationID, message, focus, nil)
+}
+
+func (s *ProjectConversationService) StartTurnWithWorkspaceFileDraft(
+	ctx context.Context,
+	userID UserID,
+	conversationID uuid.UUID,
+	message string,
+	focus *ProjectConversationFocus,
+	workspaceFileDraft *ProjectConversationWorkspaceFileDraftContext,
+) (domain.Turn, error) {
+	return s.startTurn(ctx, userID, conversationID, message, focus, workspaceFileDraft)
+}
+
+func (s *ProjectConversationService) startTurn(
+	ctx context.Context,
+	userID UserID,
+	conversationID uuid.UUID,
+	message string,
+	focus *ProjectConversationFocus,
+	workspaceFileDraft *ProjectConversationWorkspaceFileDraftContext,
+) (domain.Turn, error) {
 	conversation, err := s.GetConversation(ctx, userID, conversationID)
 	if err != nil {
 		return domain.Turn{}, err
@@ -492,7 +514,14 @@ func (s *ProjectConversationService) StartTurn(
 			if live.codex == nil {
 				break
 			}
-			resumePrompt, resumePromptErr := s.buildProjectConversationPrompt(ctx, conversation, project, promptFocus, false)
+			resumePrompt, resumePromptErr := s.buildProjectConversationPromptWithDraft(
+				ctx,
+				conversation,
+				project,
+				promptFocus,
+				workspaceFileDraft,
+				false,
+			)
 			if resumePromptErr != nil {
 				return domain.Turn{}, resumePromptErr
 			}
@@ -536,7 +565,14 @@ func (s *ProjectConversationService) StartTurn(
 		}
 	}
 
-	systemPrompt, err := s.buildProjectConversationPrompt(ctx, conversation, project, promptFocus, includeRecovery)
+	systemPrompt, err := s.buildProjectConversationPromptWithDraft(
+		ctx,
+		conversation,
+		project,
+		promptFocus,
+		workspaceFileDraft,
+		includeRecovery,
+	)
 	if err != nil {
 		return domain.Turn{}, err
 	}
@@ -2125,6 +2161,24 @@ func (s *ProjectConversationService) buildProjectConversationPrompt(
 	focus *ProjectConversationFocus,
 	includeRecovery bool,
 ) (string, error) {
+	return s.buildProjectConversationPromptWithDraft(
+		ctx,
+		conversation,
+		project,
+		focus,
+		nil,
+		includeRecovery,
+	)
+}
+
+func (s *ProjectConversationService) buildProjectConversationPromptWithDraft(
+	ctx context.Context,
+	conversation domain.Conversation,
+	project catalogdomain.Project,
+	focus *ProjectConversationFocus,
+	workspaceFileDraft *ProjectConversationWorkspaceFileDraftContext,
+	includeRecovery bool,
+) (string, error) {
 	basePrompt, err := s.promptBuilder.buildSystemPrompt(ctx, StartInput{
 		Message: "",
 		Source:  SourceProjectSidebar,
@@ -2156,6 +2210,10 @@ func (s *ProjectConversationService) buildProjectConversationPrompt(
 			builder.WriteString(ticketCapsule)
 		}
 	}
+	if workspaceDraftPrompt := renderProjectConversationWorkspaceFileDraftContext(workspaceFileDraft); strings.TrimSpace(workspaceDraftPrompt) != "" {
+		builder.WriteString("\n\n")
+		builder.WriteString(workspaceDraftPrompt)
+	}
 	if !includeRecovery {
 		return builder.String(), nil
 	}
@@ -2181,6 +2239,29 @@ func (s *ProjectConversationService) buildProjectConversationPrompt(
 	}
 	builder.WriteString("\nContinue from this conversation state without restating the entire history.")
 	return builder.String(), nil
+}
+
+func renderProjectConversationWorkspaceFileDraftContext(
+	draft *ProjectConversationWorkspaceFileDraftContext,
+) string {
+	if draft == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("## Active workspace file draft\n")
+	builder.WriteString("This draft is request-scoped context only. It has not been saved to the workspace yet.\n")
+	_, _ = fmt.Fprintf(&builder, "- repo_path: %s\n", draft.RepoPath)
+	_, _ = fmt.Fprintf(&builder, "- path: %s\n", draft.Path)
+	_, _ = fmt.Fprintf(&builder, "- encoding: %s\n", draft.Encoding)
+	_, _ = fmt.Fprintf(&builder, "- line_ending: %s\n", draft.LineEnding)
+	builder.WriteString("\nDraft content:\n```text\n")
+	builder.WriteString(draft.Content.String())
+	if !strings.HasSuffix(draft.Content.String(), "\n") {
+		builder.WriteByte('\n')
+	}
+	builder.WriteString("```\n")
+	return builder.String()
 }
 
 func (s *ProjectConversationService) projectConversationPlatformContractInput(

--- a/internal/chat/project_conversation_workspace_browser.go
+++ b/internal/chat/project_conversation_workspace_browser.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"mime"
 	"os"
 	"os/exec"
@@ -75,6 +74,11 @@ type ProjectConversationWorkspaceFilePreview struct {
 	PreviewKind    ProjectConversationWorkspacePreviewKind
 	Truncated      bool
 	Content        string
+	Revision       string
+	Writable       bool
+	ReadOnlyReason string
+	Encoding       string
+	LineEnding     string
 }
 
 type ProjectConversationWorkspacePreviewKind string
@@ -604,21 +608,16 @@ func (s *ProjectConversationService) readRemoteProjectConversationWorkspaceFileP
 	if err != nil {
 		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("read remote workspace file %s: %w", relativePath, err)
 	}
-	truncated := int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes || resolvedFile.sizeBytes > projectConversationWorkspacePreviewLimitBytes
-	if int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes {
-		snippet = snippet[:projectConversationWorkspacePreviewLimitBytes]
+	revisionCommand := fmt.Sprintf(
+		"sha256sum %s | awk '{print $1}'",
+		projectConversationShellQuote(resolvedFile.path),
+	)
+	revisionOutput, err := s.runProjectConversationShellCommand(ctx, machine, revisionCommand, false)
+	if err != nil {
+		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("read remote workspace file revision %s: %w", relativePath, err)
 	}
-	preview := ProjectConversationWorkspaceFilePreview{
-		SizeBytes: resolvedFile.sizeBytes,
-		MediaType: projectConversationWorkspaceMediaType(relativePath),
-		Truncated: truncated,
-	}
-	if projectConversationWorkspaceLooksBinary(snippet) {
-		preview.PreviewKind = ProjectConversationWorkspacePreviewKindBinary
-		return preview, nil
-	}
-	preview.PreviewKind = ProjectConversationWorkspacePreviewKindText
-	preview.Content = string(snippet)
+	preview := buildWorkspacePreviewFromContent(relativePath, snippet, resolvedFile.sizeBytes)
+	preview.Revision = strings.TrimSpace(string(revisionOutput))
 	return preview, nil
 }
 
@@ -630,35 +629,11 @@ func readLocalProjectConversationWorkspaceFilePreview(
 	if err != nil {
 		return ProjectConversationWorkspaceFilePreview{}, err
 	}
-	file, err := os.Open(resolvedFile.path)
+	content, _, err := readLocalWorkspaceFileContent(resolvedFile.path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return ProjectConversationWorkspaceFilePreview{}, ErrProjectConversationWorkspaceEntryNotFound
-		}
-		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("open workspace file %s: %w", resolvedFile.path, err)
+		return ProjectConversationWorkspaceFilePreview{}, err
 	}
-	defer func() { _ = file.Close() }()
-
-	snippet, err := io.ReadAll(io.LimitReader(file, projectConversationWorkspacePreviewLimitBytes+1))
-	if err != nil {
-		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("read workspace file %s: %w", resolvedFile.path, err)
-	}
-	truncated := int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes || resolvedFile.sizeBytes > projectConversationWorkspacePreviewLimitBytes
-	if int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes {
-		snippet = snippet[:projectConversationWorkspacePreviewLimitBytes]
-	}
-	preview := ProjectConversationWorkspaceFilePreview{
-		SizeBytes: resolvedFile.sizeBytes,
-		MediaType: projectConversationWorkspaceMediaType(relativePath),
-		Truncated: truncated,
-	}
-	if projectConversationWorkspaceLooksBinary(snippet) {
-		preview.PreviewKind = ProjectConversationWorkspacePreviewKindBinary
-		return preview, nil
-	}
-	preview.PreviewKind = ProjectConversationWorkspacePreviewKindText
-	preview.Content = string(snippet)
-	return preview, nil
+	return buildWorkspacePreviewFromContent(relativePath, content, resolvedFile.sizeBytes), nil
 }
 
 type resolvedProjectConversationWorkspaceFile struct {
@@ -676,15 +651,11 @@ func (s *ProjectConversationService) resolveRemoteProjectConversationWorkspaceFi
 repo=%s
 relative=%s
 repo_real=$(cd "$repo" && pwd -P)
-parent=""
 base="$relative"
-case "$relative" in
-  */*)
-    parent="${relative%%/*}"
-    base="${relative##*/}"
-    parent="${relative%%/*}"
-    ;;
-esac
+parent=""
+if [ "$relative" != "$base" ]; then
+  parent="${relative%%/*}"
+fi
 target_dir="$repo"
 if [ -n "$parent" ]; then
   target_dir="$repo/$parent"

--- a/internal/chat/project_conversation_workspace_file_edit.go
+++ b/internal/chat/project_conversation_workspace_file_edit.go
@@ -1,0 +1,601 @@
+package chat
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	"github.com/google/uuid"
+)
+
+type WorkspaceRepoPath string
+
+func (p WorkspaceRepoPath) String() string { return string(p) }
+
+type WorkspaceFilePath string
+
+func (p WorkspaceFilePath) String() string { return string(p) }
+
+type WorkspaceFileRevision string
+
+func (r WorkspaceFileRevision) String() string { return string(r) }
+
+type WorkspaceEncoding string
+
+const WorkspaceEncodingUTF8 WorkspaceEncoding = "utf-8"
+
+func (e WorkspaceEncoding) String() string { return string(e) }
+
+type WorkspaceLineEnding string
+
+const (
+	WorkspaceLineEndingLF   WorkspaceLineEnding = "lf"
+	WorkspaceLineEndingCRLF WorkspaceLineEnding = "crlf"
+)
+
+func (l WorkspaceLineEnding) String() string { return string(l) }
+
+type WorkspaceTextContent string
+
+func (c WorkspaceTextContent) String() string { return string(c) }
+
+type ProjectConversationWorkspaceReadOnlyReason string
+
+const (
+	ProjectConversationWorkspaceReadOnlyReasonBinaryFile          ProjectConversationWorkspaceReadOnlyReason = "binary_file"
+	ProjectConversationWorkspaceReadOnlyReasonFileTooLarge        ProjectConversationWorkspaceReadOnlyReason = "file_too_large"
+	ProjectConversationWorkspaceReadOnlyReasonUnsupportedEncoding ProjectConversationWorkspaceReadOnlyReason = "unsupported_encoding"
+)
+
+func (r ProjectConversationWorkspaceReadOnlyReason) String() string { return string(r) }
+
+type ProjectConversationWorkspaceFileSaveInput struct {
+	RepoPath     WorkspaceRepoPath
+	Path         WorkspaceFilePath
+	BaseRevision WorkspaceFileRevision
+	Content      WorkspaceTextContent
+	Encoding     WorkspaceEncoding
+	LineEnding   WorkspaceLineEnding
+}
+
+type ProjectConversationWorkspaceFileDraftContext struct {
+	RepoPath   WorkspaceRepoPath
+	Path       WorkspaceFilePath
+	Content    WorkspaceTextContent
+	Encoding   WorkspaceEncoding
+	LineEnding WorkspaceLineEnding
+}
+
+type ProjectConversationWorkspaceFileSaved struct {
+	ConversationID uuid.UUID
+	RepoPath       string
+	Path           string
+	Revision       string
+	SizeBytes      int64
+	Encoding       string
+	LineEnding     string
+}
+
+type ProjectConversationWorkspaceFileConflictError struct {
+	CurrentFile ProjectConversationWorkspaceFilePreview
+}
+
+func (e *ProjectConversationWorkspaceFileConflictError) Error() string {
+	if e == nil {
+		return "project conversation workspace file conflict"
+	}
+	return fmt.Sprintf(
+		"project conversation workspace file revision conflict for %s",
+		strings.TrimSpace(e.CurrentFile.Path),
+	)
+}
+
+type ProjectConversationWorkspaceFileReadOnlyError struct {
+	Reason ProjectConversationWorkspaceReadOnlyReason
+}
+
+func (e *ProjectConversationWorkspaceFileReadOnlyError) Error() string {
+	if e == nil || strings.TrimSpace(e.Reason.String()) == "" {
+		return "project conversation workspace file is read-only"
+	}
+	return fmt.Sprintf("project conversation workspace file is read-only: %s", e.Reason)
+}
+
+func ParseWorkspaceRepoPath(raw string) (WorkspaceRepoPath, error) {
+	parsed, err := parseProjectConversationWorkspaceRelativePath(raw, false)
+	if err != nil {
+		return "", err
+	}
+	return WorkspaceRepoPath(parsed), nil
+}
+
+func ParseWorkspaceFilePath(raw string) (WorkspaceFilePath, error) {
+	parsed, err := parseProjectConversationWorkspaceRelativePath(raw, false)
+	if err != nil {
+		return "", err
+	}
+	return WorkspaceFilePath(parsed), nil
+}
+
+func ParseWorkspaceFileRevision(raw string) (WorkspaceFileRevision, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("base_revision must not be empty")
+	}
+	return WorkspaceFileRevision(trimmed), nil
+}
+
+func ParseWorkspaceEncoding(raw string) (WorkspaceEncoding, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(WorkspaceEncodingUTF8):
+		return WorkspaceEncodingUTF8, nil
+	default:
+		return "", fmt.Errorf("encoding must be utf-8")
+	}
+}
+
+func ParseWorkspaceLineEnding(raw string) (WorkspaceLineEnding, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(WorkspaceLineEndingLF):
+		return WorkspaceLineEndingLF, nil
+	case string(WorkspaceLineEndingCRLF):
+		return WorkspaceLineEndingCRLF, nil
+	default:
+		return "", fmt.Errorf("line_ending must be lf or crlf")
+	}
+}
+
+func ParseWorkspaceTextContent(raw string) (WorkspaceTextContent, error) {
+	return WorkspaceTextContent(raw), nil
+}
+
+func normalizeWorkspaceTextContent(
+	content WorkspaceTextContent,
+	lineEnding WorkspaceLineEnding,
+) []byte {
+	normalized := strings.ReplaceAll(content.String(), "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	if lineEnding == WorkspaceLineEndingCRLF {
+		normalized = strings.ReplaceAll(normalized, "\n", "\r\n")
+	}
+	return []byte(normalized)
+}
+
+func detectWorkspaceLineEnding(content []byte) WorkspaceLineEnding {
+	if bytes.Contains(content, []byte("\r\n")) {
+		return WorkspaceLineEndingCRLF
+	}
+	return WorkspaceLineEndingLF
+}
+
+func computeWorkspaceFileRevision(content []byte) WorkspaceFileRevision {
+	sum := sha256.Sum256(content)
+	return WorkspaceFileRevision(hex.EncodeToString(sum[:]))
+}
+
+func classifyWorkspaceTextFile(content []byte, sizeBytes int64) (
+	previewKind ProjectConversationWorkspacePreviewKind,
+	writable bool,
+	reason ProjectConversationWorkspaceReadOnlyReason,
+	lineEnding WorkspaceLineEnding,
+) {
+	lineEnding = detectWorkspaceLineEnding(content)
+	if projectConversationWorkspaceLooksBinary(content) {
+		return ProjectConversationWorkspacePreviewKindBinary, false, ProjectConversationWorkspaceReadOnlyReasonBinaryFile, lineEnding
+	}
+	if sizeBytes > projectConversationWorkspacePreviewLimitBytes {
+		return ProjectConversationWorkspacePreviewKindText, false, ProjectConversationWorkspaceReadOnlyReasonFileTooLarge, lineEnding
+	}
+	return ProjectConversationWorkspacePreviewKindText, true, "", lineEnding
+}
+
+func (s *ProjectConversationService) SaveWorkspaceFile(
+	ctx context.Context,
+	userID UserID,
+	conversationID uuid.UUID,
+	input ProjectConversationWorkspaceFileSaveInput,
+) (ProjectConversationWorkspaceFileSaved, error) {
+	resolved, relativePath, err := s.resolveConversationWorkspaceRepoPath(
+		ctx,
+		userID,
+		conversationID,
+		input.RepoPath.String(),
+		input.Path.String(),
+		false,
+	)
+	if err != nil {
+		var conflictErr *ProjectConversationWorkspaceFileConflictError
+		if errors.As(err, &conflictErr) && conflictErr != nil {
+			conflictErr.CurrentFile.ConversationID = resolved.conversationID
+			conflictErr.CurrentFile.RepoPath = resolved.repo.relativePath
+			conflictErr.CurrentFile.Path = relativePath
+		}
+		return ProjectConversationWorkspaceFileSaved{}, err
+	}
+
+	content := normalizeWorkspaceTextContent(input.Content, input.LineEnding)
+	revision, sizeBytes, err := s.writeConversationWorkspaceFile(
+		ctx,
+		resolved.machine,
+		resolved.repo.repoPath,
+		relativePath,
+		input.BaseRevision,
+		content,
+		input.Encoding,
+		input.LineEnding,
+	)
+	if err != nil {
+		return ProjectConversationWorkspaceFileSaved{}, err
+	}
+
+	return ProjectConversationWorkspaceFileSaved{
+		ConversationID: resolved.conversationID,
+		RepoPath:       resolved.repo.relativePath,
+		Path:           input.Path.String(),
+		Revision:       revision.String(),
+		SizeBytes:      sizeBytes,
+		Encoding:       input.Encoding.String(),
+		LineEnding:     input.LineEnding.String(),
+	}, nil
+}
+
+func (s *ProjectConversationService) writeConversationWorkspaceFile(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	repoRoot string,
+	relativePath string,
+	baseRevision WorkspaceFileRevision,
+	content []byte,
+	encoding WorkspaceEncoding,
+	lineEnding WorkspaceLineEnding,
+) (WorkspaceFileRevision, int64, error) {
+	if machine.Host != catalogdomain.LocalMachineHost {
+		return s.writeRemoteConversationWorkspaceFile(
+			ctx,
+			machine,
+			repoRoot,
+			relativePath,
+			baseRevision,
+			content,
+			encoding,
+			lineEnding,
+		)
+	}
+	return writeLocalConversationWorkspaceFile(repoRoot, relativePath, baseRevision, content, encoding, lineEnding)
+}
+
+func writeLocalConversationWorkspaceFile(
+	repoRoot string,
+	relativePath string,
+	baseRevision WorkspaceFileRevision,
+	content []byte,
+	encoding WorkspaceEncoding,
+	_ WorkspaceLineEnding,
+) (WorkspaceFileRevision, int64, error) {
+	if encoding != WorkspaceEncodingUTF8 {
+		return "", 0, fmt.Errorf("workspace encoding %s is unsupported", encoding)
+	}
+	resolvedFile, err := resolveLocalProjectConversationWorkspaceFile(repoRoot, relativePath)
+	if err != nil {
+		return "", 0, err
+	}
+
+	currentContent, info, err := readLocalWorkspaceFileContent(resolvedFile.path)
+	if err != nil {
+		return "", 0, err
+	}
+	currentRevision := computeWorkspaceFileRevision(currentContent)
+	if currentRevision != baseRevision {
+		return "", 0, &ProjectConversationWorkspaceFileConflictError{
+			CurrentFile: buildWorkspacePreviewFromContent(relativePath, currentContent, info.Size()),
+		}
+	}
+
+	preview := buildWorkspacePreviewFromContent(relativePath, currentContent, info.Size())
+	if !preview.Writable {
+		return "", 0, &ProjectConversationWorkspaceFileReadOnlyError{Reason: ProjectConversationWorkspaceReadOnlyReason(preview.ReadOnlyReason)}
+	}
+
+	if err := writeFileAtomically(resolvedFile.path, content, info.Mode().Perm()); err != nil {
+		return "", 0, err
+	}
+
+	return computeWorkspaceFileRevision(content), int64(len(content)), nil
+}
+
+func readLocalWorkspaceFileContent(path string) ([]byte, os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, ErrProjectConversationWorkspaceEntryNotFound
+		}
+		return nil, nil, fmt.Errorf("stat workspace file %s: %w", path, err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, ErrProjectConversationWorkspaceEntryNotFound
+		}
+		return nil, nil, fmt.Errorf("read workspace file %s: %w", path, err)
+	}
+	return content, info, nil
+}
+
+func buildWorkspacePreviewFromContent(
+	relativePath string,
+	content []byte,
+	sizeBytes int64,
+) ProjectConversationWorkspaceFilePreview {
+	snippet := content
+	truncated := int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes || sizeBytes > projectConversationWorkspacePreviewLimitBytes
+	if int64(len(snippet)) > projectConversationWorkspacePreviewLimitBytes {
+		snippet = snippet[:projectConversationWorkspacePreviewLimitBytes]
+	}
+	previewKind, writable, reason, lineEnding := classifyWorkspaceTextFile(content, sizeBytes)
+	preview := ProjectConversationWorkspaceFilePreview{
+		SizeBytes:      sizeBytes,
+		MediaType:      projectConversationWorkspaceMediaType(relativePath),
+		PreviewKind:    previewKind,
+		Truncated:      truncated,
+		Revision:       computeWorkspaceFileRevision(content).String(),
+		Writable:       writable,
+		ReadOnlyReason: reason.String(),
+		Encoding:       WorkspaceEncodingUTF8.String(),
+		LineEnding:     lineEnding.String(),
+	}
+	if previewKind == ProjectConversationWorkspacePreviewKindText {
+		preview.Content = string(snippet)
+	}
+	return preview
+}
+
+func writeFileAtomically(path string, content []byte, mode os.FileMode) error {
+	dirPath := filepath.Dir(path)
+	base := filepath.Base(path)
+	tempFile, err := os.CreateTemp(dirPath, "."+base+".openase-save-*")
+	if err != nil {
+		return fmt.Errorf("create temp workspace file for %s: %w", path, err)
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := tempFile.Chmod(mode); err != nil {
+		return fmt.Errorf("chmod temp workspace file %s: %w", tempPath, err)
+	}
+	if _, err := tempFile.Write(content); err != nil {
+		return fmt.Errorf("write temp workspace file %s: %w", tempPath, err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		return fmt.Errorf("sync temp workspace file %s: %w", tempPath, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp workspace file %s: %w", tempPath, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("rename temp workspace file %s into %s: %w", tempPath, path, err)
+	}
+
+	dir, err := os.Open(dirPath)
+	if err == nil {
+		defer func() { _ = dir.Close() }()
+		if syncErr := dir.Sync(); syncErr != nil {
+			return fmt.Errorf("sync workspace directory %s: %w", dirPath, syncErr)
+		}
+	}
+	return nil
+}
+
+func (s *ProjectConversationService) writeRemoteConversationWorkspaceFile(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	repoRoot string,
+	relativePath string,
+	baseRevision WorkspaceFileRevision,
+	content []byte,
+	encoding WorkspaceEncoding,
+	_ WorkspaceLineEnding,
+) (WorkspaceFileRevision, int64, error) {
+	if encoding != WorkspaceEncodingUTF8 {
+		return "", 0, fmt.Errorf("workspace encoding %s is unsupported", encoding)
+	}
+	if s == nil || s.sshPool == nil {
+		return "", 0, fmt.Errorf("ssh pool unavailable for machine %s", machine.Name)
+	}
+	client, err := s.sshPool.Get(ctx, machine)
+	if err != nil {
+		return "", 0, err
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		return "", 0, fmt.Errorf("open ssh session for workspace file save: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return "", 0, fmt.Errorf("open ssh stdin for workspace file save: %w", err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return "", 0, fmt.Errorf("open ssh stdout for workspace file save: %w", err)
+	}
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return "", 0, fmt.Errorf("open ssh stderr for workspace file save: %w", err)
+	}
+
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	stdoutDone := make(chan struct{})
+	stderrDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&stdoutBuffer, stdout)
+		close(stdoutDone)
+	}()
+	go func() {
+		_, _ = io.Copy(&stderrBuffer, stderr)
+		close(stderrDone)
+	}()
+
+	command := buildRemoteWorkspaceFileSaveCommand(repoRoot, relativePath, baseRevision)
+	if err := session.Start(command); err != nil {
+		_ = stdin.Close()
+		<-stdoutDone
+		<-stderrDone
+		return "", 0, fmt.Errorf("start ssh workspace file save: %w", err)
+	}
+	_, writeErr := stdin.Write(content)
+	stdinCloseErr := stdin.Close()
+	waitErr := session.Wait()
+	<-stdoutDone
+	<-stderrDone
+
+	if writeErr != nil {
+		return "", 0, fmt.Errorf("stream workspace file content for %s: %w", relativePath, writeErr)
+	}
+	if stdinCloseErr != nil {
+		return "", 0, fmt.Errorf("close workspace file save stdin for %s: %w", relativePath, stdinCloseErr)
+	}
+
+	stdoutText := strings.TrimSpace(stdoutBuffer.String())
+	stderrText := strings.TrimSpace(stderrBuffer.String())
+	if waitErr != nil {
+		if strings.HasPrefix(stdoutText, "conflict\t") {
+			currentFile, parseErr := parseRemoteWorkspaceConflictPreview(stdoutText)
+			if parseErr != nil {
+				return "", 0, parseErr
+			}
+			return "", 0, &ProjectConversationWorkspaceFileConflictError{CurrentFile: currentFile}
+		}
+		if strings.Contains(stderrText, "readonly:") {
+			reason := strings.TrimSpace(strings.TrimPrefix(stderrText, "readonly:"))
+			return "", 0, &ProjectConversationWorkspaceFileReadOnlyError{Reason: ProjectConversationWorkspaceReadOnlyReason(reason)}
+		}
+		if strings.Contains(stderrText, "missing") {
+			return "", 0, ErrProjectConversationWorkspaceEntryNotFound
+		}
+		if strings.Contains(stderrText, "escape") {
+			return "", 0, ErrProjectConversationWorkspacePathInvalid
+		}
+		return "", 0, fmt.Errorf("%w: %s", waitErr, stderrText)
+	}
+
+	fields := strings.SplitN(stdoutText, "\t", 2)
+	if len(fields) != 2 {
+		return "", 0, fmt.Errorf("parse remote workspace file save output %q", stdoutText)
+	}
+	var size int64
+	if _, err := fmt.Sscanf(fields[1], "%d", &size); err != nil {
+		return "", 0, fmt.Errorf("parse remote workspace file save size %q: %w", fields[1], err)
+	}
+	return WorkspaceFileRevision(strings.TrimSpace(fields[0])), size, nil
+}
+
+func buildRemoteWorkspaceFileSaveCommand(
+	repoRoot string,
+	relativePath string,
+	baseRevision WorkspaceFileRevision,
+) string {
+	return fmt.Sprintf(`sh -lc %s`, projectConversationShellQuote(fmt.Sprintf(`set -eu
+repo=%s
+relative=%s
+expected_revision=%s
+repo_real=$(cd "$repo" && pwd -P)
+base="$relative"
+parent=""
+if [ "$relative" != "$base" ]; then
+  parent="${relative%%/*}"
+fi
+target_dir="$repo"
+if [ -n "$parent" ]; then
+  target_dir="$repo/$parent"
+fi
+dir_real=$(cd "$target_dir" 2>/dev/null && pwd -P) || { echo missing >&2; exit 11; }
+case "$dir_real" in
+  "$repo_real"|"$repo_real"/*) ;;
+  *) echo escape >&2; exit 12 ;;
+esac
+target="$dir_real/$base"
+if [ -L "$target" ]; then
+  echo escape >&2
+  exit 12
+fi
+if [ ! -f "$target" ]; then
+  echo missing >&2
+  exit 11
+fi
+current_size=$(wc -c <"$target" | tr -d '[:space:]')
+current_revision=$(sha256sum "$target" | awk '{print $1}')
+head -c 262145 "$target" | base64 -w0 >"$target.dirpreview.openase" 2>/dev/null || true
+preview_base64=$(cat "$target.dirpreview.openase" 2>/dev/null || printf '')
+rm -f "$target.dirpreview.openase"
+if [ "$current_revision" != "$expected_revision" ]; then
+  printf 'conflict\t%%s\t%%s\t%%s\n' "$current_revision" "$current_size" "$preview_base64"
+  exit 13
+fi
+if python3 - "$target" <<'PY' >/dev/null 2>&1
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+content = path.read_bytes()
+if b'\x00' in content:
+    raise SystemExit(1)
+content.decode('utf-8')
+if len(content) > 262144:
+    raise SystemExit(2)
+PY
+then
+  :
+else
+  status=$?
+  if [ "$status" = 1 ]; then
+    echo readonly:binary_file >&2
+  elif [ "$status" = 2 ]; then
+    echo readonly:file_too_large >&2
+  else
+    echo readonly:unsupported_encoding >&2
+  fi
+  exit 14
+fi
+mode=$(stat -c '%%a' "$target")
+tmp=$(mktemp "$dir_real/.openase-save.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+cat >"$tmp"
+chmod "$mode" "$tmp"
+mv "$tmp" "$target"
+new_size=$(wc -c <"$target" | tr -d '[:space:]')
+new_revision=$(sha256sum "$target" | awk '{print $1}')
+printf '%%s\t%%s' "$new_revision" "$new_size"
+`, projectConversationShellQuote(repoRoot), projectConversationShellQuote(relativePath), projectConversationShellQuote(baseRevision.String()))))
+}
+
+func parseRemoteWorkspaceConflictPreview(output string) (ProjectConversationWorkspaceFilePreview, error) {
+	fields := strings.SplitN(strings.TrimSpace(output), "\t", 4)
+	if len(fields) != 4 || fields[0] != "conflict" {
+		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("parse remote workspace file conflict output %q", output)
+	}
+	var size int64
+	if _, err := fmt.Sscanf(fields[2], "%d", &size); err != nil {
+		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("parse remote workspace file conflict size %q: %w", fields[2], err)
+	}
+	content, err := base64.StdEncoding.DecodeString(fields[3])
+	if err != nil {
+		return ProjectConversationWorkspaceFilePreview{}, fmt.Errorf("decode remote workspace file conflict preview: %w", err)
+	}
+	preview := buildWorkspacePreviewFromContent("", content, size)
+	preview.Revision = strings.TrimSpace(fields[1])
+	return preview, nil
+}

--- a/internal/chat/project_conversation_workspace_file_edit.go
+++ b/internal/chat/project_conversation_workspace_file_edit.go
@@ -320,6 +320,7 @@ func readLocalWorkspaceFileContent(path string) ([]byte, os.FileInfo, error) {
 		}
 		return nil, nil, fmt.Errorf("stat workspace file %s: %w", path, err)
 	}
+	// #nosec G304 -- path is resolved through resolveLocalProjectConversationWorkspaceFile and remains within the repo root.
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -387,6 +388,7 @@ func writeFileAtomically(path string, content []byte, mode os.FileMode) error {
 		return fmt.Errorf("rename temp workspace file %s into %s: %w", tempPath, path, err)
 	}
 
+	// #nosec G304 -- dirPath is derived from the validated resolved workspace file path above.
 	dir, err := os.Open(dirPath)
 	if err == nil {
 		defer func() { _ = dir.Close() }()

--- a/internal/chat/project_focus.go
+++ b/internal/chat/project_focus.go
@@ -9,6 +9,7 @@ import (
 
 type RawProjectConversationFocus struct {
 	Kind                 string                                     `json:"kind"`
+	ConversationID       *string                                    `json:"conversation_id"`
 	WorkflowID           *string                                    `json:"workflow_id"`
 	WorkflowName         *string                                    `json:"workflow_name"`
 	WorkflowType         *string                                    `json:"workflow_type"`
@@ -41,6 +42,8 @@ type RawProjectConversationFocus struct {
 	MachineHost          *string                                    `json:"machine_host"`
 	MachineStatus        *string                                    `json:"machine_status"`
 	HealthSummary        *string                                    `json:"health_summary"`
+	WorkspaceRepoPath    *string                                    `json:"workspace_repo_path"`
+	WorkspaceFilePath    *string                                    `json:"workspace_file_path"`
 }
 
 type RawProjectConversationTicketDependency struct {
@@ -96,18 +99,20 @@ type RawProjectConversationTicketTargetMachine struct {
 type ProjectConversationFocusKind string
 
 const (
-	ProjectConversationFocusWorkflow ProjectConversationFocusKind = "workflow"
-	ProjectConversationFocusSkill    ProjectConversationFocusKind = "skill"
-	ProjectConversationFocusTicket   ProjectConversationFocusKind = "ticket"
-	ProjectConversationFocusMachine  ProjectConversationFocusKind = "machine"
+	ProjectConversationFocusWorkflow  ProjectConversationFocusKind = "workflow"
+	ProjectConversationFocusSkill     ProjectConversationFocusKind = "skill"
+	ProjectConversationFocusTicket    ProjectConversationFocusKind = "ticket"
+	ProjectConversationFocusMachine   ProjectConversationFocusKind = "machine"
+	ProjectConversationFocusWorkspace ProjectConversationFocusKind = "workspace_file"
 )
 
 type ProjectConversationFocus struct {
-	Kind     ProjectConversationFocusKind
-	Workflow *ProjectConversationWorkflowFocus
-	Skill    *ProjectConversationSkillFocus
-	Ticket   *ProjectConversationTicketFocus
-	Machine  *ProjectConversationMachineFocus
+	Kind      ProjectConversationFocusKind
+	Workflow  *ProjectConversationWorkflowFocus
+	Skill     *ProjectConversationSkillFocus
+	Ticket    *ProjectConversationTicketFocus
+	Machine   *ProjectConversationMachineFocus
+	Workspace *ProjectConversationWorkspaceFocus
 }
 
 type ProjectConversationWorkflowFocus struct {
@@ -205,6 +210,14 @@ type ProjectConversationMachineFocus struct {
 	Status        string
 	SelectedArea  string
 	HealthSummary string
+}
+
+type ProjectConversationWorkspaceFocus struct {
+	ConversationID uuid.UUID
+	RepoPath       string
+	FilePath       string
+	SelectedArea   string
+	HasDirtyDraft  bool
 }
 
 func ParseProjectConversationFocus(raw *RawProjectConversationFocus) (*ProjectConversationFocus, error) {
@@ -332,8 +345,31 @@ func ParseProjectConversationFocus(raw *RawProjectConversationFocus) (*ProjectCo
 				HealthSummary: trimOptionalFocusString(raw.HealthSummary),
 			},
 		}, nil
+	case ProjectConversationFocusWorkspace:
+		conversationID, err := parseRequiredFocusUUID("focus.conversation_id", raw.ConversationID)
+		if err != nil {
+			return nil, err
+		}
+		repoPath, err := parseRequiredFocusString("focus.workspace_repo_path", raw.WorkspaceRepoPath)
+		if err != nil {
+			return nil, err
+		}
+		filePath, err := parseRequiredFocusString("focus.workspace_file_path", raw.WorkspaceFilePath)
+		if err != nil {
+			return nil, err
+		}
+		return &ProjectConversationFocus{
+			Kind: ProjectConversationFocusWorkspace,
+			Workspace: &ProjectConversationWorkspaceFocus{
+				ConversationID: conversationID,
+				RepoPath:       repoPath,
+				FilePath:       filePath,
+				SelectedArea:   trimOptionalFocusString(raw.SelectedArea),
+				HasDirtyDraft:  boolPointerValue(raw.HasDirtyDraft),
+			},
+		}, nil
 	default:
-		return nil, fmt.Errorf("focus.kind must be one of workflow, skill, ticket, machine")
+		return nil, fmt.Errorf("focus.kind must be one of workflow, skill, ticket, machine, workspace_file")
 	}
 }
 

--- a/internal/chat/project_focus_snapshot.go
+++ b/internal/chat/project_focus_snapshot.go
@@ -129,6 +129,18 @@ func rawProjectConversationFocusFromFocus(focus *ProjectConversationFocus) *RawP
 			SelectedArea:  optionalString(focus.Machine.SelectedArea),
 			HealthSummary: optionalString(focus.Machine.HealthSummary),
 		}
+	case ProjectConversationFocusWorkspace:
+		if focus.Workspace == nil {
+			return nil
+		}
+		return &RawProjectConversationFocus{
+			Kind:              string(ProjectConversationFocusWorkspace),
+			ConversationID:    optionalString(focus.Workspace.ConversationID.String()),
+			WorkspaceRepoPath: optionalString(focus.Workspace.RepoPath),
+			WorkspaceFilePath: optionalString(focus.Workspace.FilePath),
+			SelectedArea:      optionalString(focus.Workspace.SelectedArea),
+			HasDirtyDraft:     projectFocusBoolPointer(focus.Workspace.HasDirtyDraft),
+		}
 	default:
 		return nil
 	}

--- a/internal/chat/project_focus_test.go
+++ b/internal/chat/project_focus_test.go
@@ -141,6 +141,31 @@ func TestParseProjectConversationFocusTicketPreservesExpandedPayload(t *testing.
 	}
 }
 
+func TestParseProjectConversationFocusWorkspace(t *testing.T) {
+	t.Parallel()
+
+	focus, err := ParseProjectConversationFocus(&RawProjectConversationFocus{
+		Kind:              "workspace_file",
+		ConversationID:    stringPointer("550e8400-e29b-41d4-a716-446655440000"),
+		WorkspaceRepoPath: stringPointer("openase"),
+		WorkspaceFilePath: stringPointer("web/src/lib/app.ts"),
+		SelectedArea:      stringPointer("edit"),
+		HasDirtyDraft:     testBoolPointer(true),
+	})
+	if err != nil {
+		t.Fatalf("ParseProjectConversationFocus() error = %v", err)
+	}
+	if focus == nil || focus.Workspace == nil {
+		t.Fatalf("expected workspace focus, got %#v", focus)
+	}
+	if focus.Workspace.RepoPath != "openase" ||
+		focus.Workspace.FilePath != "web/src/lib/app.ts" ||
+		focus.Workspace.SelectedArea != "edit" ||
+		!focus.Workspace.HasDirtyDraft {
+		t.Fatalf("unexpected workspace focus = %#v", focus.Workspace)
+	}
+}
+
 func testBoolPointer(value bool) *bool {
 	return &value
 }

--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -824,6 +824,18 @@ func renderProjectConversationFocus(focus *ProjectConversationFocus) string {
 		if focus.Machine.HealthSummary != "" {
 			_, _ = fmt.Fprintf(&sb, "- health_summary: %s\n", focus.Machine.HealthSummary)
 		}
+	case ProjectConversationFocusWorkspace:
+		if focus.Workspace == nil {
+			return "- none\n"
+		}
+		_, _ = fmt.Fprintf(&sb, "- Type: workspace_file\n")
+		_, _ = fmt.Fprintf(&sb, "- conversation_id: %s\n", focus.Workspace.ConversationID)
+		_, _ = fmt.Fprintf(&sb, "- repo_path: %s\n", focus.Workspace.RepoPath)
+		_, _ = fmt.Fprintf(&sb, "- file_path: %s\n", focus.Workspace.FilePath)
+		if focus.Workspace.SelectedArea != "" {
+			_, _ = fmt.Fprintf(&sb, "- selected_area: %s\n", focus.Workspace.SelectedArea)
+		}
+		_, _ = fmt.Fprintf(&sb, "- has_dirty_draft: %t\n", focus.Workspace.HasDirtyDraft)
 	}
 	return sb.String()
 }

--- a/internal/cli/api_parity_test.go
+++ b/internal/cli/api_parity_test.go
@@ -26,6 +26,7 @@ var intentionalCLIOpenAPIGaps = map[string]string{
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace"):                                    "project conversation workspace inspection has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/file"):                               "project conversation workspace file preview has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/file-patch"):                         "project conversation workspace file diff has no first-class CLI yet",
+	contractKey("PUT", "/api/v1/chat/conversations/{conversationId}/workspace/file"):                               "project conversation workspace file save has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/tree"):                               "project conversation workspace tree browsing has no first-class CLI yet",
 	contractKey("POST", "/api/v1/chat/conversations/{conversationId}/terminal-sessions"):                           "project conversation terminal session creation has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/terminal-sessions/{terminalSessionId}/attach"): "project conversation terminal websocket attach has no first-class CLI yet",

--- a/internal/httpapi/chat_api.go
+++ b/internal/httpapi/chat_api.go
@@ -40,6 +40,7 @@ func (s *Server) registerChatRoutes(api *echo.Group) {
 	api.GET("/chat/conversations/:conversationId/workspace", s.handleGetProjectConversationWorkspace)
 	api.GET("/chat/conversations/:conversationId/workspace/tree", s.handleListProjectConversationWorkspaceTree)
 	api.GET("/chat/conversations/:conversationId/workspace/file", s.handleGetProjectConversationWorkspaceFile)
+	api.PUT("/chat/conversations/:conversationId/workspace/file", s.handlePutProjectConversationWorkspaceFile)
 	api.GET("/chat/conversations/:conversationId/workspace/file-patch", s.handleGetProjectConversationWorkspaceFilePatch)
 	api.GET("/chat/conversations/:conversationId/workspace-diff", s.handleGetProjectConversationWorkspaceDiff)
 	api.POST("/chat/conversations/:conversationId/terminal-sessions", s.handleCreateProjectConversationTerminalSession)
@@ -607,6 +608,53 @@ func (s *Server) handleGetProjectConversationWorkspaceFile(c echo.Context) error
 	return c.JSON(http.StatusOK, map[string]any{"file_preview": mapProjectConversationWorkspaceFilePreviewResponse(item)})
 }
 
+func (s *Server) handlePutProjectConversationWorkspaceFile(c echo.Context) error {
+	if s.projectConversationService == nil {
+		return writeAPIError(c, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "project conversation service unavailable")
+	}
+	conversationID, err := parseUUIDString("conversation_id", c.Param("conversationId"))
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_CONVERSATION_ID", err.Error())
+	}
+	userID, err := s.currentProjectConversationUserID(c)
+	if err != nil {
+		return writeChatUserError(c, err)
+	}
+
+	var raw rawUpdateProjectConversationWorkspaceFileRequest
+	if err := decodeJSON(c, &raw); err != nil {
+		return err
+	}
+	request, err := parseUpdateProjectConversationWorkspaceFileRequest(raw)
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	}
+
+	item, err := s.projectConversationService.SaveWorkspaceFile(
+		c.Request().Context(),
+		userID,
+		conversationID,
+		request.File,
+	)
+	if err != nil {
+		var conflictErr *chatservice.ProjectConversationWorkspaceFileConflictError
+		if errors.As(err, &conflictErr) {
+			details := map[string]any{
+				"current_file": mapProjectConversationWorkspaceFilePreviewResponse(conflictErr.CurrentFile),
+			}
+			return writeAPIErrorWithDetails(
+				c,
+				http.StatusConflict,
+				"PROJECT_CONVERSATION_WORKSPACE_FILE_CONFLICT",
+				conflictErr.Error(),
+				details,
+			)
+		}
+		return writeProjectConversationError(c, err)
+	}
+	return c.JSON(http.StatusOK, map[string]any{"file": mapProjectConversationWorkspaceFileSavedResponse(item)})
+}
+
 func (s *Server) handleGetProjectConversationWorkspaceFilePatch(c echo.Context) error {
 	if s.projectConversationService == nil {
 		return writeAPIError(c, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "project conversation service unavailable")
@@ -780,13 +828,25 @@ func (s *Server) handleStartProjectConversationTurn(c echo.Context) error {
 		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
 	}
 
-	turn, err := s.projectConversationService.StartTurn(
-		c.Request().Context(),
-		userID,
-		conversationID,
-		request.Message,
-		request.Focus,
-	)
+	var turn chatdomain.Turn
+	if request.WorkspaceFileDraft != nil {
+		turn, err = s.projectConversationService.StartTurnWithWorkspaceFileDraft(
+			c.Request().Context(),
+			userID,
+			conversationID,
+			request.Message,
+			request.Focus,
+			request.WorkspaceFileDraft,
+		)
+	} else {
+		turn, err = s.projectConversationService.StartTurn(
+			c.Request().Context(),
+			userID,
+			conversationID,
+			request.Message,
+			request.Focus,
+		)
+	}
 	if err != nil {
 		return writeProjectConversationError(c, err)
 	}
@@ -1046,6 +1106,7 @@ func writeConversationTerminalFrame(conn *websocket.Conn, event chatservice.Conv
 }
 
 func writeProjectConversationError(c echo.Context, err error) error {
+	var readOnlyErr *chatservice.ProjectConversationWorkspaceFileReadOnlyError
 	switch {
 	case errors.Is(err, chatservice.ErrConversationTurnActive):
 		return writeAPIError(c, http.StatusConflict, "PROJECT_CONVERSATION_TURN_ALREADY_ACTIVE", err.Error())
@@ -1067,6 +1128,8 @@ func writeProjectConversationError(c echo.Context, err error) error {
 		return writeAPIError(c, http.StatusConflict, "CHAT_CONVERSATION_RUNTIME_UNAVAILABLE", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspaceUnavailable):
 		return writeAPIError(c, http.StatusConflict, "PROJECT_CONVERSATION_WORKSPACE_UNAVAILABLE", err.Error())
+	case errors.As(err, &readOnlyErr):
+		return writeAPIError(c, http.StatusConflict, "PROJECT_CONVERSATION_WORKSPACE_FILE_READ_ONLY", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspacePathInvalid):
 		return writeAPIError(c, http.StatusBadRequest, "PROJECT_CONVERSATION_WORKSPACE_PATH_INVALID", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspaceRepoNotFound), errors.Is(err, chatservice.ErrProjectConversationWorkspaceEntryNotFound):
@@ -1283,14 +1346,33 @@ func mapProjectConversationWorkspaceFilePreviewResponse(
 	item chatservice.ProjectConversationWorkspaceFilePreview,
 ) map[string]any {
 	return map[string]any{
+		"conversation_id":  item.ConversationID.String(),
+		"repo_path":        item.RepoPath,
+		"path":             item.Path,
+		"size_bytes":       item.SizeBytes,
+		"media_type":       item.MediaType,
+		"preview_kind":     string(item.PreviewKind),
+		"truncated":        item.Truncated,
+		"content":          item.Content,
+		"revision":         item.Revision,
+		"writable":         item.Writable,
+		"read_only_reason": item.ReadOnlyReason,
+		"encoding":         item.Encoding,
+		"line_ending":      item.LineEnding,
+	}
+}
+
+func mapProjectConversationWorkspaceFileSavedResponse(
+	item chatservice.ProjectConversationWorkspaceFileSaved,
+) map[string]any {
+	return map[string]any{
 		"conversation_id": item.ConversationID.String(),
 		"repo_path":       item.RepoPath,
 		"path":            item.Path,
+		"revision":        item.Revision,
 		"size_bytes":      item.SizeBytes,
-		"media_type":      item.MediaType,
-		"preview_kind":    string(item.PreviewKind),
-		"truncated":       item.Truncated,
-		"content":         item.Content,
+		"encoding":        item.Encoding,
+		"line_ending":     item.LineEnding,
 	}
 }
 

--- a/internal/httpapi/chat_api_test.go
+++ b/internal/httpapi/chat_api_test.go
@@ -234,6 +234,12 @@ func TestProjectConversationRoutesRequireHumanPrincipalInOIDCMode(t *testing.T) 
 			target: "/api/v1/chat/conversations/" + conversationID + "/workspace/file?repo_path=openase&path=README.md",
 		},
 		{
+			name:   "workspace file save",
+			method: http.MethodPut,
+			target: "/api/v1/chat/conversations/" + conversationID + "/workspace/file",
+			body:   `{"repo_path":"openase","path":"README.md","base_revision":"rev-1","content":"hello\n","encoding":"utf-8","line_ending":"lf"}`,
+		},
+		{
 			name:   "workspace file patch",
 			method: http.MethodGet,
 			target: "/api/v1/chat/conversations/" + conversationID + "/workspace/file-patch?repo_path=openase&path=README.md",

--- a/internal/httpapi/chat_requests.go
+++ b/internal/httpapi/chat_requests.go
@@ -17,8 +17,9 @@ type rawCreateConversationRequest struct {
 }
 
 type rawConversationTurnRequest struct {
-	Message string                                   `json:"message"`
-	Focus   *chatservice.RawProjectConversationFocus `json:"focus"`
+	Message            string                                           `json:"message"`
+	Focus              *chatservice.RawProjectConversationFocus         `json:"focus"`
+	WorkspaceFileDraft *rawProjectConversationWorkspaceFileDraftContext `json:"workspace_file_draft,omitempty"`
 }
 
 type rawInterruptResponseRequest struct {
@@ -33,8 +34,9 @@ type createProjectConversationRequest struct {
 }
 
 type projectConversationTurnRequest struct {
-	Message string
-	Focus   *chatservice.ProjectConversationFocus
+	Message            string
+	Focus              *chatservice.ProjectConversationFocus
+	WorkspaceFileDraft *chatservice.ProjectConversationWorkspaceFileDraftContext
 }
 
 type projectConversationWorkspaceTreeRequest struct {
@@ -45,6 +47,27 @@ type projectConversationWorkspaceTreeRequest struct {
 type projectConversationWorkspaceFileRequest struct {
 	RepoPath string
 	Path     string
+}
+
+type rawUpdateProjectConversationWorkspaceFileRequest struct {
+	RepoPath     string `json:"repo_path"`
+	Path         string `json:"path"`
+	BaseRevision string `json:"base_revision"`
+	Content      string `json:"content"`
+	Encoding     string `json:"encoding"`
+	LineEnding   string `json:"line_ending"`
+}
+
+type updateProjectConversationWorkspaceFileRequest struct {
+	File chatservice.ProjectConversationWorkspaceFileSaveInput
+}
+
+type rawProjectConversationWorkspaceFileDraftContext struct {
+	RepoPath   string `json:"repo_path"`
+	Path       string `json:"path"`
+	Content    string `json:"content"`
+	Encoding   string `json:"encoding"`
+	LineEnding string `json:"line_ending"`
 }
 
 type rawCreateProjectConversationTerminalSessionRequest struct {
@@ -89,9 +112,14 @@ func parseProjectConversationTurnRequest(raw rawConversationTurnRequest) (projec
 	if err != nil {
 		return projectConversationTurnRequest{}, writeableError(err.Error())
 	}
+	workspaceFileDraft, err := parseProjectConversationWorkspaceFileDraftContext(raw.WorkspaceFileDraft)
+	if err != nil {
+		return projectConversationTurnRequest{}, writeableError(err.Error())
+	}
 	return projectConversationTurnRequest{
-		Message: message,
-		Focus:   focus,
+		Message:            message,
+		Focus:              focus,
+		WorkspaceFileDraft: workspaceFileDraft,
 	}, nil
 }
 
@@ -131,6 +159,80 @@ func parseProjectConversationWorkspaceFileRequest(
 	return projectConversationWorkspaceFileRequest{
 		RepoPath: trimmedRepoPath,
 		Path:     trimmedPath,
+	}, nil
+}
+
+func parseUpdateProjectConversationWorkspaceFileRequest(
+	raw rawUpdateProjectConversationWorkspaceFileRequest,
+) (updateProjectConversationWorkspaceFileRequest, error) {
+	repoPath, err := chatservice.ParseWorkspaceRepoPath(raw.RepoPath)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	filePath, err := chatservice.ParseWorkspaceFilePath(raw.Path)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	baseRevision, err := chatservice.ParseWorkspaceFileRevision(raw.BaseRevision)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	content, err := chatservice.ParseWorkspaceTextContent(raw.Content)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	encoding, err := chatservice.ParseWorkspaceEncoding(raw.Encoding)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	lineEnding, err := chatservice.ParseWorkspaceLineEnding(raw.LineEnding)
+	if err != nil {
+		return updateProjectConversationWorkspaceFileRequest{}, writeableError(err.Error())
+	}
+	return updateProjectConversationWorkspaceFileRequest{
+		File: chatservice.ProjectConversationWorkspaceFileSaveInput{
+			RepoPath:     repoPath,
+			Path:         filePath,
+			BaseRevision: baseRevision,
+			Content:      content,
+			Encoding:     encoding,
+			LineEnding:   lineEnding,
+		},
+	}, nil
+}
+
+func parseProjectConversationWorkspaceFileDraftContext(
+	raw *rawProjectConversationWorkspaceFileDraftContext,
+) (*chatservice.ProjectConversationWorkspaceFileDraftContext, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	repoPath, err := chatservice.ParseWorkspaceRepoPath(raw.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	filePath, err := chatservice.ParseWorkspaceFilePath(raw.Path)
+	if err != nil {
+		return nil, err
+	}
+	content, err := chatservice.ParseWorkspaceTextContent(raw.Content)
+	if err != nil {
+		return nil, err
+	}
+	encoding, err := chatservice.ParseWorkspaceEncoding(raw.Encoding)
+	if err != nil {
+		return nil, err
+	}
+	lineEnding, err := chatservice.ParseWorkspaceLineEnding(raw.LineEnding)
+	if err != nil {
+		return nil, err
+	}
+	return &chatservice.ProjectConversationWorkspaceFileDraftContext{
+		RepoPath:   repoPath,
+		Path:       filePath,
+		Content:    content,
+		Encoding:   encoding,
+		LineEnding: lineEnding,
 	}, nil
 }
 

--- a/internal/httpapi/chat_requests_test.go
+++ b/internal/httpapi/chat_requests_test.go
@@ -132,6 +132,71 @@ func TestParseCreateProjectConversationTerminalSessionRequestRejectsUnsupportedM
 	}
 }
 
+func TestParseProjectConversationTurnRequestParsesWorkspaceDraftContext(t *testing.T) {
+	t.Parallel()
+
+	request, err := parseProjectConversationTurnRequest(rawConversationTurnRequest{
+		Message: "Review my unsaved workspace draft.",
+		Focus: &chat.RawProjectConversationFocus{
+			Kind:              "workspace_file",
+			ConversationID:    testStringPointer("550e8400-e29b-41d4-a716-446655440000"),
+			WorkspaceRepoPath: testStringPointer("openase"),
+			WorkspaceFilePath: testStringPointer("web/src/lib/app.ts"),
+			SelectedArea:      testStringPointer("edit"),
+			HasDirtyDraft:     testBoolPointer(true),
+		},
+		WorkspaceFileDraft: &rawProjectConversationWorkspaceFileDraftContext{
+			RepoPath:   "openase",
+			Path:       "web/src/lib/app.ts",
+			Content:    "console.log('draft')\n",
+			Encoding:   "utf-8",
+			LineEnding: "lf",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseProjectConversationTurnRequest() error = %v", err)
+	}
+	if request.Focus == nil || request.Focus.Workspace == nil {
+		t.Fatalf("expected workspace focus, got %#v", request.Focus)
+	}
+	if request.WorkspaceFileDraft == nil {
+		t.Fatal("expected workspace file draft context")
+	}
+	if request.WorkspaceFileDraft.RepoPath.String() != "openase" ||
+		request.WorkspaceFileDraft.Path.String() != "web/src/lib/app.ts" ||
+		request.WorkspaceFileDraft.Content.String() != "console.log('draft')\n" ||
+		request.WorkspaceFileDraft.Encoding.String() != "utf-8" ||
+		request.WorkspaceFileDraft.LineEnding.String() != "lf" {
+		t.Fatalf("unexpected workspace draft context = %#v", request.WorkspaceFileDraft)
+	}
+}
+
+func TestParseUpdateProjectConversationWorkspaceFileRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := parseUpdateProjectConversationWorkspaceFileRequest(
+		rawUpdateProjectConversationWorkspaceFileRequest{
+			RepoPath:     "openase",
+			Path:         "web/src/lib/app.ts",
+			BaseRevision: "rev-1",
+			Content:      "console.log('saved')\n",
+			Encoding:     "utf-8",
+			LineEnding:   "crlf",
+		},
+	)
+	if err != nil {
+		t.Fatalf("parseUpdateProjectConversationWorkspaceFileRequest() error = %v", err)
+	}
+	if request.File.RepoPath.String() != "openase" ||
+		request.File.Path.String() != "web/src/lib/app.ts" ||
+		request.File.BaseRevision.String() != "rev-1" ||
+		request.File.Content.String() != "console.log('saved')\n" ||
+		request.File.Encoding.String() != "utf-8" ||
+		request.File.LineEnding.String() != "crlf" {
+		t.Fatalf("unexpected parsed workspace file save request = %#v", request.File)
+	}
+}
+
 func testStringPointer(value string) *string {
 	return &value
 }

--- a/internal/httpapi/openapi.go
+++ b/internal/httpapi/openapi.go
@@ -354,12 +354,14 @@ type OpenAPIProjectConversationCreateRequest struct {
 }
 
 type OpenAPIProjectConversationTurnRequest struct {
-	Message string                               `json:"message"`
-	Focus   *OpenAPIProjectConversationTurnFocus `json:"focus,omitempty"`
+	Message            string                                        `json:"message"`
+	Focus              *OpenAPIProjectConversationTurnFocus          `json:"focus,omitempty"`
+	WorkspaceFileDraft *OpenAPIProjectConversationWorkspaceFileDraft `json:"workspace_file_draft,omitempty"`
 }
 
 type OpenAPIProjectConversationTurnFocus struct {
 	Kind                 string                                         `json:"kind"`
+	ConversationID       *string                                        `json:"conversation_id,omitempty"`
 	WorkflowID           *string                                        `json:"workflow_id,omitempty"`
 	WorkflowName         *string                                        `json:"workflow_name,omitempty"`
 	WorkflowType         *string                                        `json:"workflow_type,omitempty"`
@@ -392,6 +394,8 @@ type OpenAPIProjectConversationTurnFocus struct {
 	MachineHost          *string                                        `json:"machine_host,omitempty"`
 	MachineStatus        *string                                        `json:"machine_status,omitempty"`
 	HealthSummary        *string                                        `json:"health_summary,omitempty"`
+	WorkspaceRepoPath    *string                                        `json:"workspace_repo_path,omitempty"`
+	WorkspaceFilePath    *string                                        `json:"workspace_file_path,omitempty"`
 }
 
 type OpenAPIProjectConversationTicketDependency struct {
@@ -568,10 +572,46 @@ type OpenAPIProjectConversationWorkspaceFilePreview struct {
 	PreviewKind    string `json:"preview_kind"`
 	Truncated      bool   `json:"truncated"`
 	Content        string `json:"content"`
+	Revision       string `json:"revision"`
+	Writable       bool   `json:"writable"`
+	ReadOnlyReason string `json:"read_only_reason"`
+	Encoding       string `json:"encoding"`
+	LineEnding     string `json:"line_ending"`
 }
 
 type OpenAPIProjectConversationWorkspaceFilePreviewResponse struct {
 	FilePreview OpenAPIProjectConversationWorkspaceFilePreview `json:"file_preview"`
+}
+
+type OpenAPIProjectConversationWorkspaceFileDraft struct {
+	RepoPath   string `json:"repo_path"`
+	Path       string `json:"path"`
+	Content    string `json:"content"`
+	Encoding   string `json:"encoding"`
+	LineEnding string `json:"line_ending"`
+}
+
+type OpenAPIProjectConversationWorkspaceFileSaveRequest struct {
+	RepoPath     string `json:"repo_path"`
+	Path         string `json:"path"`
+	BaseRevision string `json:"base_revision"`
+	Content      string `json:"content"`
+	Encoding     string `json:"encoding"`
+	LineEnding   string `json:"line_ending"`
+}
+
+type OpenAPIProjectConversationWorkspaceFileSaved struct {
+	ConversationID string `json:"conversation_id"`
+	RepoPath       string `json:"repo_path"`
+	Path           string `json:"path"`
+	Revision       string `json:"revision"`
+	SizeBytes      int64  `json:"size_bytes"`
+	Encoding       string `json:"encoding"`
+	LineEnding     string `json:"line_ending"`
+}
+
+type OpenAPIProjectConversationWorkspaceFileSavedResponse struct {
+	File OpenAPIProjectConversationWorkspaceFileSaved `json:"file"`
 }
 
 type OpenAPIProjectConversationWorkspaceFilePatch struct {
@@ -2535,7 +2575,8 @@ var (
 	openAPIProjectConversationTurnDescriptions = map[string]string{
 		"message":                                           "User message content appended as the next project conversation turn.",
 		"focus":                                             "Optional per-turn focus context describing the currently selected workflow, skill, ticket, or machine surface.",
-		"focus.kind":                                        "Focused surface kind. Supported values are workflow, skill, ticket, and machine.",
+		"focus.kind":                                        "Focused surface kind. Supported values are workflow, skill, ticket, machine, and workspace_file.",
+		"focus.conversation_id":                             "Conversation ID for the focused workspace file surface.",
 		"focus.workflow_id":                                 "Workflow ID currently in focus.",
 		"focus.workflow_name":                               "Workflow name currently in focus.",
 		"focus.workflow_type":                               "Workflow type currently in focus.",
@@ -2597,6 +2638,14 @@ var (
 		"focus.machine_host":                                "Machine host currently in focus.",
 		"focus.machine_status":                              "Machine runtime status currently in focus.",
 		"focus.health_summary":                              "Compact health or resource summary for the focused machine.",
+		"focus.workspace_repo_path":                         "Workspace-relative repo path for the focused workspace file.",
+		"focus.workspace_file_path":                         "Repo-relative file path for the focused workspace file.",
+		"workspace_file_draft":                              "Optional request-scoped unsaved workspace file draft context for the active turn.",
+		"workspace_file_draft.repo_path":                    "Workspace-relative repo path for the unsaved draft.",
+		"workspace_file_draft.path":                         "Repo-relative file path for the unsaved draft.",
+		"workspace_file_draft.content":                      "Full unsaved draft content for the active workspace file.",
+		"workspace_file_draft.encoding":                     "Normalized draft encoding. V1 supports utf-8 only.",
+		"workspace_file_draft.line_ending":                  "Requested line ending style for the unsaved draft context.",
 	}
 	openAPIProjectConversationTerminalSessionDescriptions = map[string]string{
 		"mode":      "Terminal mode to create. Only shell is currently supported.",
@@ -2608,6 +2657,14 @@ var (
 	openAPIProjectConversationInterruptResponseDescriptions = map[string]string{
 		"decision": "Provider-native interrupt decision identifier such as approve_once.",
 		"answer":   "Structured answer payload for requestUserInput interrupts.",
+	}
+	openAPIProjectConversationWorkspaceFileSaveDescriptions = map[string]string{
+		"repo_path":     "Workspace-relative repo path chosen from the workspace metadata response.",
+		"path":          "Repo-relative existing file path to update inside the conversation workspace.",
+		"base_revision": "Opaque saved-file revision token the client last loaded. Saves reject stale revisions with 409 Conflict.",
+		"content":       "Complete replacement text content for the file save request.",
+		"encoding":      "Normalized text encoding for the save request. V1 supports utf-8 only.",
+		"line_ending":   "Requested line ending style to preserve when writing the file.",
 	}
 	openAPIRoleBindingRequestDescriptions = map[string]string{
 		"subject_kind": "Binding subject kind. Supported values are user and group.",
@@ -2719,6 +2776,7 @@ var (
 		"POST /api/v1/projects/{projectId}/hr-advisor/activate":                                        openAPIHRAdvisorActivateDescriptions,
 		"POST /api/v1/chat":               openAPIChatRequestDescriptions,
 		"POST /api/v1/chat/conversations": openAPIProjectConversationCreateDescriptions,
+		"PUT /api/v1/chat/conversations/{conversationId}/workspace/file":                    openAPIProjectConversationWorkspaceFileSaveDescriptions,
 		"POST /api/v1/chat/conversations/{conversationId}/terminal-sessions":                openAPIProjectConversationTerminalSessionDescriptions,
 		"POST /api/v1/chat/conversations/{conversationId}/turns":                            openAPIProjectConversationTurnDescriptions,
 		"POST /api/v1/chat/conversations/{conversationId}/interrupts/{interruptId}/respond": openAPIProjectConversationInterruptResponseDescriptions,
@@ -6452,6 +6510,25 @@ func (b openAPISpecBuilder) addChatOperations() error {
 		WithSchema(openapi3.NewStringSchema()),
 	)
 	b.doc.AddOperation("/api/v1/chat/conversations/{conversationId}/workspace/file", http.MethodGet, projectConversationWorkspaceFile)
+
+	projectConversationWorkspaceFileSave, err := b.jsonOperation(
+		"saveProjectConversationWorkspaceFile",
+		"Save one project conversation workspace file",
+		[]string{"chat"},
+		http.StatusOK,
+		OpenAPIProjectConversationWorkspaceFileSavedResponse{},
+		OpenAPIProjectConversationWorkspaceFileSaveRequest{},
+		http.StatusBadRequest,
+		http.StatusConflict,
+		http.StatusNotFound,
+		http.StatusServiceUnavailable,
+		http.StatusInternalServerError,
+	)
+	if err != nil {
+		return err
+	}
+	projectConversationWorkspaceFileSave.AddParameter(uuidPathParameter("conversationId", "Stable OpenASE conversation ID."))
+	b.doc.AddOperation("/api/v1/chat/conversations/{conversationId}/workspace/file", http.MethodPut, projectConversationWorkspaceFileSave)
 
 	projectConversationWorkspaceFilePatch, err := b.jsonOperation(
 		"getProjectConversationWorkspaceFilePatch",

--- a/web/src/lib/api/chat.ts
+++ b/web/src/lib/api/chat.ts
@@ -212,6 +212,11 @@ export type ProjectConversationWorkspaceFilePreview = {
   previewKind: ProjectConversationWorkspacePreviewKind
   truncated: boolean
   content: string
+  revision: string
+  writable: boolean
+  readOnlyReason: string
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
 }
 
 export type ProjectConversationWorkspaceDiffKind = 'none' | 'text' | 'binary'
@@ -265,6 +270,25 @@ export type ProjectConversationInterruptResolvedPayload = {
 export type ProjectConversationTurnRequest = {
   message: string
   focus?: ProjectAIFocus | null
+}
+
+export type ProjectConversationWorkspaceFileSaveRequest = {
+  repoPath: string
+  path: string
+  baseRevision: string
+  content: string
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
+}
+
+export type ProjectConversationWorkspaceFileSaved = {
+  conversationId: string
+  repoPath: string
+  path: string
+  revision: string
+  sizeBytes: number
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
 }
 
 export type ProjectConversationTurnDonePayload = {
@@ -534,6 +558,30 @@ export async function getProjectConversationWorkspaceFilePreview(
   }
 }
 
+export async function saveProjectConversationWorkspaceFile(
+  conversationId: string,
+  request: ProjectConversationWorkspaceFileSaveRequest,
+) {
+  const payload = await fetchJSON<{ file?: unknown }>(
+    `/api/v1/chat/conversations/${encodeURIComponent(conversationId)}/workspace/file`,
+    {
+      method: 'PUT',
+      body: {
+        repo_path: request.repoPath,
+        path: request.path,
+        base_revision: request.baseRevision,
+        content: request.content,
+        encoding: request.encoding,
+        line_ending: request.lineEnding,
+      },
+    },
+  )
+  const object = parseRequiredObject(payload as Record<string, unknown>)
+  return {
+    file: parseProjectConversationWorkspaceFileSaved(object.file ?? object),
+  }
+}
+
 export async function getProjectConversationWorkspaceFilePatch(
   conversationId: string,
   request: { repoPath: string; path: string },
@@ -580,6 +628,7 @@ export function startProjectConversationTurn(
   conversationId: string,
   request: ProjectConversationTurnRequest,
 ) {
+  const workspaceFileDraft = serializeProjectConversationWorkspaceFileDraft(request.focus)
   return fetchJSON<{ turn?: Record<string, unknown>; conversation?: RawProjectConversation }>(
     `/api/v1/chat/conversations/${encodeURIComponent(conversationId)}/turns`,
     {
@@ -587,6 +636,7 @@ export function startProjectConversationTurn(
       body: {
         message: request.message,
         focus: serializeProjectConversationFocus(request.focus),
+        workspace_file_draft: workspaceFileDraft,
       },
     },
   ).then((payload) => {
@@ -627,6 +677,15 @@ function serializeProjectConversationFocus(focus: ProjectAIFocus | null | undefi
         skill_name: focus.skillName,
         selected_file_path: focus.selectedFilePath,
         bound_workflow_names: focus.boundWorkflowNames,
+        has_dirty_draft: focus.hasDirtyDraft,
+      }
+    case 'workspace_file':
+      return {
+        kind: focus.kind,
+        conversation_id: focus.conversationId,
+        workspace_repo_path: focus.repoPath,
+        workspace_file_path: focus.filePath,
+        selected_area: focus.selectedArea,
         has_dirty_draft: focus.hasDirtyDraft,
       }
     case 'ticket':
@@ -702,6 +761,24 @@ function serializeProjectConversationFocus(focus: ProjectAIFocus | null | undefi
         selected_area: focus.selectedArea,
         health_summary: focus.healthSummary,
       }
+  }
+}
+
+function serializeProjectConversationWorkspaceFileDraft(focus: ProjectAIFocus | null | undefined) {
+  if (
+    focus?.kind !== 'workspace_file' ||
+    !focus.hasDirtyDraft ||
+    typeof focus.draftContent !== 'string' ||
+    focus.draftContent.length === 0
+  ) {
+    return undefined
+  }
+  return {
+    repo_path: focus.repoPath,
+    path: focus.filePath,
+    content: focus.draftContent,
+    encoding: focus.encoding ?? 'utf-8',
+    line_ending: focus.lineEnding ?? 'lf',
   }
 }
 
@@ -1133,6 +1210,26 @@ function parseProjectConversationWorkspaceFilePreview(
     previewKind,
     truncated: readRequiredBoolean(object, 'truncated'),
     content: readOptionalString(object, 'content') ?? '',
+    revision: readRequiredString(object, 'revision'),
+    writable: readRequiredBoolean(object, 'writable'),
+    readOnlyReason: readOptionalString(object, 'read_only_reason') ?? '',
+    encoding: readRequiredString(object, 'encoding') as 'utf-8',
+    lineEnding: readRequiredString(object, 'line_ending') as 'lf' | 'crlf',
+  }
+}
+
+function parseProjectConversationWorkspaceFileSaved(
+  value: unknown,
+): ProjectConversationWorkspaceFileSaved {
+  const object = parseRequiredObject(value)
+  return {
+    conversationId: readRequiredString(object, 'conversation_id'),
+    repoPath: readRequiredString(object, 'repo_path'),
+    path: readRequiredString(object, 'path'),
+    revision: readRequiredString(object, 'revision'),
+    sizeBytes: readRequiredNumber(object, 'size_bytes'),
+    encoding: readRequiredString(object, 'encoding') as 'utf-8',
+    lineEnding: readRequiredString(object, 'line_ending') as 'lf' | 'crlf',
   }
 }
 
@@ -1550,7 +1647,7 @@ function isDiffLineOp(value: string): value is ChatDiffLineOp {
 async function fetchJSON<T>(
   path: string,
   options?: {
-    method?: 'GET' | 'POST' | 'DELETE'
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
     params?: Record<string, string | undefined>
     body?: unknown
   },
@@ -1574,8 +1671,30 @@ async function fetchJSON<T>(
     credentials: 'same-origin',
   })
   if (!response.ok) {
-    const detail = await response.text().catch(() => response.statusText)
-    throw new ApiError(response.status, detail)
+    let detail = response.statusText
+    let code: string | undefined
+    let details: unknown
+    try {
+      const contentType = response.headers.get('content-type') ?? ''
+      if (contentType.includes('application/json')) {
+        const payload = (await response.json()) as {
+          message?: string
+          detail?: string
+          error?: string
+          code?: string
+          details?: unknown
+        }
+        detail =
+          payload.message || payload.detail || payload.error || payload.code || response.statusText
+        code = payload.code
+        details = payload.details
+      } else {
+        detail = await response.text()
+      }
+    } catch {
+      detail = response.statusText
+    }
+    throw new ApiError(response.status, detail, code, details)
   }
   if (response.status === 204) {
     return undefined as T

--- a/web/src/lib/api/generated/openapi.d.ts
+++ b/web/src/lib/api/generated/openapi.d.ts
@@ -595,7 +595,8 @@ export interface paths {
     }
     /** Read a project conversation workspace file preview */
     get: operations['getProjectConversationWorkspaceFile']
-    put?: never
+    /** Save one project conversation workspace file */
+    put: operations['saveProjectConversationWorkspaceFile']
     post?: never
     delete?: never
     options?: never
@@ -5911,6 +5912,8 @@ export interface operations {
           focus?: {
             /** @description Workflow names currently bound to the focused skill. */
             bound_workflow_names?: string[]
+            /** @description Conversation ID for the focused workspace file surface. */
+            conversation_id?: string | null
             /** @description Harness path for the focused workflow. */
             harness_path?: string | null
             /** @description Whether the focused workflow or skill surface currently has unsaved draft edits. */
@@ -5919,7 +5922,7 @@ export interface operations {
             health_summary?: string | null
             /** @description Whether the focused workflow is currently active. */
             is_active?: boolean | null
-            /** @description Focused surface kind. Supported values are workflow, skill, ticket, and machine. */
+            /** @description Focused surface kind. Supported values are workflow, skill, ticket, machine, and workspace_file. */
             kind?: string
             /** @description Machine host currently in focus. */
             machine_host?: string | null
@@ -6040,9 +6043,26 @@ export interface operations {
             workflow_name?: string | null
             /** @description Workflow type currently in focus. */
             workflow_type?: string | null
+            /** @description Repo-relative file path for the focused workspace file. */
+            workspace_file_path?: string | null
+            /** @description Workspace-relative repo path for the focused workspace file. */
+            workspace_repo_path?: string | null
           } | null
           /** @description User message content appended as the next project conversation turn. */
           message?: string
+          /** @description Optional request-scoped unsaved workspace file draft context for the active turn. */
+          workspace_file_draft?: {
+            /** @description Full unsaved draft content for the active workspace file. */
+            content?: string
+            /** @description Normalized draft encoding. V1 supports utf-8 only. */
+            encoding?: string
+            /** @description Requested line ending style for the unsaved draft context. */
+            line_ending?: string
+            /** @description Repo-relative file path for the unsaved draft. */
+            path?: string
+            /** @description Workspace-relative repo path for the unsaved draft. */
+            repo_path?: string
+          } | null
         }
       }
     }
@@ -6360,13 +6380,130 @@ export interface operations {
             file_preview?: {
               content?: string
               conversation_id?: string
+              encoding?: string
+              line_ending?: string
               media_type?: string
               path?: string
               preview_kind?: string
+              read_only_reason?: string
               repo_path?: string
+              revision?: string
               /** Format: int64 */
               size_bytes?: number
               truncated?: boolean
+              writable?: boolean
+            }
+          }
+        }
+      }
+      /** @description Bad Request response. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Not Found response. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Conflict response. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Internal Server Error response. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Service Unavailable response. */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+    }
+  }
+  saveProjectConversationWorkspaceFile: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Stable OpenASE conversation ID. */
+        conversationId: string
+      }
+      cookie?: never
+    }
+    /** @description Save one project conversation workspace file request body. */
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description Opaque saved-file revision token the client last loaded. Saves reject stale revisions with 409 Conflict. */
+          base_revision?: string
+          /** @description Complete replacement text content for the file save request. */
+          content?: string
+          /** @description Normalized text encoding for the save request. V1 supports utf-8 only. */
+          encoding?: string
+          /** @description Requested line ending style to preserve when writing the file. */
+          line_ending?: string
+          /** @description Repo-relative existing file path to update inside the conversation workspace. */
+          path?: string
+          /** @description Workspace-relative repo path chosen from the workspace metadata response. */
+          repo_path?: string
+        }
+      }
+    }
+    responses: {
+      /** @description Save one project conversation workspace file response. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            file?: {
+              conversation_id?: string
+              encoding?: string
+              line_ending?: string
+              path?: string
+              repo_path?: string
+              revision?: string
+              /** Format: int64 */
+              size_bytes?: number
             }
           }
         }

--- a/web/src/lib/components/code/code-editor.svelte
+++ b/web/src/lib/components/code/code-editor.svelte
@@ -3,16 +3,45 @@
   import { cn } from '$lib/utils'
   import {
     EditorView,
+    GutterMarker,
+    gutter,
     keymap,
     lineNumbers,
     highlightActiveLine,
     placeholder as cmPlaceholder,
   } from '@codemirror/view'
-  import { EditorState, type Extension } from '@codemirror/state'
+  import {
+    Compartment,
+    EditorState,
+    RangeSet,
+    RangeSetBuilder,
+    StateEffect,
+    StateField,
+    type Extension,
+  } from '@codemirror/state'
   import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
-  import { syntaxHighlighting, defaultHighlightStyle, bracketMatching } from '@codemirror/language'
+  import { HighlightStyle, syntaxHighlighting, bracketMatching } from '@codemirror/language'
   import { searchKeymap, highlightSelectionMatches } from '@codemirror/search'
+  import { tags as t } from '@lezer/highlight'
+  import { appStore } from '$lib/stores/app.svelte'
   import { detectLanguage } from './lang'
+
+  type EditorTheme = 'light' | 'dark'
+
+  /** Per-line diff markers passed in by the parent (1-based line numbers). */
+  export type CodeEditorDiffMarkers = {
+    added: number[]
+    modified: number[]
+    deletionAbove: number[]
+    deletionAtEnd: boolean
+  }
+
+  const EMPTY_DIFF_MARKERS: CodeEditorDiffMarkers = {
+    added: [],
+    modified: [],
+    deletionAbove: [],
+    deletionAtEnd: false,
+  }
 
   let {
     value = '',
@@ -21,6 +50,7 @@
     readonly = false,
     placeholder = '',
     class: className = '',
+    diffMarkers = null,
     onchange,
   }: {
     /** Current document content */
@@ -34,6 +64,8 @@
     /** Placeholder text when empty */
     placeholder?: string
     class?: string
+    /** Per-line diff markers rendered in a left gutter. Pass null to hide. */
+    diffMarkers?: CodeEditorDiffMarkers | null
     /** Fires on every edit */
     onchange?: (value: string) => void
   } = $props()
@@ -44,44 +76,234 @@
 
   const lang = $derived(language || detectLanguage(filePath))
 
-  // Build a dark theme that matches the existing harness-editor look
-  const darkTheme = EditorView.theme(
+  // Theme shell (background, gutters, cursor, selection). Mirrors the harness
+  // look used elsewhere, parameterized for light vs. dark.
+  function editorThemeFor(mode: EditorTheme): Extension {
+    const isDark = mode === 'dark'
+    return EditorView.theme(
+      {
+        '&': {
+          backgroundColor: 'transparent',
+          color: isDark ? '#e6edf3' : '#1f2328',
+          fontSize: '13px',
+          height: '100%',
+        },
+        '&.cm-focused': { outline: 'none' },
+        '.cm-scroller': { fontFamily: 'inherit', lineHeight: '1.5rem', overflow: 'auto' },
+        '.cm-gutters': {
+          backgroundColor: 'transparent',
+          borderRight: '1px solid color-mix(in srgb, currentColor 12%, transparent)',
+          color: 'color-mix(in srgb, currentColor 35%, transparent)',
+          minWidth: '3rem',
+        },
+        '.cm-activeLineGutter': {
+          backgroundColor: 'transparent',
+          color: 'color-mix(in srgb, currentColor 60%, transparent)',
+        },
+        '.cm-activeLine': {
+          backgroundColor: 'color-mix(in srgb, currentColor 4%, transparent)',
+        },
+        '.cm-cursor': { borderLeftColor: isDark ? '#e6edf3' : '#1f2328' },
+        '.cm-selectionBackground': {
+          backgroundColor: isDark
+            ? 'rgba(56, 139, 253, 0.25) !important'
+            : 'rgba(9, 105, 218, 0.18) !important',
+        },
+        '.cm-matchingBracket': {
+          backgroundColor: isDark ? 'rgba(56, 139, 253, 0.15)' : 'rgba(9, 105, 218, 0.12)',
+          outline: isDark
+            ? '1px solid rgba(56, 139, 253, 0.4)'
+            : '1px solid rgba(9, 105, 218, 0.35)',
+        },
+        '.cm-placeholder': {
+          color: 'color-mix(in srgb, currentColor 30%, transparent)',
+        },
+      },
+      { dark: isDark },
+    )
+  }
+
+  // Syntax highlight palette matching shiki `github-dark-default`, so the
+  // edit view stays visually consistent with the preview/CodeViewer.
+  const githubDarkHighlight = HighlightStyle.define([
+    { tag: t.keyword, color: '#ff7b72' },
+    { tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName], color: '#d2a8ff' },
+    { tag: [t.function(t.variableName), t.labelName], color: '#d2a8ff' },
+    { tag: [t.color, t.constant(t.name), t.standard(t.name)], color: '#79c0ff' },
+    { tag: [t.definition(t.name), t.separator], color: '#ffa657' },
     {
-      '&': {
-        backgroundColor: 'transparent',
-        color: '#e6edf3',
-        fontSize: '13px',
-        height: '100%',
-      },
-      '&.cm-focused': { outline: 'none' },
-      '.cm-scroller': { fontFamily: 'inherit', lineHeight: '1.5rem', overflow: 'auto' },
-      '.cm-gutters': {
-        backgroundColor: 'transparent',
-        borderRight: '1px solid color-mix(in srgb, currentColor 12%, transparent)',
-        color: 'color-mix(in srgb, currentColor 35%, transparent)',
-        minWidth: '3rem',
-      },
-      '.cm-activeLineGutter': {
-        backgroundColor: 'transparent',
-        color: 'color-mix(in srgb, currentColor 60%, transparent)',
-      },
-      '.cm-activeLine': {
-        backgroundColor: 'color-mix(in srgb, currentColor 4%, transparent)',
-      },
-      '.cm-cursor': { borderLeftColor: '#e6edf3' },
-      '.cm-selectionBackground': {
-        backgroundColor: 'rgba(56, 139, 253, 0.25) !important',
-      },
-      '.cm-matchingBracket': {
-        backgroundColor: 'rgba(56, 139, 253, 0.15)',
-        outline: '1px solid rgba(56, 139, 253, 0.4)',
-      },
-      '.cm-placeholder': {
-        color: 'color-mix(in srgb, currentColor 30%, transparent)',
-      },
+      tag: [
+        t.typeName,
+        t.className,
+        t.number,
+        t.changed,
+        t.annotation,
+        t.modifier,
+        t.self,
+        t.namespace,
+      ],
+      color: '#ffa657',
     },
-    { dark: true },
-  )
+    {
+      tag: [t.operator, t.operatorKeyword, t.url, t.escape, t.regexp, t.special(t.string)],
+      color: '#ff7b72',
+    },
+    { tag: [t.meta, t.comment], color: '#8b949e', fontStyle: 'italic' },
+    { tag: t.strong, fontWeight: 'bold' },
+    { tag: t.emphasis, fontStyle: 'italic' },
+    { tag: t.strikethrough, textDecoration: 'line-through' },
+    { tag: t.link, color: '#a5d6ff', textDecoration: 'underline' },
+    { tag: t.heading, fontWeight: 'bold', color: '#79c0ff' },
+    { tag: [t.atom, t.bool, t.special(t.variableName)], color: '#79c0ff' },
+    { tag: [t.processingInstruction, t.string, t.inserted], color: '#a5d6ff' },
+    { tag: t.invalid, color: '#f85149' },
+  ])
+
+  // Syntax highlight palette matching shiki `github-light-default`.
+  const githubLightHighlight = HighlightStyle.define([
+    { tag: t.keyword, color: '#cf222e' },
+    { tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName], color: '#8250df' },
+    { tag: [t.function(t.variableName), t.labelName], color: '#8250df' },
+    { tag: [t.color, t.constant(t.name), t.standard(t.name)], color: '#0550ae' },
+    { tag: [t.definition(t.name), t.separator], color: '#953800' },
+    {
+      tag: [
+        t.typeName,
+        t.className,
+        t.number,
+        t.changed,
+        t.annotation,
+        t.modifier,
+        t.self,
+        t.namespace,
+      ],
+      color: '#953800',
+    },
+    {
+      tag: [t.operator, t.operatorKeyword, t.url, t.escape, t.regexp, t.special(t.string)],
+      color: '#cf222e',
+    },
+    { tag: [t.meta, t.comment], color: '#6e7781', fontStyle: 'italic' },
+    { tag: t.strong, fontWeight: 'bold' },
+    { tag: t.emphasis, fontStyle: 'italic' },
+    { tag: t.strikethrough, textDecoration: 'line-through' },
+    { tag: t.link, color: '#0a3069', textDecoration: 'underline' },
+    { tag: t.heading, fontWeight: 'bold', color: '#0550ae' },
+    { tag: [t.atom, t.bool, t.special(t.variableName)], color: '#0550ae' },
+    { tag: [t.processingInstruction, t.string, t.inserted], color: '#0a3069' },
+    { tag: t.invalid, color: '#82071e' },
+  ])
+
+  const themeCompartment = new Compartment()
+
+  function buildThemeExtensions(mode: EditorTheme): Extension[] {
+    return [
+      editorThemeFor(mode),
+      syntaxHighlighting(mode === 'dark' ? githubDarkHighlight : githubLightHighlight, {
+        fallback: true,
+      }),
+    ]
+  }
+
+  // ──────────────────────────── diff gutter ────────────────────────────
+  // A 4 px-wide column placed to the left of the line numbers. Each line that
+  // changed against the saved version gets a colored bar (green = added,
+  // amber = modified). Lines below a deletion gap get a small red triangle at
+  // the top edge; deletions past the end of the document put the triangle on
+  // the bottom edge of the last line.
+
+  type DiffMarkerInfo = {
+    kind?: 'added' | 'modified'
+    deletionAbove?: boolean
+    deletionBelow?: boolean
+  }
+
+  class DiffGutterMarker extends GutterMarker {
+    info: DiffMarkerInfo
+    constructor(info: DiffMarkerInfo) {
+      super()
+      this.info = info
+    }
+    eq(other: GutterMarker): boolean {
+      if (!(other instanceof DiffGutterMarker)) return false
+      return (
+        other.info.kind === this.info.kind &&
+        Boolean(other.info.deletionAbove) === Boolean(this.info.deletionAbove) &&
+        Boolean(other.info.deletionBelow) === Boolean(this.info.deletionBelow)
+      )
+    }
+    toDOM() {
+      const el = document.createElement('div')
+      el.className = 'cm-diff-marker'
+      if (this.info.kind) {
+        el.dataset.kind = this.info.kind
+      }
+      if (this.info.deletionAbove) {
+        el.dataset.deletionAbove = 'true'
+      }
+      if (this.info.deletionBelow) {
+        el.dataset.deletionBelow = 'true'
+      }
+      return el
+    }
+  }
+
+  const setDiffMarkersEffect = StateEffect.define<CodeEditorDiffMarkers>()
+
+  function buildDiffMarkerSet(
+    state: EditorState,
+    markers: CodeEditorDiffMarkers,
+  ): RangeSet<DiffGutterMarker> {
+    const totalLines = state.doc.lines
+    const byLine = new Map<number, DiffMarkerInfo>()
+    const stamp = (line: number, patch: DiffMarkerInfo) => {
+      if (line < 1 || line > totalLines) return
+      const existing = byLine.get(line) ?? {}
+      byLine.set(line, { ...existing, ...patch })
+    }
+    for (const line of markers.added) stamp(line, { kind: 'added' })
+    for (const line of markers.modified) stamp(line, { kind: 'modified' })
+    for (const line of markers.deletionAbove) stamp(line, { deletionAbove: true })
+    if (markers.deletionAtEnd && totalLines > 0) {
+      stamp(totalLines, { deletionBelow: true })
+    }
+
+    const builder = new RangeSetBuilder<DiffGutterMarker>()
+    const sorted = [...byLine.keys()].sort((a, b) => a - b)
+    for (const lineNum of sorted) {
+      const lineObj = state.doc.line(lineNum)
+      const info = byLine.get(lineNum)
+      if (!info) continue
+      builder.add(lineObj.from, lineObj.from, new DiffGutterMarker(info))
+    }
+    return builder.finish()
+  }
+
+  const diffMarkersField = StateField.define<RangeSet<DiffGutterMarker>>({
+    create() {
+      // Real markers are seeded by the parent via setDiffMarkersEffect right
+      // after the view is mounted, so an empty initial value is fine.
+      return RangeSet.empty
+    },
+    update(value, tr) {
+      let next = value.map(tr.changes)
+      for (const effect of tr.effects) {
+        if (effect.is(setDiffMarkersEffect)) {
+          next = buildDiffMarkerSet(tr.state, effect.value)
+        }
+      }
+      return next
+    },
+  })
+
+  const diffGutterExtension: Extension = [
+    diffMarkersField,
+    gutter({
+      class: 'cm-diff-gutter',
+      markers: (v) => v.state.field(diffMarkersField),
+      initialSpacer: () => new DiffGutterMarker({}),
+    }),
+  ]
 
   async function loadLanguageExtension(langId: string): Promise<Extension[]> {
     try {
@@ -135,13 +357,13 @@
 
   function buildBaseExtensions(): Extension[] {
     const exts: Extension[] = [
+      diffGutterExtension,
       lineNumbers(),
       history(),
       bracketMatching(),
       highlightActiveLine(),
       highlightSelectionMatches(),
-      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-      darkTheme,
+      themeCompartment.of(buildThemeExtensions(appStore.theme)),
       keymap.of([...defaultKeymap, ...historyKeymap, ...searchKeymap, indentWithTab]),
       EditorView.lineWrapping,
     ]
@@ -168,6 +390,8 @@
   }
 
   async function createEditor() {
+    const currentTheme = appStore.theme
+    const currentDiffMarkers = diffMarkers ?? EMPTY_DIFF_MARKERS
     const langExts = await loadLanguageExtension(lang)
     view = new EditorView({
       state: EditorState.create({
@@ -176,7 +400,16 @@
       }),
       parent: container,
     })
+    lastTheme = currentTheme
+    // Seed the diff gutter with whatever the parent passed at mount time. We
+    // dispatch instead of using StateField.init() so the same code path runs
+    // for both initial creation and later prop changes.
+    view.dispatch({ effects: setDiffMarkersEffect.of(currentDiffMarkers) })
+    lastDiffMarkers = currentDiffMarkers
   }
+
+  let lastTheme: EditorTheme | '' = ''
+  let lastDiffMarkers: CodeEditorDiffMarkers | null = null
 
   onMount(() => {
     void createEditor()
@@ -196,6 +429,27 @@
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: nextValue },
     })
+  })
+
+  // Swap theme + highlight extensions when the app theme toggles, without
+  // destroying the editor state.
+  $effect(() => {
+    const nextTheme = appStore.theme
+    if (!view || nextTheme === lastTheme) return
+    lastTheme = nextTheme
+    view.dispatch({
+      effects: themeCompartment.reconfigure(buildThemeExtensions(nextTheme)),
+    })
+  })
+
+  // Push new diff marker payloads into the editor as they come from the parent.
+  // We compare by reference: callers should produce a fresh object on every
+  // change so this effect re-runs.
+  $effect(() => {
+    const nextMarkers = diffMarkers ?? EMPTY_DIFF_MARKERS
+    if (!view || nextMarkers === lastDiffMarkers) return
+    lastDiffMarkers = nextMarkers
+    view.dispatch({ effects: setDiffMarkersEffect.of(nextMarkers) })
   })
 
   // Recreate editor when language changes
@@ -220,5 +474,56 @@
 <style>
   .code-editor :global(.cm-editor) {
     height: 100%;
+  }
+
+  /* ── diff gutter ─────────────────────────────────────────────── */
+  .code-editor :global(.cm-gutter.cm-diff-gutter) {
+    width: 6px;
+    min-width: 6px;
+    padding: 0;
+    background: transparent;
+    border-right: none;
+    overflow: visible;
+  }
+  .code-editor :global(.cm-diff-gutter .cm-gutterElement) {
+    padding: 0;
+    overflow: visible;
+  }
+  .code-editor :global(.cm-diff-marker) {
+    position: relative;
+    width: 6px;
+    height: 100%;
+  }
+  .code-editor :global(.cm-diff-marker[data-kind='added']) {
+    background-color: #2da44e;
+  }
+  .code-editor :global(.cm-diff-marker[data-kind='modified']) {
+    background-color: #d4a72c;
+  }
+  /* Red right-pointing triangle straddling the top edge of the line. */
+  .code-editor :global(.cm-diff-marker[data-deletion-above='true'])::before {
+    content: '';
+    position: absolute;
+    top: -3px;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    border-left: 6px solid #cf222e;
+    pointer-events: none;
+  }
+  /* Same triangle on the bottom edge for end-of-file deletions. */
+  .code-editor :global(.cm-diff-marker[data-deletion-below='true'])::after {
+    content: '';
+    position: absolute;
+    bottom: -3px;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    border-left: 6px solid #cf222e;
+    pointer-events: none;
   }
 </style>

--- a/web/src/lib/features/app-shell/components/project-shell-frame.svelte
+++ b/web/src/lib/features/app-shell/components/project-shell-frame.svelte
@@ -194,6 +194,7 @@
             conversationId={workspaceBrowserPortal.conversationId}
             workspaceDiff={workspaceBrowserPortal.workspaceDiff}
             workspaceDiffLoading={workspaceBrowserPortal.workspaceDiffLoading}
+            runtimeActive={workspaceBrowserPortal.runtimeActive}
             pendingFilePath={workspaceBrowserPortal.pendingFilePath}
             onClose={() => workspaceBrowserPortal.close()}
             onPendingFileConsumed={() => workspaceBrowserPortal.consumePendingFile()}

--- a/web/src/lib/features/chat/project-ai-focus.ts
+++ b/web/src/lib/features/chat/project-ai-focus.ts
@@ -88,6 +88,18 @@ export type ProjectAIFocus =
       selectedArea?: string
       healthSummary?: string
     }
+  | {
+      kind: 'workspace_file'
+      projectId: string
+      conversationId: string
+      repoPath: string
+      filePath: string
+      selectedArea?: string
+      hasDirtyDraft?: boolean
+      draftContent?: string
+      encoding?: 'utf-8'
+      lineEnding?: 'lf' | 'crlf'
+    }
 
 export type ProjectAIFocusCard = {
   label: string
@@ -126,6 +138,16 @@ export function projectAIFocusKey(focus: ProjectAIFocus | null | undefined): str
       return [focus.kind, focus.projectId, focus.ticketId, focus.selectedArea ?? ''].join(':')
     case 'machine':
       return [focus.kind, focus.projectId, focus.machineId, focus.selectedArea ?? ''].join(':')
+    case 'workspace_file':
+      return [
+        focus.kind,
+        focus.projectId,
+        focus.conversationId,
+        focus.repoPath,
+        focus.filePath,
+        focus.selectedArea ?? '',
+        focus.hasDirtyDraft ? 'dirty' : 'clean',
+      ].join(':')
   }
 }
 
@@ -171,6 +193,14 @@ export function describeProjectAIFocus(focus: ProjectAIFocus): ProjectAIFocusCar
         label: 'Machine',
         title: `${focus.machineName} / ${focus.selectedArea ?? 'health'}`,
         detail: [focus.machineHost, focus.machineStatus, focus.healthSummary]
+          .filter(Boolean)
+          .join(' · '),
+      }
+    case 'workspace_file':
+      return {
+        label: 'Workspace file',
+        title: `${focus.repoPath} / ${focus.filePath}`,
+        detail: [focus.selectedArea ?? 'preview', focus.hasDirtyDraft ? 'unsaved draft' : 'saved']
           .filter(Boolean)
           .join(' · '),
       }

--- a/web/src/lib/features/chat/project-ai-focus.ts
+++ b/web/src/lib/features/chat/project-ai-focus.ts
@@ -200,7 +200,7 @@ export function describeProjectAIFocus(focus: ProjectAIFocus): ProjectAIFocusCar
       return {
         label: 'Workspace file',
         title: `${focus.repoPath} / ${focus.filePath}`,
-        detail: [focus.selectedArea ?? 'preview', focus.hasDirtyDraft ? 'unsaved draft' : 'saved']
+        detail: [focus.selectedArea ?? 'edit', focus.hasDirtyDraft ? 'unsaved draft' : 'saved']
           .filter(Boolean)
           .join(' · '),
       }

--- a/web/src/lib/features/chat/project-conversation-content.svelte
+++ b/web/src/lib/features/chat/project-conversation-content.svelte
@@ -49,6 +49,7 @@
     workspaceBrowserPortal.conversationId = conversationId
     workspaceBrowserPortal.workspaceDiff = workspaceDiff ?? null
     workspaceBrowserPortal.workspaceDiffLoading = workspaceDiffLoading
+    workspaceBrowserPortal.runtimeActive = pending
   })
 
   $effect(() => {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
@@ -1,80 +1,107 @@
 <script lang="ts">
   import { cn } from '$lib/utils'
   import { Button } from '$ui/button'
-  import { CodeEditor, CodeViewer, DiffViewer } from '$lib/components/code'
-  import { FileCode2 } from '@lucide/svelte'
-  import type {
-    ProjectConversationWorkspaceFilePatch,
-    ProjectConversationWorkspaceFilePreview,
-    ProjectConversationWorkspaceRepoMetadata,
-  } from '$lib/api/chat'
-  import type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state.svelte'
+  import * as Dialog from '$ui/dialog'
+  import { CodeEditor } from '$lib/components/code'
+  import { FileCode2, X } from '@lucide/svelte'
+  import type { ProjectConversationWorkspaceRepoMetadata } from '$lib/api/chat'
   import {
-    type WorkspaceFileViewMode,
-    workspaceFileReadOnlyMessage,
-  } from './project-conversation-workspace-file-drafts'
+    workspaceTabKey,
+    type ProjectConversationWorkspaceBrowserState,
+  } from './project-conversation-workspace-browser-state.svelte'
+  import { workspaceFileReadOnlyMessage } from './project-conversation-workspace-file-drafts'
 
   let {
+    browser,
     selectedRepo = null,
-    selectedFilePath = '',
-    preview = null,
-    patch = null,
-    editorState = null,
-    draftDiff = '',
-    fileLoading = false,
-    fileError = '',
     runtimeActive = false,
-    onViewModeChange,
-    onDraftChange,
-    onSave,
-    onRevert,
-    onKeepDraft,
-    onReloadSavedVersion,
   }: {
+    browser: ProjectConversationWorkspaceBrowserState
     selectedRepo?: ProjectConversationWorkspaceRepoMetadata | null
-    selectedFilePath?: string
-    preview?: ProjectConversationWorkspaceFilePreview | null
-    patch?: ProjectConversationWorkspaceFilePatch | null
-    editorState?: WorkspaceFileEditorState | null
-    draftDiff?: string
-    fileLoading?: boolean
-    fileError?: string
     runtimeActive?: boolean
-    onViewModeChange?: (viewMode: WorkspaceFileViewMode) => void
-    onDraftChange?: (value: string) => void
-    onSave?: () => void
-    onRevert?: () => void
-    onKeepDraft?: () => void
-    onReloadSavedVersion?: () => void
   } = $props()
 
-  const fileName = $derived(selectedFilePath.split('/').pop() ?? '')
-  const fileDirPath = $derived.by(() => {
-    const parts = selectedFilePath.split('/')
+  // ─── close-confirm dialog state ─────────────────────────────────────
+  // When the user closes a dirty tab we stash it here and pop the dialog;
+  // pickling these on the parent's state would couple too much, so they live
+  // locally and the dialog drives all three outcomes (Save / Don't Save /
+  // Cancel) through this single in-flight handle.
+
+  let pendingClose = $state<{ repoPath: string; filePath: string } | null>(null)
+  let saving = $state(false)
+  const dialogOpen = $derived(pendingClose !== null)
+
+  function isTabDirty(repoPath: string, filePath: string): boolean {
+    return browser.getEditorState(repoPath, filePath)?.dirty === true
+  }
+
+  function requestCloseTab(event: MouseEvent, repoPath: string, filePath: string) {
+    event.stopPropagation()
+    if (isTabDirty(repoPath, filePath)) {
+      pendingClose = { repoPath, filePath }
+      return
+    }
+    browser.discardDraft(repoPath, filePath)
+    browser.closeTab(repoPath, filePath)
+  }
+
+  function dismissDialog() {
+    pendingClose = null
+  }
+
+  async function confirmSaveAndClose() {
+    if (!pendingClose) return
+    const target = pendingClose
+    saving = true
+    try {
+      // Activate so the editor store thinks of this file as "selected" and
+      // also so any conflict UI surfaces on the tab the user is closing.
+      browser.activateTab(target.repoPath, target.filePath)
+      const ok = await browser.saveFile(target.repoPath, target.filePath)
+      if (ok) {
+        browser.closeTab(target.repoPath, target.filePath)
+        pendingClose = null
+      }
+      // On failure, leave the dialog open and the conflict banner will guide
+      // the user. They can hit Cancel to back out.
+    } finally {
+      saving = false
+    }
+  }
+
+  function confirmDiscardAndClose() {
+    if (!pendingClose) return
+    const target = pendingClose
+    browser.discardDraft(target.repoPath, target.filePath)
+    browser.closeTab(target.repoPath, target.filePath)
+    pendingClose = null
+  }
+
+  function pendingCloseFilename(): string {
+    return pendingClose?.filePath.split('/').pop() ?? ''
+  }
+
+  // ─── active tab projections ────────────────────────────────────────────────
+  const activeFilePath = $derived(
+    browser.openTabs.find((t) => workspaceTabKey(t) === browser.activeTabKey)?.filePath ?? '',
+  )
+  const activeFileName = $derived(activeFilePath.split('/').pop() ?? '')
+  const activeFileDirPath = $derived.by(() => {
+    const parts = activeFilePath.split('/')
     return parts.length > 1 ? parts.slice(0, -1).join('/') : ''
   })
-  const viewMode = $derived(editorState?.viewMode ?? 'preview')
+  const activePreview = $derived(browser.preview)
+  const activePatch = $derived(browser.patch)
+  const activeFileLoading = $derived(browser.fileLoading)
+  const activeFileError = $derived(browser.fileError)
+  const activeEditorState = $derived(browser.selectedEditorState)
+  const activeDiffMarkers = $derived(browser.selectedDraftLineDiff)
+
   const readOnlyMessage = $derived(
-    preview?.writable === false ? workspaceFileReadOnlyMessage(preview.readOnlyReason) : '',
+    activePreview?.writable === false
+      ? workspaceFileReadOnlyMessage(activePreview.readOnlyReason)
+      : '',
   )
-  const fileState = $derived.by(() => {
-    if (!editorState) {
-      return { label: 'Saved', className: 'bg-emerald-500/10 text-emerald-700' }
-    }
-    if (editorState.savePhase === 'saving') {
-      return { label: 'Saving...', className: 'bg-sky-500/10 text-sky-700' }
-    }
-    if (editorState.savePhase === 'conflict') {
-      return { label: 'Conflict', className: 'bg-amber-500/15 text-amber-700' }
-    }
-    if (editorState.externalChange) {
-      return { label: 'Changed in workspace', className: 'bg-amber-500/15 text-amber-700' }
-    }
-    if (editorState.dirty) {
-      return { label: 'Unsaved', className: 'bg-orange-500/15 text-orange-700' }
-    }
-    return { label: 'Saved', className: 'bg-emerald-500/10 text-emerald-700' }
-  })
 </script>
 
 <div class="flex h-full min-h-0 flex-col overflow-hidden">
@@ -84,7 +111,7 @@
     >
       Select a repo to browse its files.
     </div>
-  {:else if !selectedFilePath}
+  {:else if browser.openTabs.length === 0}
     <div
       class="text-muted-foreground flex flex-1 items-center justify-center px-6 text-center text-sm"
     >
@@ -93,162 +120,189 @@
         <p>Select a file to view its contents</p>
       </div>
     </div>
-  {:else if fileError}
-    <div class="border-destructive/20 bg-destructive/5 m-4 rounded-lg border p-3">
-      <p class="text-destructive text-sm">{fileError}</p>
-    </div>
   {:else}
-    <div class="border-border bg-muted/30 flex flex-wrap items-center gap-2 border-b px-3 py-2">
-      <FileCode2 class="text-muted-foreground size-3.5 shrink-0" />
-      <span class="min-w-0 truncate text-[13px] font-medium">{fileName}</span>
-      {#if fileDirPath}
-        <span class="text-muted-foreground/40 min-w-0 truncate text-[11px]">{fileDirPath}</span>
-      {/if}
-      <span class={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold', fileState.className)}>
-        {fileState.label}
-      </span>
-      {#if patch?.status && patch.status !== 'modified'}
-        <span
+    <!-- Tab bar -->
+    <div
+      class="border-border bg-muted/20 flex min-h-9 shrink-0 items-stretch overflow-x-auto border-b"
+      data-testid="workspace-browser-detail-tab-bar"
+      role="tablist"
+    >
+      {#each browser.openTabs as tab (workspaceTabKey(tab))}
+        {@const tabKey = workspaceTabKey(tab)}
+        {@const isActive = tabKey === browser.activeTabKey}
+        {@const dirty = isTabDirty(tab.repoPath, tab.filePath)}
+        {@const tabName = tab.filePath.split('/').pop() ?? tab.filePath}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={isActive}
           class={cn(
-            'rounded px-1 text-[10px] font-bold uppercase',
-            patch.status === 'added'
-              ? 'bg-emerald-500/15 text-emerald-600'
-              : patch.status === 'deleted'
-                ? 'bg-rose-500/15 text-rose-600'
-                : 'bg-sky-500/15 text-sky-600',
+            'border-border flex max-w-[220px] min-w-0 shrink-0 items-center gap-1.5 border-r px-2.5 py-1.5 text-[12px] transition-colors',
+            isActive
+              ? 'bg-background text-foreground'
+              : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
           )}
+          onclick={() => browser.activateTab(tab.repoPath, tab.filePath)}
+          data-testid={`workspace-browser-detail-tab-${tabName}`}
         >
-          {patch.status}
-        </span>
-      {/if}
-      <div class="ml-auto flex flex-wrap items-center gap-1">
-        <Button
-          size="sm"
-          variant={viewMode === 'preview' ? 'secondary' : 'ghost'}
-          onclick={() => onViewModeChange?.('preview')}
-        >
-          Preview
-        </Button>
-        <Button
-          size="sm"
-          variant={viewMode === 'edit' ? 'secondary' : 'ghost'}
-          disabled={!preview || preview.previewKind !== 'text' || !preview.writable}
-          onclick={() => onViewModeChange?.('edit')}
-        >
-          Edit
-        </Button>
-        <Button
-          size="sm"
-          variant={viewMode === 'diff' ? 'secondary' : 'ghost'}
-          disabled={!editorState || draftDiff.length === 0}
-          onclick={() => onViewModeChange?.('diff')}
-        >
-          Diff
-        </Button>
-        <Button
-          size="sm"
-          disabled={!editorState?.dirty || !preview?.writable || editorState.savePhase === 'saving'}
-          onclick={() => onSave?.()}
-        >
-          Save
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={!editorState?.dirty && !editorState?.externalChange}
-          onclick={() => onRevert?.()}
-        >
-          Revert
-        </Button>
-      </div>
-      {#if preview}
-        <span class="text-muted-foreground/50 text-[10px]">
-          {preview.mediaType} · {preview.sizeBytes} B
-        </span>
-      {/if}
-      {#if fileLoading}
-        <span class="text-muted-foreground/50 text-[10px]">Loading…</span>
-      {/if}
+          <FileCode2 class="size-3 shrink-0 opacity-60" />
+          <span class="min-w-0 truncate">{tabName}</span>
+          <span
+            role="button"
+            tabindex="0"
+            class="hover:bg-muted/80 ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors"
+            aria-label={`Close ${tabName}`}
+            onclick={(event) => requestCloseTab(event, tab.repoPath, tab.filePath)}
+            onkeydown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                event.stopPropagation()
+                requestCloseTab(event as unknown as MouseEvent, tab.repoPath, tab.filePath)
+              }
+            }}
+          >
+            {#if dirty}
+              <span
+                class="size-1.5 rounded-full bg-orange-500"
+                aria-label="Unsaved changes"
+                data-testid="workspace-browser-detail-tab-dirty-dot"
+              ></span>
+            {:else}
+              <X class="size-3" />
+            {/if}
+          </span>
+        </button>
+      {/each}
     </div>
 
-    {#if runtimeActive}
-      <div class="bg-muted/40 text-muted-foreground border-border border-b px-3 py-1.5 text-[11px]">
-        Project AI can keep updating this workspace during active turns. Your local draft stays
-        preserved.
+    {#if activeFileError}
+      <div class="border-destructive/20 bg-destructive/5 m-4 rounded-lg border p-3">
+        <p class="text-destructive text-sm">{activeFileError}</p>
       </div>
-    {/if}
-
-    {#if readOnlyMessage}
-      <div class="border-border bg-muted/40 px-3 py-2 text-sm">{readOnlyMessage}</div>
-    {/if}
-
-    {#if editorState?.externalChange || editorState?.savePhase === 'conflict'}
-      <div
-        class="flex flex-wrap items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm"
-      >
-        <span class="text-amber-900">
-          {editorState.errorMessage ||
-            'This file changed in the workspace while your draft was open.'}
-        </span>
-        <Button size="sm" variant="ghost" onclick={() => onViewModeChange?.('diff')}>
-          Review changes
-        </Button>
-        <Button size="sm" variant="ghost" onclick={() => onReloadSavedVersion?.()}>
-          Reload saved version
-        </Button>
-        <Button size="sm" variant="ghost" onclick={() => onKeepDraft?.()}>Keep my draft</Button>
+    {:else if browser.activeTabKey}
+      <!-- Header strip with file path + size -->
+      <div class="border-border bg-muted/30 flex flex-wrap items-center gap-2 border-b px-3 py-1.5">
+        <FileCode2 class="text-muted-foreground size-3 shrink-0" />
+        <span class="min-w-0 truncate text-[12px] font-medium">{activeFileName}</span>
+        {#if activeFileDirPath}
+          <span class="text-muted-foreground/40 min-w-0 truncate text-[11px]">
+            {activeFileDirPath}
+          </span>
+        {/if}
+        {#if activePatch?.status && activePatch.status !== 'modified'}
+          <span
+            class={cn(
+              'rounded px-1 text-[10px] font-bold uppercase',
+              activePatch.status === 'added'
+                ? 'bg-emerald-500/15 text-emerald-600'
+                : activePatch.status === 'deleted'
+                  ? 'bg-rose-500/15 text-rose-600'
+                  : 'bg-sky-500/15 text-sky-600',
+            )}
+          >
+            {activePatch.status}
+          </span>
+        {/if}
+        <div class="ml-auto flex items-center gap-2">
+          {#if activePreview}
+            <span class="text-muted-foreground/50 text-[10px]">
+              {activePreview.mediaType} · {activePreview.sizeBytes} B
+            </span>
+          {/if}
+          {#if activeFileLoading}
+            <span class="text-muted-foreground/50 text-[10px]">Loading…</span>
+          {/if}
+        </div>
       </div>
-    {:else if editorState?.errorMessage}
-      <div class="border-destructive/20 bg-destructive/5 border-b px-3 py-2 text-sm">
-        <span class="text-destructive">{editorState.errorMessage}</span>
-      </div>
-    {/if}
 
-    <div class="min-h-0 flex-1 overflow-hidden" data-testid="workspace-browser-detail-content">
-      {#if preview?.previewKind === 'binary'}
-        <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
-          <div class="mx-auto max-w-md">Binary file — not rendered inline.</div>
-        </div>
-      {:else if viewMode === 'edit' && editorState}
+      {#if runtimeActive}
         <div
-          class="h-full min-h-0 min-w-0 overflow-hidden"
-          data-testid="workspace-browser-detail-scroll-frame"
+          class="bg-muted/40 text-muted-foreground border-border border-b px-3 py-1.5 text-[11px]"
         >
-          <CodeEditor
-            value={editorState.draftContent}
-            filePath={selectedFilePath}
-            readonly={!preview?.writable}
-            class="h-full"
-            onchange={(value) => onDraftChange?.(value)}
-          />
-        </div>
-      {:else if viewMode === 'diff' && editorState}
-        <div
-          class="h-full min-h-0 min-w-0 overflow-hidden"
-          data-testid="workspace-browser-detail-scroll-frame"
-        >
-          <DiffViewer
-            diff={draftDiff}
-            sourceContent={editorState.latestSavedContent}
-            class="h-full"
-          />
-        </div>
-      {:else if preview}
-        <div
-          class="h-full min-h-0 min-w-0 overflow-hidden"
-          data-testid="workspace-browser-detail-scroll-frame"
-        >
-          <CodeViewer code={preview.content ?? ''} filePath={selectedFilePath} class="h-full" />
-        </div>
-      {:else if fileLoading}
-        <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
-          Loading…
-        </div>
-      {:else}
-        <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
-          Select a file to view its contents.
+          Project AI can keep updating this workspace during active turns. Your local draft stays
+          preserved.
         </div>
       {/if}
-    </div>
+
+      {#if readOnlyMessage}
+        <div class="border-border bg-muted/40 px-3 py-2 text-sm">{readOnlyMessage}</div>
+      {/if}
+
+      {#if activeEditorState?.externalChange || activeEditorState?.savePhase === 'conflict'}
+        <div
+          class="flex flex-wrap items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm"
+        >
+          <span class="text-amber-900">
+            {activeEditorState.errorMessage ||
+              'This file changed in the workspace while your draft was open.'}
+          </span>
+          <Button size="sm" variant="ghost" onclick={() => browser.reloadSelectedSavedVersion()}>
+            Reload saved version
+          </Button>
+          <Button size="sm" variant="ghost" onclick={() => browser.keepSelectedDraft()}>
+            Keep my draft
+          </Button>
+        </div>
+      {:else if activeEditorState?.errorMessage}
+        <div class="border-destructive/20 bg-destructive/5 border-b px-3 py-2 text-sm">
+          <span class="text-destructive">{activeEditorState.errorMessage}</span>
+        </div>
+      {/if}
+
+      <div class="min-h-0 flex-1 overflow-hidden" data-testid="workspace-browser-detail-content">
+        {#if activePreview?.previewKind === 'binary'}
+          <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
+            <div class="mx-auto max-w-md">Binary file — not rendered inline.</div>
+          </div>
+        {:else if activeEditorState && activePreview}
+          <div
+            class="h-full min-h-0 min-w-0 overflow-hidden"
+            data-testid="workspace-browser-detail-scroll-frame"
+          >
+            <CodeEditor
+              value={activeEditorState.draftContent}
+              filePath={activeFilePath}
+              readonly={!activePreview.writable}
+              diffMarkers={activeDiffMarkers}
+              class="h-full"
+              onchange={(value) => browser.updateSelectedDraft(value)}
+            />
+          </div>
+        {:else if activeFileLoading}
+          <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
+            Loading…
+          </div>
+        {:else}
+          <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
+            Select a file to view its contents.
+          </div>
+        {/if}
+      </div>
+    {/if}
   {/if}
 </div>
+
+<Dialog.Root
+  open={dialogOpen}
+  onOpenChange={(next) => {
+    if (!next) dismissDialog()
+  }}
+>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>Save changes?</Dialog.Title>
+      <Dialog.Description>
+        {pendingCloseFilename()} has unsaved changes. Save them before closing the tab?
+      </Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Button variant="ghost" onclick={dismissDialog} disabled={saving}>Cancel</Button>
+      <Button variant="ghost" onclick={confirmDiscardAndClose} disabled={saving}>
+        Don&apos;t save
+      </Button>
+      <Button onclick={confirmSaveAndClose} disabled={saving}>
+        {saving ? 'Saving…' : 'Save'}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
@@ -1,35 +1,80 @@
 <script lang="ts">
   import { cn } from '$lib/utils'
+  import { Button } from '$ui/button'
+  import { CodeEditor, CodeViewer, DiffViewer } from '$lib/components/code'
   import { FileCode2 } from '@lucide/svelte'
-  import { CodeViewer, DiffViewer } from '$lib/components/code'
   import type {
     ProjectConversationWorkspaceFilePatch,
     ProjectConversationWorkspaceFilePreview,
     ProjectConversationWorkspaceRepoMetadata,
   } from '$lib/api/chat'
+  import type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state.svelte'
+  import {
+    type WorkspaceFileViewMode,
+    workspaceFileReadOnlyMessage,
+  } from './project-conversation-workspace-file-drafts'
 
   let {
     selectedRepo = null,
     selectedFilePath = '',
     preview = null,
     patch = null,
+    editorState = null,
+    draftDiff = '',
     fileLoading = false,
     fileError = '',
+    runtimeActive = false,
+    onViewModeChange,
+    onDraftChange,
+    onSave,
+    onRevert,
+    onKeepDraft,
+    onReloadSavedVersion,
   }: {
     selectedRepo?: ProjectConversationWorkspaceRepoMetadata | null
     selectedFilePath?: string
     preview?: ProjectConversationWorkspaceFilePreview | null
     patch?: ProjectConversationWorkspaceFilePatch | null
+    editorState?: WorkspaceFileEditorState | null
+    draftDiff?: string
     fileLoading?: boolean
     fileError?: string
+    runtimeActive?: boolean
+    onViewModeChange?: (viewMode: WorkspaceFileViewMode) => void
+    onDraftChange?: (value: string) => void
+    onSave?: () => void
+    onRevert?: () => void
+    onKeepDraft?: () => void
+    onReloadSavedVersion?: () => void
   } = $props()
 
   const fileName = $derived(selectedFilePath.split('/').pop() ?? '')
-  const fileDirPath = $derived(() => {
+  const fileDirPath = $derived.by(() => {
     const parts = selectedFilePath.split('/')
     return parts.length > 1 ? parts.slice(0, -1).join('/') : ''
   })
-  const hasDiff = $derived(patch?.diffKind === 'text' && !!patch.diff)
+  const viewMode = $derived(editorState?.viewMode ?? 'preview')
+  const readOnlyMessage = $derived(
+    preview?.writable === false ? workspaceFileReadOnlyMessage(preview.readOnlyReason) : '',
+  )
+  const fileState = $derived.by(() => {
+    if (!editorState) {
+      return { label: 'Saved', className: 'bg-emerald-500/10 text-emerald-700' }
+    }
+    if (editorState.savePhase === 'saving') {
+      return { label: 'Saving...', className: 'bg-sky-500/10 text-sky-700' }
+    }
+    if (editorState.savePhase === 'conflict') {
+      return { label: 'Conflict', className: 'bg-amber-500/15 text-amber-700' }
+    }
+    if (editorState.externalChange) {
+      return { label: 'Changed in workspace', className: 'bg-amber-500/15 text-amber-700' }
+    }
+    if (editorState.dirty) {
+      return { label: 'Unsaved', className: 'bg-orange-500/15 text-orange-700' }
+    }
+    return { label: 'Saved', className: 'bg-emerald-500/10 text-emerald-700' }
+  })
 </script>
 
 <div class="flex h-full min-h-0 flex-col overflow-hidden">
@@ -53,13 +98,15 @@
       <p class="text-destructive text-sm">{fileError}</p>
     </div>
   {:else}
-    <!-- File tab bar -->
-    <div class="border-border bg-muted/30 flex items-center gap-2 border-b px-3 py-1.5">
+    <div class="border-border bg-muted/30 flex flex-wrap items-center gap-2 border-b px-3 py-2">
       <FileCode2 class="text-muted-foreground size-3.5 shrink-0" />
       <span class="min-w-0 truncate text-[13px] font-medium">{fileName}</span>
-      {#if fileDirPath()}
-        <span class="text-muted-foreground/40 min-w-0 truncate text-[11px]">{fileDirPath()}</span>
+      {#if fileDirPath}
+        <span class="text-muted-foreground/40 min-w-0 truncate text-[11px]">{fileDirPath}</span>
       {/if}
+      <span class={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold', fileState.className)}>
+        {fileState.label}
+      </span>
       {#if patch?.status && patch.status !== 'modified'}
         <span
           class={cn(
@@ -74,8 +121,48 @@
           {patch.status}
         </span>
       {/if}
+      <div class="ml-auto flex flex-wrap items-center gap-1">
+        <Button
+          size="sm"
+          variant={viewMode === 'preview' ? 'secondary' : 'ghost'}
+          onclick={() => onViewModeChange?.('preview')}
+        >
+          Preview
+        </Button>
+        <Button
+          size="sm"
+          variant={viewMode === 'edit' ? 'secondary' : 'ghost'}
+          disabled={!preview || preview.previewKind !== 'text' || !preview.writable}
+          onclick={() => onViewModeChange?.('edit')}
+        >
+          Edit
+        </Button>
+        <Button
+          size="sm"
+          variant={viewMode === 'diff' ? 'secondary' : 'ghost'}
+          disabled={!editorState || draftDiff.length === 0}
+          onclick={() => onViewModeChange?.('diff')}
+        >
+          Diff
+        </Button>
+        <Button
+          size="sm"
+          disabled={!editorState?.dirty || !preview?.writable || editorState.savePhase === 'saving'}
+          onclick={() => onSave?.()}
+        >
+          Save
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={!editorState?.dirty && !editorState?.externalChange}
+          onclick={() => onRevert?.()}
+        >
+          Revert
+        </Button>
+      </div>
       {#if preview}
-        <span class="text-muted-foreground/50 ml-auto text-[10px]">
+        <span class="text-muted-foreground/50 text-[10px]">
           {preview.mediaType} · {preview.sizeBytes} B
         </span>
       {/if}
@@ -84,22 +171,67 @@
       {/if}
     </div>
 
-    <!-- Unified content: diff or syntax-highlighted preview -->
+    {#if runtimeActive}
+      <div class="bg-muted/40 text-muted-foreground border-border border-b px-3 py-1.5 text-[11px]">
+        Project AI can keep updating this workspace during active turns. Your local draft stays
+        preserved.
+      </div>
+    {/if}
+
+    {#if readOnlyMessage}
+      <div class="border-border bg-muted/40 px-3 py-2 text-sm">{readOnlyMessage}</div>
+    {/if}
+
+    {#if editorState?.externalChange || editorState?.savePhase === 'conflict'}
+      <div
+        class="flex flex-wrap items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm"
+      >
+        <span class="text-amber-900">
+          {editorState.errorMessage ||
+            'This file changed in the workspace while your draft was open.'}
+        </span>
+        <Button size="sm" variant="ghost" onclick={() => onViewModeChange?.('diff')}>
+          Review changes
+        </Button>
+        <Button size="sm" variant="ghost" onclick={() => onReloadSavedVersion?.()}>
+          Reload saved version
+        </Button>
+        <Button size="sm" variant="ghost" onclick={() => onKeepDraft?.()}>Keep my draft</Button>
+      </div>
+    {:else if editorState?.errorMessage}
+      <div class="border-destructive/20 bg-destructive/5 border-b px-3 py-2 text-sm">
+        <span class="text-destructive">{editorState.errorMessage}</span>
+      </div>
+    {/if}
+
     <div class="min-h-0 flex-1 overflow-hidden" data-testid="workspace-browser-detail-content">
-      {#if hasDiff}
+      {#if preview?.previewKind === 'binary'}
+        <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
+          <div class="mx-auto max-w-md">Binary file — not rendered inline.</div>
+        </div>
+      {:else if viewMode === 'edit' && editorState}
+        <div
+          class="h-full min-h-0 min-w-0 overflow-hidden"
+          data-testid="workspace-browser-detail-scroll-frame"
+        >
+          <CodeEditor
+            value={editorState.draftContent}
+            filePath={selectedFilePath}
+            readonly={!preview?.writable}
+            class="h-full"
+            onchange={(value) => onDraftChange?.(value)}
+          />
+        </div>
+      {:else if viewMode === 'diff' && editorState}
         <div
           class="h-full min-h-0 min-w-0 overflow-hidden"
           data-testid="workspace-browser-detail-scroll-frame"
         >
           <DiffViewer
-            diff={patch?.diff ?? ''}
-            sourceContent={preview?.content ?? ''}
+            diff={draftDiff}
+            sourceContent={editorState.latestSavedContent}
             class="h-full"
           />
-        </div>
-      {:else if preview?.previewKind === 'binary'}
-        <div class="text-muted-foreground h-full overflow-auto px-4 py-8 text-center text-sm">
-          <div class="mx-auto max-w-md">Binary file — not rendered inline.</div>
         </div>
       {:else if preview}
         <div

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
@@ -559,7 +559,9 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     await fireEvent.click(
       await view.findByRole('button', { name: /README\.md/ }, { timeout: 3000 }),
     )
-    await waitFor(() => expect(view.getByTestId('workspace-browser-detail-tab-dirty-dot')).toBeTruthy())
+    await waitFor(() =>
+      expect(view.getByTestId('workspace-browser-detail-tab-dirty-dot')).toBeTruthy(),
+    )
 
     const event = new Event('beforeunload', { cancelable: true })
     window.dispatchEvent(event)

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
@@ -4,21 +4,27 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { ProjectConversationWorkspaceDiff } from '$lib/api/chat'
 const {
   getProjectConversationWorkspace,
+  getProjectConversationWorkspaceDiff,
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
+  saveProjectConversationWorkspaceFile,
 } = vi.hoisted(() => ({
   getProjectConversationWorkspace: vi.fn(),
+  getProjectConversationWorkspaceDiff: vi.fn(),
   getProjectConversationWorkspaceFilePatch: vi.fn(),
   getProjectConversationWorkspaceFilePreview: vi.fn(),
   listProjectConversationWorkspaceTree: vi.fn(),
+  saveProjectConversationWorkspaceFile: vi.fn(),
 }))
 
 vi.mock('$lib/api/chat', () => ({
   getProjectConversationWorkspace,
+  getProjectConversationWorkspaceDiff,
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
+  saveProjectConversationWorkspaceFile,
 }))
 
 import ProjectConversationWorkspaceBrowser from './project-conversation-workspace-browser.svelte'
@@ -27,6 +33,25 @@ import {
   mockWorkspaceMetadata,
   workspaceDiff,
 } from './project-conversation-workspace-browser.test-helpers'
+import { workspaceFileDraftStorageKey } from './project-conversation-workspace-file-drafts'
+
+function buildTextPreview(path: string, content: string) {
+  return {
+    conversationId: 'conversation-1',
+    repoPath: 'services/openase',
+    path,
+    sizeBytes: content.length,
+    mediaType: 'text/plain',
+    previewKind: 'text' as const,
+    truncated: false,
+    content,
+    revision: `rev-${path}`,
+    writable: true,
+    readOnlyReason: '',
+    encoding: 'utf-8' as const,
+    lineEnding: 'lf' as const,
+  }
+}
 
 describe('ProjectConversationWorkspaceBrowser', () => {
   beforeAll(() => {
@@ -36,6 +61,7 @@ describe('ProjectConversationWorkspaceBrowser', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    window.localStorage.clear()
   })
 
   it('reloads workspace metadata after the parent diff refresh completes', async () => {
@@ -207,8 +233,10 @@ describe('ProjectConversationWorkspaceBrowser', () => {
 
     expect(view.container.textContent).toContain('README.md')
     expect(view.container.textContent).toContain('text/plain')
-    expect(view.container.textContent).toContain('line alpha')
-    expect(view.container.textContent).toContain('line beta')
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('line alpha')
+      expect(view.container.textContent).toContain('line beta')
+    })
     expect(view.getByTestId('workspace-browser-detail-panel').className).toContain(
       'overflow-hidden',
     )
@@ -218,8 +246,7 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     expect(view.getByTestId('workspace-browser-detail-scroll-frame').className).toContain(
       'overflow-hidden',
     )
-    expect(view.container.querySelector('.code-viewer')?.className).toContain('overflow-auto')
-    expect(view.getByTestId('code-viewer-content').className).toContain('w-max')
+    expect(view.container.querySelector('.code-editor')).not.toBeNull()
   })
 
   it('renders git changes and opens a changed file from the status list', async () => {
@@ -293,7 +320,9 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     })
 
     expect(view.container.textContent).toContain('added')
-    expect(view.container.textContent).toContain('export const ready = true;')
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('export const ready = true;')
+    })
     expect(view.getByTestId('workspace-browser-detail-panel').className).toContain(
       'overflow-hidden',
     )
@@ -303,7 +332,7 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     expect(view.getByTestId('workspace-browser-detail-scroll-frame').className).toContain(
       'overflow-hidden',
     )
-    expect(view.container.querySelector('.code-viewer')?.className).toContain('overflow-auto')
+    expect(view.container.querySelector('.code-editor')).not.toBeNull()
   })
 
   it('expands the explorer tree to the selected changed file from the changes list', async () => {
@@ -365,7 +394,8 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     })
 
     const changeButton = await view.findByRole('button', { name: /new\.ts/i })
-    expect(view.getAllByRole('button', { name: /new\.ts/i })).toHaveLength(1)
+    const explorerList = view.getByTestId('workspace-browser-explorer-list')
+    expect(within(explorerList).queryAllByRole('button', { name: /new\.ts/i })).toHaveLength(0)
 
     await fireEvent.click(changeButton)
 
@@ -374,10 +404,167 @@ describe('ProjectConversationWorkspaceBrowser', () => {
         repoPath: 'services/openase',
         path: 'src',
       })
-      expect(view.getAllByRole('button', { name: /new\.ts/i })).toHaveLength(2)
+      expect(within(explorerList).getAllByRole('button', { name: /new\.ts/i })).toHaveLength(1)
     })
 
     expect(view.container.textContent).toContain('src')
-    expect(view.container.textContent).toContain('export const ready = true;')
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('export const ready = true;')
+    })
+  })
+
+  it('asks before closing a dirty tab and discards the persisted draft when requested', async () => {
+    mockWorkspaceMetadata(getProjectConversationWorkspace)
+    getProjectConversationWorkspaceDiff.mockResolvedValue({ workspaceDiff })
+    listProjectConversationWorkspaceTree.mockResolvedValue({
+      workspaceTree: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: '',
+        entries: [{ path: 'README.md', name: 'README.md', kind: 'file', sizeBytes: 64 }],
+      },
+    })
+    getProjectConversationWorkspaceFilePreview.mockResolvedValue({
+      filePreview: buildTextPreview('README.md', 'line one\n'),
+    })
+    getProjectConversationWorkspaceFilePatch.mockResolvedValue({
+      filePatch: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: 'README.md',
+        status: 'modified',
+        diffKind: 'text',
+        truncated: false,
+        diff: '@@ -1 +1 @@\n-line one\n+line one\n',
+      },
+    })
+    saveProjectConversationWorkspaceFile.mockResolvedValue({
+      file: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: 'README.md',
+        revision: 'rev-readme-next',
+        sizeBytes: 18,
+        encoding: 'utf-8',
+        lineEnding: 'lf',
+      },
+    })
+
+    const persistedKey = workspaceFileDraftStorageKey({
+      conversationId: 'conversation-1',
+      repoPath: 'services/openase',
+      filePath: 'README.md',
+    })
+    window.localStorage.setItem(
+      'openase.project-conversation.workspace-file-drafts',
+      JSON.stringify({
+        [persistedKey]: {
+          draftContent: 'line one\nline two\n',
+          baseSavedContent: 'line one\n',
+          baseSavedRevision: 'rev-README.md',
+          encoding: 'utf-8',
+          lineEnding: 'lf',
+          updatedAt: '2026-04-11T00:00:00.000Z',
+        },
+      }),
+    )
+
+    const view = render(ProjectConversationWorkspaceBrowser, {
+      props: {
+        conversationId: 'conversation-1',
+        workspaceDiff,
+        workspaceDiffLoading: false,
+      },
+    })
+
+    await fireEvent.click(
+      await view.findByRole('button', { name: /README\.md/ }, { timeout: 3000 }),
+    )
+
+    await waitFor(() => {
+      expect(view.getByTestId('workspace-browser-detail-tab-dirty-dot')).toBeTruthy()
+      expect(view.container.textContent).toContain('line two')
+    })
+
+    await fireEvent.click(view.getByLabelText('Close README.md'))
+
+    expect(await view.findByText('Save changes?')).toBeTruthy()
+    expect(
+      await view.findByText('README.md has unsaved changes. Save them before closing the tab?'),
+    ).toBeTruthy()
+
+    await fireEvent.click(view.getByRole('button', { name: "Don't save" }))
+
+    await waitFor(() => {
+      expect(view.queryByTestId('workspace-browser-detail-tab-README.md')).toBeNull()
+      expect(
+        window.localStorage.getItem('openase.project-conversation.workspace-file-drafts'),
+      ).toBeNull()
+    })
+  })
+
+  it('prompts the browser before unload when any open tab has unsaved changes', async () => {
+    mockWorkspaceMetadata(getProjectConversationWorkspace)
+    getProjectConversationWorkspaceDiff.mockResolvedValue({ workspaceDiff })
+    listProjectConversationWorkspaceTree.mockResolvedValue({
+      workspaceTree: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: '',
+        entries: [{ path: 'README.md', name: 'README.md', kind: 'file', sizeBytes: 64 }],
+      },
+    })
+    getProjectConversationWorkspaceFilePreview.mockResolvedValue({
+      filePreview: buildTextPreview('README.md', 'line one\n'),
+    })
+    getProjectConversationWorkspaceFilePatch.mockResolvedValue({
+      filePatch: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: 'README.md',
+        status: 'modified',
+        diffKind: 'text',
+        truncated: false,
+        diff: '@@ -1 +1 @@\n-line one\n+line one\n',
+      },
+    })
+
+    const persistedKey = workspaceFileDraftStorageKey({
+      conversationId: 'conversation-1',
+      repoPath: 'services/openase',
+      filePath: 'README.md',
+    })
+    window.localStorage.setItem(
+      'openase.project-conversation.workspace-file-drafts',
+      JSON.stringify({
+        [persistedKey]: {
+          draftContent: 'dirty readme\n',
+          baseSavedContent: 'line one\n',
+          baseSavedRevision: 'rev-README.md',
+          encoding: 'utf-8',
+          lineEnding: 'lf',
+          updatedAt: '2026-04-11T00:00:00.000Z',
+        },
+      }),
+    )
+
+    const view = render(ProjectConversationWorkspaceBrowser, {
+      props: {
+        conversationId: 'conversation-1',
+        workspaceDiff,
+        workspaceDiffLoading: false,
+      },
+    })
+
+    await fireEvent.click(
+      await view.findByRole('button', { name: /README\.md/ }, { timeout: 3000 }),
+    )
+    await waitFor(() => expect(view.getByTestId('workspace-browser-detail-tab-dirty-dot')).toBeTruthy())
+
+    const event = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+
+    view.unmount()
   })
 })

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts
@@ -303,7 +303,7 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     expect(view.getByTestId('workspace-browser-detail-scroll-frame').className).toContain(
       'overflow-hidden',
     )
-    expect(view.container.querySelector('.diff-viewer')?.className).toContain('overflow-auto')
+    expect(view.container.querySelector('.code-viewer')?.className).toContain('overflow-auto')
   })
 
   it('expands the explorer tree to the selected changed file from the changes list', async () => {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-pane.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-pane.svelte
@@ -122,23 +122,7 @@
       class="min-h-0 min-w-0 flex-1 overflow-hidden"
       data-testid="workspace-browser-detail-panel"
     >
-      <ProjectConversationWorkspaceBrowserDetail
-        {selectedRepo}
-        selectedFilePath={browser.selectedFilePath}
-        preview={browser.preview}
-        patch={browser.patch}
-        editorState={browser.selectedEditorState}
-        draftDiff={browser.selectedDraftDiff}
-        fileLoading={browser.fileLoading}
-        fileError={browser.fileError}
-        {runtimeActive}
-        onViewModeChange={browser.setSelectedViewMode}
-        onDraftChange={browser.updateSelectedDraft}
-        onSave={() => void browser.saveSelectedFile()}
-        onRevert={browser.revertSelectedDraft}
-        onKeepDraft={browser.keepSelectedDraft}
-        onReloadSavedVersion={browser.reloadSelectedSavedVersion}
-      />
+      <ProjectConversationWorkspaceBrowserDetail {browser} {selectedRepo} {runtimeActive} />
     </div>
   </div>
 

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-pane.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-pane.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import { cn } from '$lib/utils'
+  import type {
+    ProjectConversationWorkspaceDiffRepo,
+    ProjectConversationWorkspaceRepoMetadata,
+  } from '$lib/api/chat'
+  import ProjectConversationWorkspaceBrowserDetail from './project-conversation-workspace-browser-detail.svelte'
+  import ProjectConversationWorkspaceBrowserSidebar from './project-conversation-workspace-browser-sidebar.svelte'
+  import type { ProjectConversationWorkspaceBrowserState } from './project-conversation-workspace-browser-state.svelte'
+  import { createTerminalManager } from './terminal-manager.svelte'
+  import WorkspaceTerminalPanel from './workspace-terminal-panel.svelte'
+
+  let {
+    browser,
+    selectedRepo = null,
+    selectedRepoDiff = null,
+    runtimeActive = false,
+    terminalManager,
+  }: {
+    browser: ProjectConversationWorkspaceBrowserState
+    selectedRepo?: ProjectConversationWorkspaceRepoMetadata | null
+    selectedRepoDiff?: ProjectConversationWorkspaceDiffRepo | null
+    runtimeActive?: boolean
+    terminalManager: ReturnType<typeof createTerminalManager>
+  } = $props()
+
+  const MIN_SIDEBAR_WIDTH = 180
+  const MAX_SIDEBAR_WIDTH = 480
+  let sidebarWidth = $state(240)
+  let sidebarResizing = $state(false)
+
+  const MIN_TERMINAL_HEIGHT = 120
+  const DEFAULT_TERMINAL_HEIGHT = 260
+  let terminalHeight = $state(DEFAULT_TERMINAL_HEIGHT)
+  let terminalResizing = $state(false)
+  let containerElement: HTMLDivElement | null = null
+
+  function handleSidebarResizeStart(event: PointerEvent) {
+    event.preventDefault()
+    sidebarResizing = true
+    const startX = event.clientX
+    const startWidth = sidebarWidth
+
+    function onMove(nextEvent: PointerEvent) {
+      sidebarWidth = Math.min(
+        MAX_SIDEBAR_WIDTH,
+        Math.max(MIN_SIDEBAR_WIDTH, startWidth + (nextEvent.clientX - startX)),
+      )
+    }
+
+    function onUp() {
+      sidebarResizing = false
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+
+  function handleTerminalResizeStart(event: PointerEvent) {
+    event.preventDefault()
+    terminalResizing = true
+    const startY = event.clientY
+    const startHeight = terminalHeight
+
+    function onMove(nextEvent: PointerEvent) {
+      const maxHeight = containerElement ? containerElement.clientHeight - 100 : 600
+      terminalHeight = Math.min(
+        maxHeight,
+        Math.max(MIN_TERMINAL_HEIGHT, startHeight - (nextEvent.clientY - startY)),
+      )
+    }
+
+    function onUp() {
+      terminalResizing = false
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      terminalManager.refitAll()
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+</script>
+
+<div
+  class={cn('flex min-h-0 flex-1 flex-col', (sidebarResizing || terminalResizing) && 'select-none')}
+  bind:this={containerElement}
+>
+  <div class="flex min-h-0 flex-1">
+    <div
+      class="relative min-h-0 shrink-0 overflow-hidden"
+      style="width: {sidebarWidth}px"
+      data-testid="workspace-browser-sidebar-panel"
+    >
+      <ProjectConversationWorkspaceBrowserSidebar
+        repos={browser.metadata?.repos ?? []}
+        selectedRepoPath={browser.selectedRepoPath}
+        {selectedRepo}
+        {selectedRepoDiff}
+        treeNodes={browser.treeNodes}
+        expandedDirs={browser.expandedDirs}
+        loadingDirs={browser.loadingDirs}
+        selectedFilePath={browser.selectedFilePath}
+        onOpenRepo={browser.openRepo}
+        onToggleDir={browser.toggleDir}
+        onSelectFile={browser.selectFile}
+      />
+      <div
+        class={cn(
+          'absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize transition-colors',
+          sidebarResizing ? 'bg-primary' : 'bg-border hover:bg-primary/50',
+        )}
+        role="separator"
+        aria-orientation="vertical"
+        onpointerdown={handleSidebarResizeStart}
+      ></div>
+    </div>
+
+    <div
+      class="min-h-0 min-w-0 flex-1 overflow-hidden"
+      data-testid="workspace-browser-detail-panel"
+    >
+      <ProjectConversationWorkspaceBrowserDetail
+        {selectedRepo}
+        selectedFilePath={browser.selectedFilePath}
+        preview={browser.preview}
+        patch={browser.patch}
+        editorState={browser.selectedEditorState}
+        draftDiff={browser.selectedDraftDiff}
+        fileLoading={browser.fileLoading}
+        fileError={browser.fileError}
+        {runtimeActive}
+        onViewModeChange={browser.setSelectedViewMode}
+        onDraftChange={browser.updateSelectedDraft}
+        onSave={() => void browser.saveSelectedFile()}
+        onRevert={browser.revertSelectedDraft}
+        onKeepDraft={browser.keepSelectedDraft}
+        onReloadSavedVersion={browser.reloadSelectedSavedVersion}
+      />
+    </div>
+  </div>
+
+  {#if terminalManager.panelOpen}
+    <div
+      class={cn(
+        'h-[3px] shrink-0 cursor-row-resize transition-colors',
+        terminalResizing ? 'bg-primary' : 'bg-border hover:bg-primary/50',
+      )}
+      role="separator"
+      aria-orientation="horizontal"
+      onpointerdown={handleTerminalResizeStart}
+    ></div>
+    <div class="flex min-h-0 shrink-0 overflow-hidden" style="height: {terminalHeight}px">
+      <WorkspaceTerminalPanel manager={terminalManager} />
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
@@ -137,7 +137,9 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     })
 
     expect(view.container.textContent).toContain('main.ts')
-    expect(view.container.textContent).toContain('export const refreshed = true;')
+    await waitFor(() => {
+      expect(view.container.textContent).toContain('export const refreshed = true;')
+    })
   })
 
   it('keeps tree and file DOM stable when a refresh returns identical data', async () => {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-sidebar.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-sidebar.svelte
@@ -91,7 +91,7 @@
       {@const isDirtyDir = dirtyParentDirs().has(entry.path)}
       <button
         type="button"
-        class="hover:bg-muted/50 flex w-full items-center gap-1 py-[3px] text-left text-[13px] transition-colors"
+        class="hover:bg-muted/50 flex w-full items-center gap-1 py-[3px] pr-3 text-left text-[13px] transition-colors"
         style="padding-left: {depth * 16 + 8}px"
         onclick={() => onToggleDir?.(entry.path)}
       >
@@ -142,7 +142,7 @@
       <button
         type="button"
         class={cn(
-          'hover:bg-muted/50 flex w-full items-center gap-1 py-[3px] text-left text-[13px] transition-colors',
+          'hover:bg-muted/50 flex w-full items-center gap-1 py-[3px] pr-3 text-left text-[13px] transition-colors',
           entry.path === selectedFilePath && 'bg-primary/10 text-primary',
         )}
         style="padding-left: {depth * 16 + 24}px"

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
@@ -1,0 +1,153 @@
+import type {
+  ProjectConversationWorkspaceFilePatch,
+  ProjectConversationWorkspaceFilePreview,
+  ProjectConversationWorkspaceMetadata,
+  ProjectConversationWorkspaceTreeEntry,
+} from '$lib/api/chat'
+import type {
+  WorkspaceFileSavePhase,
+  WorkspaceFileViewMode,
+} from './project-conversation-workspace-file-drafts'
+
+export type WorkspaceFileEditorState = {
+  baseSavedContent: string
+  baseSavedRevision: string
+  latestSavedContent: string
+  latestSavedRevision: string
+  draftContent: string
+  dirty: boolean
+  viewMode: WorkspaceFileViewMode
+  savePhase: WorkspaceFileSavePhase
+  externalChange: boolean
+  errorMessage: string
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
+  lastSavedAt: string
+}
+
+export function areTreeEntriesEqual(
+  left: ProjectConversationWorkspaceTreeEntry[] | undefined,
+  right: ProjectConversationWorkspaceTreeEntry[],
+) {
+  if (!left || left.length !== right.length) {
+    return false
+  }
+
+  return left.every((entry, index) => {
+    const next = right[index]
+    return (
+      next != null &&
+      entry.path === next.path &&
+      entry.name === next.name &&
+      entry.kind === next.kind &&
+      entry.sizeBytes === next.sizeBytes
+    )
+  })
+}
+
+export function areWorkspaceMetadataEqual(
+  left: ProjectConversationWorkspaceMetadata | null,
+  right: ProjectConversationWorkspaceMetadata,
+) {
+  if (
+    !left ||
+    left.conversationId !== right.conversationId ||
+    left.available !== right.available ||
+    left.workspacePath !== right.workspacePath ||
+    left.repos.length !== right.repos.length
+  ) {
+    return false
+  }
+
+  return left.repos.every((repo, index) => {
+    const next = right.repos[index]
+    return (
+      next != null &&
+      repo.name === next.name &&
+      repo.path === next.path &&
+      repo.branch === next.branch &&
+      repo.headCommit === next.headCommit &&
+      repo.headSummary === next.headSummary &&
+      repo.dirty === next.dirty &&
+      repo.filesChanged === next.filesChanged &&
+      repo.added === next.added &&
+      repo.removed === next.removed
+    )
+  })
+}
+
+export function areFilePreviewEqual(
+  left: ProjectConversationWorkspaceFilePreview | null,
+  right: ProjectConversationWorkspaceFilePreview,
+) {
+  return (
+    !!left &&
+    left.conversationId === right.conversationId &&
+    left.repoPath === right.repoPath &&
+    left.path === right.path &&
+    left.sizeBytes === right.sizeBytes &&
+    left.mediaType === right.mediaType &&
+    left.previewKind === right.previewKind &&
+    left.truncated === right.truncated &&
+    left.content === right.content &&
+    left.revision === right.revision &&
+    left.writable === right.writable &&
+    left.readOnlyReason === right.readOnlyReason &&
+    left.encoding === right.encoding &&
+    left.lineEnding === right.lineEnding
+  )
+}
+
+export function areFilePatchEqual(
+  left: ProjectConversationWorkspaceFilePatch | null,
+  right: ProjectConversationWorkspaceFilePatch,
+) {
+  return (
+    !!left &&
+    left.conversationId === right.conversationId &&
+    left.repoPath === right.repoPath &&
+    left.path === right.path &&
+    left.status === right.status &&
+    left.diffKind === right.diffKind &&
+    left.truncated === right.truncated &&
+    left.diff === right.diff
+  )
+}
+
+export function createInitialEditorState(
+  preview: ProjectConversationWorkspaceFilePreview,
+): WorkspaceFileEditorState {
+  return {
+    baseSavedContent: preview.content,
+    baseSavedRevision: preview.revision,
+    latestSavedContent: preview.content,
+    latestSavedRevision: preview.revision,
+    draftContent: preview.content,
+    dirty: false,
+    viewMode: 'preview',
+    savePhase: 'idle',
+    externalChange: false,
+    errorMessage: '',
+    encoding: preview.encoding,
+    lineEnding: preview.lineEnding,
+    lastSavedAt: '',
+  }
+}
+
+export function buildWholeFileDiff(filePath: string, savedContent: string, draftContent: string) {
+  if (savedContent === draftContent) {
+    return ''
+  }
+  const oldLines = savedContent.split('\n')
+  const newLines = draftContent.split('\n')
+  const oldCount = savedContent === '' ? 0 : oldLines.length
+  const newCount = draftContent === '' ? 0 : newLines.length
+
+  return [
+    `--- saved/${filePath}`,
+    `+++ draft/${filePath}`,
+    `@@ -1,${oldCount} +1,${newCount} @@`,
+    ...oldLines.map((line) => `-${line}`),
+    ...newLines.map((line) => `+${line}`),
+  ].join('\n')
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
@@ -4,10 +4,109 @@ import type {
   ProjectConversationWorkspaceMetadata,
   ProjectConversationWorkspaceTreeEntry,
 } from '$lib/api/chat'
-import type {
-  WorkspaceFileSavePhase,
-  WorkspaceFileViewMode,
-} from './project-conversation-workspace-file-drafts'
+import type { WorkspaceFileSavePhase } from './project-conversation-workspace-file-drafts'
+
+export type WorkspaceTab = {
+  repoPath: string
+  filePath: string
+}
+
+export type WorkspaceTabFileState = {
+  preview: ProjectConversationWorkspaceFilePreview | null
+  patch: ProjectConversationWorkspaceFilePatch | null
+  loading: boolean
+  error: string
+}
+
+export const EMPTY_TAB_FILE_STATE: WorkspaceTabFileState = {
+  preview: null,
+  patch: null,
+  loading: false,
+  error: '',
+}
+
+export function workspaceTabKey(tab: { repoPath: string; filePath: string }): string {
+  return `${tab.repoPath}::${tab.filePath}`
+}
+
+/**
+ * Pure transform: insert (or focus) a tab and return the next state slice.
+ * Caller is responsible for assigning the returned values to $state holders.
+ */
+export function applyOpenTab(
+  openTabs: WorkspaceTab[],
+  repoPath: string,
+  filePath: string,
+): { openTabs: WorkspaceTab[]; activeTabKey: string; treeRepoPath: string } {
+  const key = workspaceTabKey({ repoPath, filePath })
+  const exists = openTabs.some((t) => workspaceTabKey(t) === key)
+  return {
+    openTabs: exists ? openTabs : [...openTabs, { repoPath, filePath }],
+    activeTabKey: key,
+    treeRepoPath: repoPath,
+  }
+}
+
+/**
+ * Pure transform: close a tab and figure out the new active tab. Returns null
+ * if no such tab existed.
+ */
+export function applyCloseTab(
+  openTabs: WorkspaceTab[],
+  activeTabKey: string,
+  repoPath: string,
+  filePath: string,
+): {
+  openTabs: WorkspaceTab[]
+  activeTabKey: string
+  nextTreeRepo: string | null
+} | null {
+  const key = workspaceTabKey({ repoPath, filePath })
+  const idx = openTabs.findIndex((t) => workspaceTabKey(t) === key)
+  if (idx === -1) return null
+  const nextTabs = openTabs.slice(0, idx).concat(openTabs.slice(idx + 1))
+  let nextActive = activeTabKey
+  let nextTreeRepo: string | null = null
+  if (activeTabKey === key) {
+    const fallback = nextTabs[idx] ?? nextTabs[idx - 1] ?? null
+    nextActive = fallback ? workspaceTabKey(fallback) : ''
+    if (fallback) nextTreeRepo = fallback.repoPath
+  }
+  return { openTabs: nextTabs, activeTabKey: nextActive, nextTreeRepo }
+}
+
+/**
+ * Pure transform: merge a partial tab file-state patch into the map. Identity
+ * for `preview` / `patch` is preserved when their values are deep-equal so
+ * downstream identity-based effects don't refire on no-op refreshes.
+ */
+export function patchTabFileStateMap(
+  current: Map<string, WorkspaceTabFileState>,
+  key: string,
+  patch: Partial<WorkspaceTabFileState>,
+): Map<string, WorkspaceTabFileState> {
+  const next = new Map(current)
+  const existing = next.get(key) ?? EMPTY_TAB_FILE_STATE
+  const merged: WorkspaceTabFileState = { ...existing, ...patch }
+  if ('preview' in patch && patch.preview && areFilePreviewEqual(existing.preview, patch.preview)) {
+    merged.preview = existing.preview
+  }
+  if ('patch' in patch && patch.patch && areFilePatchEqual(existing.patch, patch.patch)) {
+    merged.patch = existing.patch
+  }
+  next.set(key, merged)
+  return next
+}
+
+export function deleteTabFileStateMap(
+  current: Map<string, WorkspaceTabFileState>,
+  key: string,
+): Map<string, WorkspaceTabFileState> {
+  if (!current.has(key)) return current
+  const next = new Map(current)
+  next.delete(key)
+  return next
+}
 
 export type WorkspaceFileEditorState = {
   baseSavedContent: string
@@ -16,7 +115,6 @@ export type WorkspaceFileEditorState = {
   latestSavedRevision: string
   draftContent: string
   dirty: boolean
-  viewMode: WorkspaceFileViewMode
   savePhase: WorkspaceFileSavePhase
   externalChange: boolean
   errorMessage: string
@@ -124,7 +222,6 @@ export function createInitialEditorState(
     latestSavedRevision: preview.revision,
     draftContent: preview.content,
     dirty: false,
-    viewMode: 'preview',
     savePhase: 'idle',
     externalChange: false,
     errorMessage: '',
@@ -134,20 +231,7 @@ export function createInitialEditorState(
   }
 }
 
-export function buildWholeFileDiff(filePath: string, savedContent: string, draftContent: string) {
-  if (savedContent === draftContent) {
-    return ''
-  }
-  const oldLines = savedContent.split('\n')
-  const newLines = draftContent.split('\n')
-  const oldCount = savedContent === '' ? 0 : oldLines.length
-  const newCount = draftContent === '' ? 0 : newLines.length
-
-  return [
-    `--- saved/${filePath}`,
-    `+++ draft/${filePath}`,
-    `@@ -1,${oldCount} +1,${newCount} @@`,
-    ...oldLines.map((line) => `-${line}`),
-    ...newLines.map((line) => `+${line}`),
-  ].join('\n')
-}
+export {
+  computeDraftLineDiff,
+  type WorkspaceFileLineDiffMarkers,
+} from './project-conversation-workspace-line-diff'

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,175 +1,23 @@
-/* eslint-disable max-lines */
-
-import { ApiError } from '$lib/api/client'
 import {
   getProjectConversationWorkspace,
   getProjectConversationWorkspaceDiff,
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
-  saveProjectConversationWorkspaceFile,
   type ProjectConversationWorkspaceDiff,
   type ProjectConversationWorkspaceFilePatch,
   type ProjectConversationWorkspaceFilePreview,
   type ProjectConversationWorkspaceMetadata,
   type ProjectConversationWorkspaceTreeEntry,
 } from '$lib/api/chat'
+import { createWorkspaceFileEditorStore } from './project-conversation-workspace-file-editor-state.svelte'
 import {
-  deletePersistedWorkspaceFileDraft,
-  loadPersistedWorkspaceFileDraft,
-  savePersistedWorkspaceFileDraft,
-  type WorkspaceFileSavePhase,
-  type WorkspaceFileViewMode,
-  workspaceFileDraftStorageKey,
-} from './project-conversation-workspace-file-drafts'
-
-export type WorkspaceFileEditorState = {
-  baseSavedContent: string
-  baseSavedRevision: string
-  latestSavedContent: string
-  latestSavedRevision: string
-  draftContent: string
-  dirty: boolean
-  viewMode: WorkspaceFileViewMode
-  savePhase: WorkspaceFileSavePhase
-  externalChange: boolean
-  errorMessage: string
-  encoding: 'utf-8'
-  lineEnding: 'lf' | 'crlf'
-  lastSavedAt: string
-}
-
-function areTreeEntriesEqual(
-  left: ProjectConversationWorkspaceTreeEntry[] | undefined,
-  right: ProjectConversationWorkspaceTreeEntry[],
-) {
-  if (!left) {
-    return false
-  }
-  if (left.length !== right.length) {
-    return false
-  }
-
-  return left.every((entry, index) => {
-    const next = right[index]
-    return (
-      next != null &&
-      entry.path === next.path &&
-      entry.name === next.name &&
-      entry.kind === next.kind &&
-      entry.sizeBytes === next.sizeBytes
-    )
-  })
-}
-
-function areWorkspaceMetadataEqual(
-  left: ProjectConversationWorkspaceMetadata | null,
-  right: ProjectConversationWorkspaceMetadata,
-) {
-  if (!left) {
-    return false
-  }
-  if (
-    left.conversationId !== right.conversationId ||
-    left.available !== right.available ||
-    left.workspacePath !== right.workspacePath ||
-    left.repos.length !== right.repos.length
-  ) {
-    return false
-  }
-
-  return left.repos.every((repo, index) => {
-    const next = right.repos[index]
-    return (
-      next != null &&
-      repo.name === next.name &&
-      repo.path === next.path &&
-      repo.branch === next.branch &&
-      repo.headCommit === next.headCommit &&
-      repo.headSummary === next.headSummary &&
-      repo.dirty === next.dirty &&
-      repo.filesChanged === next.filesChanged &&
-      repo.added === next.added &&
-      repo.removed === next.removed
-    )
-  })
-}
-
-function areFilePreviewEqual(
-  left: ProjectConversationWorkspaceFilePreview | null,
-  right: ProjectConversationWorkspaceFilePreview,
-) {
-  return (
-    !!left &&
-    left.conversationId === right.conversationId &&
-    left.repoPath === right.repoPath &&
-    left.path === right.path &&
-    left.sizeBytes === right.sizeBytes &&
-    left.mediaType === right.mediaType &&
-    left.previewKind === right.previewKind &&
-    left.truncated === right.truncated &&
-    left.content === right.content &&
-    left.revision === right.revision &&
-    left.writable === right.writable &&
-    left.readOnlyReason === right.readOnlyReason &&
-    left.encoding === right.encoding &&
-    left.lineEnding === right.lineEnding
-  )
-}
-
-function areFilePatchEqual(
-  left: ProjectConversationWorkspaceFilePatch | null,
-  right: ProjectConversationWorkspaceFilePatch,
-) {
-  return (
-    !!left &&
-    left.conversationId === right.conversationId &&
-    left.repoPath === right.repoPath &&
-    left.path === right.path &&
-    left.status === right.status &&
-    left.diffKind === right.diffKind &&
-    left.truncated === right.truncated &&
-    left.diff === right.diff
-  )
-}
-
-function createInitialEditorState(
-  preview: ProjectConversationWorkspaceFilePreview,
-): WorkspaceFileEditorState {
-  return {
-    baseSavedContent: preview.content,
-    baseSavedRevision: preview.revision,
-    latestSavedContent: preview.content,
-    latestSavedRevision: preview.revision,
-    draftContent: preview.content,
-    dirty: false,
-    viewMode: 'preview',
-    savePhase: 'idle',
-    externalChange: false,
-    errorMessage: '',
-    encoding: preview.encoding,
-    lineEnding: preview.lineEnding,
-    lastSavedAt: '',
-  }
-}
-
-function buildWholeFileDiff(filePath: string, savedContent: string, draftContent: string) {
-  if (savedContent === draftContent) {
-    return ''
-  }
-  const oldLines = savedContent.split('\n')
-  const newLines = draftContent.split('\n')
-  const oldCount = savedContent === '' ? 0 : oldLines.length
-  const newCount = draftContent === '' ? 0 : newLines.length
-  const diffLines = [
-    `--- saved/${filePath}`,
-    `+++ draft/${filePath}`,
-    `@@ -1,${oldCount} +1,${newCount} @@`,
-    ...oldLines.map((line) => `-${line}`),
-    ...newLines.map((line) => `+${line}`),
-  ]
-  return diffLines.join('\n')
-}
+  areFilePatchEqual,
+  areFilePreviewEqual,
+  areTreeEntriesEqual,
+  areWorkspaceMetadataEqual,
+} from './project-conversation-workspace-browser-state-helpers'
+export type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state-helpers'
 
 export function createProjectConversationWorkspaceBrowserState(input: {
   getConversationId: () => string
@@ -190,7 +38,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   let selectedRepoPath = $state('')
   let selectedFilePath = $state('')
   let loadRequestID = 0
-  let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
 
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
     if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) {
@@ -199,8 +46,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   }
 
   function setTreeEntries(dirPath: string, entries: ProjectConversationWorkspaceTreeEntry[]) {
-    const currentEntries = treeNodes.get(dirPath)
-    if (areTreeEntriesEqual(currentEntries, entries)) {
+    if (areTreeEntriesEqual(treeNodes.get(dirPath), entries)) {
       return
     }
 
@@ -244,7 +90,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       }
       return
     }
-
     if (!areFilePreviewEqual(preview, nextPreview)) {
       preview = nextPreview
     }
@@ -257,132 +102,56 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       }
       return
     }
-
     if (!areFilePatchEqual(patch, nextPatch)) {
       patch = nextPatch
     }
   }
 
-  function selectedFileStorageKey(repoPath = selectedRepoPath, filePath = selectedFilePath) {
-    return workspaceFileDraftStorageKey({
-      conversationId: input.getConversationId(),
-      repoPath,
-      filePath,
-    })
-  }
-
-  function getEditorState(repoPath = selectedRepoPath, filePath = selectedFilePath) {
-    if (!repoPath || !filePath) {
-      return null
-    }
-    return editorStates.get(selectedFileStorageKey(repoPath, filePath)) ?? null
-  }
-
-  function setEditorState(
-    repoPath: string,
-    filePath: string,
-    nextState: WorkspaceFileEditorState | null,
-  ) {
-    const key = selectedFileStorageKey(repoPath, filePath)
-    const nextEditorStates = new Map(editorStates)
-    if (nextState) {
-      nextEditorStates.set(key, nextState)
-      if (nextState.dirty) {
-        savePersistedWorkspaceFileDraft(key, {
-          draftContent: nextState.draftContent,
-          baseSavedContent: nextState.baseSavedContent,
-          baseSavedRevision: nextState.baseSavedRevision,
-          viewMode: nextState.viewMode,
-          encoding: nextState.encoding,
-          lineEnding: nextState.lineEnding,
-          updatedAt: new Date().toISOString(),
-        })
-      } else {
-        deletePersistedWorkspaceFileDraft(key)
-      }
-    } else {
-      nextEditorStates.delete(key)
-      deletePersistedWorkspaceFileDraft(key)
-    }
-    editorStates = nextEditorStates
-  }
-
-  function syncEditorStateFromPreview(
-    repoPath: string,
-    filePath: string,
-    nextPreview: ProjectConversationWorkspaceFilePreview,
-  ) {
-    const key = selectedFileStorageKey(repoPath, filePath)
-    const existing = editorStates.get(key)
-    if (!existing) {
-      const persisted = loadPersistedWorkspaceFileDraft(key)
-      if (!persisted) {
-        setEditorState(repoPath, filePath, createInitialEditorState(nextPreview))
-        return
-      }
-      const dirty = persisted.draftContent !== nextPreview.content
-      setEditorState(repoPath, filePath, {
-        baseSavedContent: persisted.baseSavedContent,
-        baseSavedRevision: persisted.baseSavedRevision,
-        latestSavedContent: nextPreview.content,
-        latestSavedRevision: nextPreview.revision,
-        draftContent: persisted.draftContent,
-        dirty,
-        viewMode: dirty ? 'edit' : persisted.viewMode,
-        savePhase: 'idle',
-        externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
-        errorMessage: '',
-        encoding: nextPreview.encoding,
-        lineEnding: nextPreview.lineEnding,
-        lastSavedAt: '',
-      })
+  async function refreshWorkspaceDiff() {
+    const conversationId = input.getConversationId()
+    if (!conversationId || !input.onWorkspaceDiffUpdated) {
       return
     }
+    const payload = await getProjectConversationWorkspaceDiff(conversationId)
+    input.onWorkspaceDiffUpdated(payload.workspaceDiff)
+  }
 
-    if (existing.dirty) {
-      const latestChanged = existing.latestSavedRevision !== nextPreview.revision
-      setEditorState(repoPath, filePath, {
-        ...existing,
-        latestSavedContent: nextPreview.content,
-        latestSavedRevision: nextPreview.revision,
-        dirty: existing.draftContent !== nextPreview.content,
-        externalChange: latestChanged || existing.baseSavedRevision !== nextPreview.revision,
-        encoding: nextPreview.encoding,
-        lineEnding: nextPreview.lineEnding,
-      })
-      return
-    }
+  const editorStore = createWorkspaceFileEditorStore({
+    getConversationId: input.getConversationId,
+    getSelectedRepoPath: () => selectedRepoPath,
+    getSelectedFilePath: () => selectedFilePath,
+    getPreview: () => preview,
+    setPreview,
+    reloadSelectedFile: async () => {
+      if (selectedFilePath) {
+        await loadFile(selectedFilePath, { silent: true })
+      }
+    },
+    refreshWorkspaceDiff,
+  })
 
-    setEditorState(repoPath, filePath, {
-      ...existing,
-      baseSavedContent: nextPreview.content,
-      baseSavedRevision: nextPreview.revision,
-      latestSavedContent: nextPreview.content,
-      latestSavedRevision: nextPreview.revision,
-      draftContent: nextPreview.content,
-      dirty: false,
-      externalChange: false,
-      savePhase: 'idle',
-      errorMessage: '',
-      encoding: nextPreview.encoding,
-      lineEnding: nextPreview.lineEnding,
-    })
+  function clearSelectionState() {
+    selectedFilePath = ''
+    setPreview(null)
+    setPatch(null)
+    fileError = ''
+  }
+
+  function resetTreeState() {
+    treeNodes = new Map()
+    expandedDirs = new Set()
+    loadingDirs = new Set()
   }
 
   function reset() {
     metadata = null
     metadataLoading = false
     metadataError = ''
-    treeNodes = new Map()
-    expandedDirs = new Set()
-    loadingDirs = new Set()
-    preview = null
-    patch = null
+    resetTreeState()
+    clearSelectionState()
     fileLoading = false
-    fileError = ''
     selectedRepoPath = ''
-    selectedFilePath = ''
-    editorStates = new Map()
+    editorStore.reset()
   }
 
   async function refreshWorkspace(preserveSelection: boolean) {
@@ -393,18 +162,15 @@ export function createProjectConversationWorkspaceBrowserState(input: {
 
     try {
       const payload = await getProjectConversationWorkspace(conversationId)
-      if (requestID !== loadRequestID || conversationId !== input.getConversationId()) return
+      if (requestID !== loadRequestID || conversationId !== input.getConversationId()) {
+        return
+      }
 
       setMetadata(payload.workspace)
       if (!payload.workspace.available || payload.workspace.repos.length === 0) {
         selectedRepoPath = ''
-        selectedFilePath = ''
-        treeNodes = new Map()
-        expandedDirs = new Set()
-        loadingDirs = new Set()
-        setPreview(null)
-        setPatch(null)
-        fileError = ''
+        resetTreeState()
+        clearSelectionState()
         return
       }
 
@@ -420,19 +186,20 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       selectedRepoPath = nextRepoPath
 
       if (repoChanged) {
-        selectedFilePath = ''
-        expandedDirs = new Set()
-        setPreview(null)
-        setPatch(null)
-        treeNodes = new Map()
+        resetTreeState()
+        clearSelectionState()
       }
 
       await loadDirEntries('', requestID, { silent: treeNodes.has('') })
-      if (requestID !== loadRequestID) return
+      if (requestID !== loadRequestID) {
+        return
+      }
 
       if (prevExpanded.length > 0) {
         await Promise.all(
-          prevExpanded.map((dir) => loadDirEntries(dir, requestID, { silent: treeNodes.has(dir) })),
+          prevExpanded.map((dirPath) =>
+            loadDirEntries(dirPath, requestID, { silent: treeNodes.has(dirPath) }),
+          ),
         )
       }
 
@@ -443,11 +210,12 @@ export function createProjectConversationWorkspaceBrowserState(input: {
         })
       }
     } catch (error) {
-      if (requestID !== loadRequestID || conversationId !== input.getConversationId()) return
+      if (requestID !== loadRequestID || conversationId !== input.getConversationId()) {
+        return
+      }
       metadata = null
-      treeNodes = new Map()
-      setPreview(null)
-      setPatch(null)
+      resetTreeState()
+      clearSelectionState()
       metadataError =
         error instanceof Error ? error.message : 'Failed to load the Project AI workspace.'
     } finally {
@@ -464,11 +232,12 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   ) {
     const conversationId = input.getConversationId()
     const repoPath = selectedRepoPath
-    if (!repoPath || !conversationId) return
+    if (!repoPath || !conversationId) {
+      return
+    }
 
     const requestID = externalRequestID ?? loadRequestID
     const silent = options.silent ?? false
-
     if (!silent) {
       setDirLoading(dirPath, true)
     }
@@ -478,8 +247,9 @@ export function createProjectConversationWorkspaceBrowserState(input: {
         repoPath,
         path: dirPath,
       })
-      if (requestID !== loadRequestID || repoPath !== selectedRepoPath) return
-
+      if (requestID !== loadRequestID || repoPath !== selectedRepoPath) {
+        return
+      }
       setTreeEntries(dirPath, payload.workspaceTree.entries)
     } catch {
       setTreeEntries(dirPath, [])
@@ -497,7 +267,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     }
 
     setDirExpanded(dirPath, true)
-
     if (!treeNodes.has(dirPath)) {
       await loadDirEntries(dirPath)
     }
@@ -507,10 +276,11 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     path: string,
     options: { requestID?: number; silent?: boolean } = {},
   ) {
-    if (!path) return
+    if (!path) {
+      return
+    }
 
     const requestID = options.requestID ?? loadRequestID
-    const silent = options.silent ?? false
     const ancestorDirs = path
       .split('/')
       .slice(0, -1)
@@ -523,28 +293,26 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     if (ancestorDirs.length === 0) {
       return
     }
-
     if (!treeNodes.has('')) {
-      await loadDirEntries('', requestID, { silent })
+      await loadDirEntries('', requestID, options)
     }
 
     for (const dirPath of ancestorDirs) {
       if (requestID !== loadRequestID || path !== selectedFilePath) {
         return
       }
-
       setDirExpanded(dirPath, true)
       if (!treeNodes.has(dirPath)) {
-        await loadDirEntries(dirPath, requestID, { silent })
+        await loadDirEntries(dirPath, requestID, options)
       }
     }
   }
 
   async function loadFile(path: string, options: { requestID?: number; silent?: boolean } = {}) {
     const conversationId = input.getConversationId()
-    if (!selectedRepoPath || !conversationId) {
-      setPreview(null)
-      setPatch(null)
+    const repoPath = selectedRepoPath
+    if (!repoPath || !conversationId) {
+      clearSelectionState()
       return
     }
 
@@ -558,21 +326,19 @@ export function createProjectConversationWorkspaceBrowserState(input: {
 
     try {
       const [previewPayload, patchPayload] = await Promise.all([
-        getProjectConversationWorkspaceFilePreview(conversationId, {
-          repoPath: selectedRepoPath,
-          path,
-        }),
-        getProjectConversationWorkspaceFilePatch(conversationId, {
-          repoPath: selectedRepoPath,
-          path,
-        }),
+        getProjectConversationWorkspaceFilePreview(conversationId, { repoPath, path }),
+        getProjectConversationWorkspaceFilePatch(conversationId, { repoPath, path }),
       ])
-      if (requestID !== loadRequestID || path !== selectedFilePath) return
+      if (requestID !== loadRequestID || path !== selectedFilePath) {
+        return
+      }
       setPreview(previewPayload.filePreview)
       setPatch(patchPayload.filePatch)
-      syncEditorStateFromPreview(selectedRepoPath, path, previewPayload.filePreview)
+      editorStore.syncFromPreview(repoPath, path, previewPayload.filePreview)
     } catch (error) {
-      if (requestID !== loadRequestID || path !== selectedFilePath) return
+      if (requestID !== loadRequestID || path !== selectedFilePath) {
+        return
+      }
       setPreview(null)
       setPatch(null)
       fileError =
@@ -585,199 +351,23 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   }
 
   function openRepo(repoPath: string) {
-    if (!repoPath || repoPath === selectedRepoPath) return
+    if (!repoPath || repoPath === selectedRepoPath) {
+      return
+    }
     selectedRepoPath = repoPath
-    selectedFilePath = ''
-    expandedDirs = new Set()
-    treeNodes = new Map()
-    setPreview(null)
-    setPatch(null)
+    resetTreeState()
+    clearSelectionState()
     void loadDirEntries('')
   }
 
   function selectFile(path: string) {
-    if (!path) return
+    if (!path) {
+      return
+    }
     const requestID = ++loadRequestID
     selectedFilePath = path
     void revealFileInTree(path, { requestID, silent: true })
     void loadFile(path, { requestID })
-  }
-
-  function setSelectedViewMode(viewMode: WorkspaceFileViewMode) {
-    const editor = getEditorState()
-    if (!editor || !selectedRepoPath || !selectedFilePath) {
-      return
-    }
-    setEditorState(selectedRepoPath, selectedFilePath, { ...editor, viewMode })
-  }
-
-  function updateSelectedDraft(nextDraftContent: string) {
-    const editor = getEditorState()
-    if (!editor || !selectedRepoPath || !selectedFilePath) {
-      return
-    }
-    const dirty = nextDraftContent !== editor.latestSavedContent
-    setEditorState(selectedRepoPath, selectedFilePath, {
-      ...editor,
-      draftContent: nextDraftContent,
-      dirty,
-      viewMode: 'edit',
-      savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
-      errorMessage: '',
-    })
-  }
-
-  function revertSelectedDraft() {
-    const editor = getEditorState()
-    if (!editor || !selectedRepoPath || !selectedFilePath) {
-      return
-    }
-    setEditorState(selectedRepoPath, selectedFilePath, {
-      ...editor,
-      baseSavedContent: editor.latestSavedContent,
-      baseSavedRevision: editor.latestSavedRevision,
-      draftContent: editor.latestSavedContent,
-      dirty: false,
-      savePhase: 'idle',
-      externalChange: false,
-      errorMessage: '',
-      viewMode: 'preview',
-    })
-  }
-
-  function keepSelectedDraft() {
-    const editor = getEditorState()
-    if (!editor || !selectedRepoPath || !selectedFilePath) {
-      return
-    }
-    setEditorState(selectedRepoPath, selectedFilePath, {
-      ...editor,
-      baseSavedContent: editor.latestSavedContent,
-      baseSavedRevision: editor.latestSavedRevision,
-      dirty: editor.draftContent !== editor.latestSavedContent,
-      savePhase: 'idle',
-      externalChange: false,
-      errorMessage: '',
-      viewMode: 'edit',
-    })
-  }
-
-  function reloadSelectedSavedVersion() {
-    revertSelectedDraft()
-  }
-
-  async function refreshWorkspaceDiff() {
-    const conversationId = input.getConversationId()
-    if (!conversationId || !input.onWorkspaceDiffUpdated) {
-      return
-    }
-    const payload = await getProjectConversationWorkspaceDiff(conversationId)
-    input.onWorkspaceDiffUpdated(payload.workspaceDiff)
-  }
-
-  async function saveSelectedFile() {
-    const conversationId = input.getConversationId()
-    const editor = getEditorState()
-    if (
-      !conversationId ||
-      !selectedRepoPath ||
-      !selectedFilePath ||
-      !editor ||
-      !preview?.writable
-    ) {
-      return
-    }
-    if (!editor.dirty || editor.savePhase === 'saving') {
-      return
-    }
-
-    setEditorState(selectedRepoPath, selectedFilePath, {
-      ...editor,
-      savePhase: 'saving',
-      errorMessage: '',
-    })
-
-    try {
-      const payload = await saveProjectConversationWorkspaceFile(conversationId, {
-        repoPath: selectedRepoPath,
-        path: selectedFilePath,
-        baseRevision: editor.baseSavedRevision,
-        content: editor.draftContent,
-        encoding: editor.encoding,
-        lineEnding: editor.lineEnding,
-      })
-      const nextEditor = getEditorState()
-      if (!nextEditor) {
-        return
-      }
-      const now = new Date().toISOString()
-      setEditorState(selectedRepoPath, selectedFilePath, {
-        ...nextEditor,
-        baseSavedContent: nextEditor.draftContent,
-        baseSavedRevision: payload.file.revision,
-        latestSavedContent: nextEditor.draftContent,
-        latestSavedRevision: payload.file.revision,
-        dirty: false,
-        savePhase: 'idle',
-        externalChange: false,
-        errorMessage: '',
-        lastSavedAt: now,
-      })
-      await loadFile(selectedFilePath, { silent: true })
-      try {
-        await refreshWorkspaceDiff()
-      } catch {
-        const refreshedEditor = getEditorState()
-        if (refreshedEditor) {
-          setEditorState(selectedRepoPath, selectedFilePath, {
-            ...refreshedEditor,
-            errorMessage: 'Saved, but the workspace summary could not be refreshed.',
-          })
-        }
-      }
-    } catch (error) {
-      const latestEditor = getEditorState()
-      if (!latestEditor) {
-        return
-      }
-      if (
-        error instanceof ApiError &&
-        error.status === 409 &&
-        error.code === 'PROJECT_CONVERSATION_WORKSPACE_FILE_CONFLICT'
-      ) {
-        const currentFile = (
-          error.details as { current_file?: ProjectConversationWorkspaceFilePreview } | undefined
-        )?.current_file
-        if (currentFile) {
-          setEditorState(selectedRepoPath, selectedFilePath, {
-            ...latestEditor,
-            latestSavedContent: currentFile.content,
-            latestSavedRevision: currentFile.revision,
-            dirty: latestEditor.draftContent !== currentFile.content,
-            savePhase: 'conflict',
-            externalChange: true,
-            errorMessage: 'The workspace file changed before your save completed.',
-            encoding: currentFile.encoding,
-            lineEnding: currentFile.lineEnding,
-            viewMode: 'diff',
-          })
-          setPreview(currentFile)
-        } else {
-          setEditorState(selectedRepoPath, selectedFilePath, {
-            ...latestEditor,
-            savePhase: 'conflict',
-            externalChange: true,
-            errorMessage: error.message,
-          })
-        }
-        return
-      }
-      setEditorState(selectedRepoPath, selectedFilePath, {
-        ...latestEditor,
-        savePhase: 'error',
-        errorMessage: error instanceof Error ? error.message : 'Failed to save the workspace file.',
-      })
-    }
   }
 
   return {
@@ -818,25 +408,25 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       return selectedFilePath
     },
     get selectedEditorState() {
-      return getEditorState()
+      return editorStore.selectedEditorState
     },
     get selectedDraftDiff() {
-      const editor = getEditorState()
-      if (!editor || !selectedFilePath) {
-        return ''
-      }
-      return buildWholeFileDiff(selectedFilePath, editor.latestSavedContent, editor.draftContent)
+      return editorStore.selectedDraftDiff
     },
     reset,
     refreshWorkspace,
     toggleDir,
     openRepo,
     selectFile,
-    setSelectedViewMode,
-    updateSelectedDraft,
-    revertSelectedDraft,
-    keepSelectedDraft,
-    reloadSelectedSavedVersion,
-    saveSelectedFile,
+    setSelectedViewMode: editorStore.setSelectedViewMode,
+    updateSelectedDraft: editorStore.updateSelectedDraft,
+    revertSelectedDraft: editorStore.revertSelectedDraft,
+    keepSelectedDraft: editorStore.keepSelectedDraft,
+    reloadSelectedSavedVersion: editorStore.reloadSelectedSavedVersion,
+    saveSelectedFile: editorStore.saveSelectedFile,
   }
 }
+
+export type ProjectConversationWorkspaceBrowserState = ReturnType<
+  typeof createProjectConversationWorkspaceBrowserState
+>

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,13 +1,41 @@
+import { ApiError } from '$lib/api/client'
 import {
   getProjectConversationWorkspace,
+  getProjectConversationWorkspaceDiff,
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
+  saveProjectConversationWorkspaceFile,
+  type ProjectConversationWorkspaceDiff,
   type ProjectConversationWorkspaceFilePatch,
   type ProjectConversationWorkspaceFilePreview,
   type ProjectConversationWorkspaceMetadata,
   type ProjectConversationWorkspaceTreeEntry,
 } from '$lib/api/chat'
+import {
+  deletePersistedWorkspaceFileDraft,
+  loadPersistedWorkspaceFileDraft,
+  savePersistedWorkspaceFileDraft,
+  type WorkspaceFileSavePhase,
+  type WorkspaceFileViewMode,
+  workspaceFileDraftStorageKey,
+} from './project-conversation-workspace-file-drafts'
+
+export type WorkspaceFileEditorState = {
+  baseSavedContent: string
+  baseSavedRevision: string
+  latestSavedContent: string
+  latestSavedRevision: string
+  draftContent: string
+  dirty: boolean
+  viewMode: WorkspaceFileViewMode
+  savePhase: WorkspaceFileSavePhase
+  externalChange: boolean
+  errorMessage: string
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
+  lastSavedAt: string
+}
 
 function areTreeEntriesEqual(
   left: ProjectConversationWorkspaceTreeEntry[] | undefined,
@@ -78,7 +106,12 @@ function areFilePreviewEqual(
     left.mediaType === right.mediaType &&
     left.previewKind === right.previewKind &&
     left.truncated === right.truncated &&
-    left.content === right.content
+    left.content === right.content &&
+    left.revision === right.revision &&
+    left.writable === right.writable &&
+    left.readOnlyReason === right.readOnlyReason &&
+    left.encoding === right.encoding &&
+    left.lineEnding === right.lineEnding
   )
 }
 
@@ -98,14 +131,52 @@ function areFilePatchEqual(
   )
 }
 
+function createInitialEditorState(
+  preview: ProjectConversationWorkspaceFilePreview,
+): WorkspaceFileEditorState {
+  return {
+    baseSavedContent: preview.content,
+    baseSavedRevision: preview.revision,
+    latestSavedContent: preview.content,
+    latestSavedRevision: preview.revision,
+    draftContent: preview.content,
+    dirty: false,
+    viewMode: 'preview',
+    savePhase: 'idle',
+    externalChange: false,
+    errorMessage: '',
+    encoding: preview.encoding,
+    lineEnding: preview.lineEnding,
+    lastSavedAt: '',
+  }
+}
+
+function buildWholeFileDiff(filePath: string, savedContent: string, draftContent: string) {
+  if (savedContent === draftContent) {
+    return ''
+  }
+  const oldLines = savedContent.split('\n')
+  const newLines = draftContent.split('\n')
+  const oldCount = savedContent === '' ? 0 : oldLines.length
+  const newCount = draftContent === '' ? 0 : newLines.length
+  const diffLines = [
+    `--- saved/${filePath}`,
+    `+++ draft/${filePath}`,
+    `@@ -1,${oldCount} +1,${newCount} @@`,
+    ...oldLines.map((line) => `-${line}`),
+    ...newLines.map((line) => `+${line}`),
+  ]
+  return diffLines.join('\n')
+}
+
 export function createProjectConversationWorkspaceBrowserState(input: {
   getConversationId: () => string
+  onWorkspaceDiffUpdated?: (workspaceDiff: ProjectConversationWorkspaceDiff | null) => void
 }) {
   let metadata = $state<ProjectConversationWorkspaceMetadata | null>(null)
   let metadataLoading = $state(false)
   let metadataError = $state('')
 
-  // Recursive tree: directory path → child entries
   let treeNodes = $state<Map<string, ProjectConversationWorkspaceTreeEntry[]>>(new Map())
   let expandedDirs = $state<Set<string>>(new Set())
   let loadingDirs = $state<Set<string>>(new Set())
@@ -117,6 +188,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   let selectedRepoPath = $state('')
   let selectedFilePath = $state('')
   let loadRequestID = 0
+  let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
 
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
     if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) {
@@ -189,6 +261,112 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     }
   }
 
+  function selectedFileStorageKey(repoPath = selectedRepoPath, filePath = selectedFilePath) {
+    return workspaceFileDraftStorageKey({
+      conversationId: input.getConversationId(),
+      repoPath,
+      filePath,
+    })
+  }
+
+  function getEditorState(repoPath = selectedRepoPath, filePath = selectedFilePath) {
+    if (!repoPath || !filePath) {
+      return null
+    }
+    return editorStates.get(selectedFileStorageKey(repoPath, filePath)) ?? null
+  }
+
+  function setEditorState(
+    repoPath: string,
+    filePath: string,
+    nextState: WorkspaceFileEditorState | null,
+  ) {
+    const key = selectedFileStorageKey(repoPath, filePath)
+    const nextEditorStates = new Map(editorStates)
+    if (nextState) {
+      nextEditorStates.set(key, nextState)
+      if (nextState.dirty) {
+        savePersistedWorkspaceFileDraft(key, {
+          draftContent: nextState.draftContent,
+          baseSavedContent: nextState.baseSavedContent,
+          baseSavedRevision: nextState.baseSavedRevision,
+          viewMode: nextState.viewMode,
+          encoding: nextState.encoding,
+          lineEnding: nextState.lineEnding,
+          updatedAt: new Date().toISOString(),
+        })
+      } else {
+        deletePersistedWorkspaceFileDraft(key)
+      }
+    } else {
+      nextEditorStates.delete(key)
+      deletePersistedWorkspaceFileDraft(key)
+    }
+    editorStates = nextEditorStates
+  }
+
+  function syncEditorStateFromPreview(
+    repoPath: string,
+    filePath: string,
+    nextPreview: ProjectConversationWorkspaceFilePreview,
+  ) {
+    const key = selectedFileStorageKey(repoPath, filePath)
+    const existing = editorStates.get(key)
+    if (!existing) {
+      const persisted = loadPersistedWorkspaceFileDraft(key)
+      if (!persisted) {
+        setEditorState(repoPath, filePath, createInitialEditorState(nextPreview))
+        return
+      }
+      const dirty = persisted.draftContent !== nextPreview.content
+      setEditorState(repoPath, filePath, {
+        baseSavedContent: persisted.baseSavedContent,
+        baseSavedRevision: persisted.baseSavedRevision,
+        latestSavedContent: nextPreview.content,
+        latestSavedRevision: nextPreview.revision,
+        draftContent: persisted.draftContent,
+        dirty,
+        viewMode: dirty ? 'edit' : persisted.viewMode,
+        savePhase: 'idle',
+        externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
+        errorMessage: '',
+        encoding: nextPreview.encoding,
+        lineEnding: nextPreview.lineEnding,
+        lastSavedAt: '',
+      })
+      return
+    }
+
+    if (existing.dirty) {
+      const latestChanged = existing.latestSavedRevision !== nextPreview.revision
+      setEditorState(repoPath, filePath, {
+        ...existing,
+        latestSavedContent: nextPreview.content,
+        latestSavedRevision: nextPreview.revision,
+        dirty: existing.draftContent !== nextPreview.content,
+        externalChange: latestChanged || existing.baseSavedRevision !== nextPreview.revision,
+        encoding: nextPreview.encoding,
+        lineEnding: nextPreview.lineEnding,
+      })
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...existing,
+      baseSavedContent: nextPreview.content,
+      baseSavedRevision: nextPreview.revision,
+      latestSavedContent: nextPreview.content,
+      latestSavedRevision: nextPreview.revision,
+      draftContent: nextPreview.content,
+      dirty: false,
+      externalChange: false,
+      savePhase: 'idle',
+      errorMessage: '',
+      encoding: nextPreview.encoding,
+      lineEnding: nextPreview.lineEnding,
+    })
+  }
+
   function reset() {
     metadata = null
     metadataLoading = false
@@ -202,6 +380,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     fileError = ''
     selectedRepoPath = ''
     selectedFilePath = ''
+    editorStates = new Map()
   }
 
   async function refreshWorkspace(preserveSelection: boolean) {
@@ -249,14 +428,12 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       await loadDirEntries('', requestID, { silent: treeNodes.has('') })
       if (requestID !== loadRequestID) return
 
-      // Re-expand previously expanded directories
       if (prevExpanded.length > 0) {
         await Promise.all(
           prevExpanded.map((dir) => loadDirEntries(dir, requestID, { silent: treeNodes.has(dir) })),
         )
       }
 
-      // Reload selected file if preserved
       if (preserveSelection && selectedFilePath && !repoChanged) {
         await loadFile(selectedFilePath, {
           requestID,
@@ -303,7 +480,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
 
       setTreeEntries(dirPath, payload.workspaceTree.entries)
     } catch {
-      // Individual directory load failures are silent — the directory shows as empty.
       setTreeEntries(dirPath, [])
     } finally {
       if (!silent) {
@@ -392,6 +568,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       if (requestID !== loadRequestID || path !== selectedFilePath) return
       setPreview(previewPayload.filePreview)
       setPatch(patchPayload.filePatch)
+      syncEditorStateFromPreview(selectedRepoPath, path, previewPayload.filePreview)
     } catch (error) {
       if (requestID !== loadRequestID || path !== selectedFilePath) return
       setPreview(null)
@@ -422,6 +599,183 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     selectedFilePath = path
     void revealFileInTree(path, { requestID, silent: true })
     void loadFile(path, { requestID })
+  }
+
+  function setSelectedViewMode(viewMode: WorkspaceFileViewMode) {
+    const editor = getEditorState()
+    if (!editor || !selectedRepoPath || !selectedFilePath) {
+      return
+    }
+    setEditorState(selectedRepoPath, selectedFilePath, { ...editor, viewMode })
+  }
+
+  function updateSelectedDraft(nextDraftContent: string) {
+    const editor = getEditorState()
+    if (!editor || !selectedRepoPath || !selectedFilePath) {
+      return
+    }
+    const dirty = nextDraftContent !== editor.latestSavedContent
+    setEditorState(selectedRepoPath, selectedFilePath, {
+      ...editor,
+      draftContent: nextDraftContent,
+      dirty,
+      viewMode: 'edit',
+      savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
+      errorMessage: '',
+    })
+  }
+
+  function revertSelectedDraft() {
+    const editor = getEditorState()
+    if (!editor || !selectedRepoPath || !selectedFilePath) {
+      return
+    }
+    setEditorState(selectedRepoPath, selectedFilePath, {
+      ...editor,
+      baseSavedContent: editor.latestSavedContent,
+      baseSavedRevision: editor.latestSavedRevision,
+      draftContent: editor.latestSavedContent,
+      dirty: false,
+      savePhase: 'idle',
+      externalChange: false,
+      errorMessage: '',
+      viewMode: 'preview',
+    })
+  }
+
+  function keepSelectedDraft() {
+    const editor = getEditorState()
+    if (!editor || !selectedRepoPath || !selectedFilePath) {
+      return
+    }
+    setEditorState(selectedRepoPath, selectedFilePath, {
+      ...editor,
+      baseSavedContent: editor.latestSavedContent,
+      baseSavedRevision: editor.latestSavedRevision,
+      dirty: editor.draftContent !== editor.latestSavedContent,
+      savePhase: 'idle',
+      externalChange: false,
+      errorMessage: '',
+      viewMode: 'edit',
+    })
+  }
+
+  function reloadSelectedSavedVersion() {
+    revertSelectedDraft()
+  }
+
+  async function refreshWorkspaceDiff() {
+    const conversationId = input.getConversationId()
+    if (!conversationId || !input.onWorkspaceDiffUpdated) {
+      return
+    }
+    const payload = await getProjectConversationWorkspaceDiff(conversationId)
+    input.onWorkspaceDiffUpdated(payload.workspaceDiff)
+  }
+
+  async function saveSelectedFile() {
+    const conversationId = input.getConversationId()
+    const editor = getEditorState()
+    if (
+      !conversationId ||
+      !selectedRepoPath ||
+      !selectedFilePath ||
+      !editor ||
+      !preview?.writable
+    ) {
+      return
+    }
+    if (!editor.dirty || editor.savePhase === 'saving') {
+      return
+    }
+
+    setEditorState(selectedRepoPath, selectedFilePath, {
+      ...editor,
+      savePhase: 'saving',
+      errorMessage: '',
+    })
+
+    try {
+      const payload = await saveProjectConversationWorkspaceFile(conversationId, {
+        repoPath: selectedRepoPath,
+        path: selectedFilePath,
+        baseRevision: editor.baseSavedRevision,
+        content: editor.draftContent,
+        encoding: editor.encoding,
+        lineEnding: editor.lineEnding,
+      })
+      const nextEditor = getEditorState()
+      if (!nextEditor) {
+        return
+      }
+      const now = new Date().toISOString()
+      setEditorState(selectedRepoPath, selectedFilePath, {
+        ...nextEditor,
+        baseSavedContent: nextEditor.draftContent,
+        baseSavedRevision: payload.file.revision,
+        latestSavedContent: nextEditor.draftContent,
+        latestSavedRevision: payload.file.revision,
+        dirty: false,
+        savePhase: 'idle',
+        externalChange: false,
+        errorMessage: '',
+        lastSavedAt: now,
+      })
+      await loadFile(selectedFilePath, { silent: true })
+      try {
+        await refreshWorkspaceDiff()
+      } catch {
+        const refreshedEditor = getEditorState()
+        if (refreshedEditor) {
+          setEditorState(selectedRepoPath, selectedFilePath, {
+            ...refreshedEditor,
+            errorMessage: 'Saved, but the workspace summary could not be refreshed.',
+          })
+        }
+      }
+    } catch (error) {
+      const latestEditor = getEditorState()
+      if (!latestEditor) {
+        return
+      }
+      if (
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.code === 'PROJECT_CONVERSATION_WORKSPACE_FILE_CONFLICT'
+      ) {
+        const currentFile = (
+          error.details as { current_file?: ProjectConversationWorkspaceFilePreview } | undefined
+        )?.current_file
+        if (currentFile) {
+          setEditorState(selectedRepoPath, selectedFilePath, {
+            ...latestEditor,
+            latestSavedContent: currentFile.content,
+            latestSavedRevision: currentFile.revision,
+            dirty: latestEditor.draftContent !== currentFile.content,
+            savePhase: 'conflict',
+            externalChange: true,
+            errorMessage: 'The workspace file changed before your save completed.',
+            encoding: currentFile.encoding,
+            lineEnding: currentFile.lineEnding,
+            viewMode: 'diff',
+          })
+          setPreview(currentFile)
+        } else {
+          setEditorState(selectedRepoPath, selectedFilePath, {
+            ...latestEditor,
+            savePhase: 'conflict',
+            externalChange: true,
+            errorMessage: error.message,
+          })
+        }
+        return
+      }
+      setEditorState(selectedRepoPath, selectedFilePath, {
+        ...latestEditor,
+        savePhase: 'error',
+        errorMessage: error instanceof Error ? error.message : 'Failed to save the workspace file.',
+      })
+    }
   }
 
   return {
@@ -461,10 +815,26 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     get selectedFilePath() {
       return selectedFilePath
     },
+    get selectedEditorState() {
+      return getEditorState()
+    },
+    get selectedDraftDiff() {
+      const editor = getEditorState()
+      if (!editor || !selectedFilePath) {
+        return ''
+      }
+      return buildWholeFileDiff(selectedFilePath, editor.latestSavedContent, editor.draftContent)
+    },
     reset,
     refreshWorkspace,
     toggleDir,
     openRepo,
     selectFile,
+    setSelectedViewMode,
+    updateSelectedDraft,
+    revertSelectedDraft,
+    keepSelectedDraft,
+    reloadSelectedSavedVersion,
+    saveSelectedFile,
   }
 }

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 import { ApiError } from '$lib/api/client'
 import {
   getProjectConversationWorkspace,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,23 +1,31 @@
 import {
   getProjectConversationWorkspace,
   getProjectConversationWorkspaceDiff,
-  getProjectConversationWorkspaceFilePatch,
-  getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
   type ProjectConversationWorkspaceDiff,
-  type ProjectConversationWorkspaceFilePatch,
-  type ProjectConversationWorkspaceFilePreview,
   type ProjectConversationWorkspaceMetadata,
   type ProjectConversationWorkspaceTreeEntry,
 } from '$lib/api/chat'
 import { createWorkspaceFileEditorStore } from './project-conversation-workspace-file-editor-state.svelte'
+import { loadWorkspaceFile } from './project-conversation-workspace-data-loader'
 import {
-  areFilePatchEqual,
-  areFilePreviewEqual,
+  EMPTY_TAB_FILE_STATE,
+  applyCloseTab,
+  applyOpenTab,
   areTreeEntriesEqual,
   areWorkspaceMetadataEqual,
+  deleteTabFileStateMap,
+  patchTabFileStateMap,
+  workspaceTabKey,
+  type WorkspaceTab,
+  type WorkspaceTabFileState,
 } from './project-conversation-workspace-browser-state-helpers'
-export type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state-helpers'
+export type {
+  WorkspaceFileEditorState,
+  WorkspaceTab,
+  WorkspaceTabFileState,
+} from './project-conversation-workspace-browser-state-helpers'
+export { workspaceTabKey } from './project-conversation-workspace-browser-state-helpers'
 
 export function createProjectConversationWorkspaceBrowserState(input: {
   getConversationId: () => string
@@ -31,12 +39,13 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   let expandedDirs = $state<Set<string>>(new Set())
   let loadingDirs = $state<Set<string>>(new Set())
 
-  let preview = $state<ProjectConversationWorkspaceFilePreview | null>(null)
-  let patch = $state<ProjectConversationWorkspaceFilePatch | null>(null)
-  let fileLoading = $state(false)
-  let fileError = $state('')
-  let selectedRepoPath = $state('')
-  let selectedFilePath = $state('')
+  // Tab state. `treeRepoPath` is the repo whose tree the sidebar is currently
+  // showing — it is independent from the active tab so the user can browse one
+  // repo while a tab from another repo is focused.
+  let openTabs = $state<WorkspaceTab[]>([])
+  let activeTabKey = $state('')
+  let tabFileStates = $state<Map<string, WorkspaceTabFileState>>(new Map())
+  let treeRepoPath = $state('')
   let loadRequestID = 0
 
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
@@ -83,29 +92,65 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     expandedDirs = nextExpandedDirs
   }
 
-  function setPreview(nextPreview: ProjectConversationWorkspaceFilePreview | null) {
-    if (nextPreview == null) {
-      if (preview !== null) {
-        preview = null
-      }
-      return
-    }
-    if (!areFilePreviewEqual(preview, nextPreview)) {
-      preview = nextPreview
+  // ─────────────────────────── tab helpers ──────────────────────────────────
+
+  function getActiveTab(): WorkspaceTab | null {
+    if (!activeTabKey) return null
+    return openTabs.find((t) => workspaceTabKey(t) === activeTabKey) ?? null
+  }
+
+  function getActiveTabFileState(): WorkspaceTabFileState {
+    return tabFileStates.get(activeTabKey) ?? EMPTY_TAB_FILE_STATE
+  }
+
+  function patchTabFileState(key: string, patch: Partial<WorkspaceTabFileState>) {
+    tabFileStates = patchTabFileStateMap(tabFileStates, key, patch)
+  }
+
+  function activateTabKey(key: string) {
+    if (activeTabKey === key) return
+    activeTabKey = key
+    const tab = getActiveTab()
+    if (tab) treeRepoPath = tab.repoPath
+  }
+
+  function openTab(repoPath: string, filePath: string) {
+    if (!repoPath || !filePath) return
+    const next = applyOpenTab(openTabs, repoPath, filePath)
+    openTabs = next.openTabs
+    activeTabKey = next.activeTabKey
+    treeRepoPath = next.treeRepoPath
+    // Load file content lazily — only fetch if the tab doesn't already have a
+    // preview cached. (Reloads after save go through reloadFile directly.)
+    const cached = tabFileStates.get(next.activeTabKey)
+    if (!cached || !cached.preview) {
+      void loadFile(repoPath, filePath, { silent: cached?.preview != null })
     }
   }
 
-  function setPatch(nextPatch: ProjectConversationWorkspaceFilePatch | null) {
-    if (nextPatch == null) {
-      if (patch !== null) {
-        patch = null
-      }
-      return
-    }
-    if (!areFilePatchEqual(patch, nextPatch)) {
-      patch = nextPatch
-    }
+  function closeTab(repoPath: string, filePath: string) {
+    const next = applyCloseTab(openTabs, activeTabKey, repoPath, filePath)
+    if (!next) return
+    const key = workspaceTabKey({ repoPath, filePath })
+    openTabs = next.openTabs
+    tabFileStates = deleteTabFileStateMap(tabFileStates, key)
+    activeTabKey = next.activeTabKey
+    if (next.nextTreeRepo) treeRepoPath = next.nextTreeRepo
   }
+
+  function closeAllTabs() {
+    openTabs = []
+    activeTabKey = ''
+    tabFileStates = new Map()
+  }
+
+  function activateTab(repoPath: string, filePath: string) {
+    const key = workspaceTabKey({ repoPath, filePath })
+    if (!openTabs.some((t) => workspaceTabKey(t) === key)) return
+    activateTabKey(key)
+  }
+
+  // ──────────────────────────── data loading ────────────────────────────────
 
   async function refreshWorkspaceDiff() {
     const conversationId = input.getConversationId()
@@ -118,39 +163,33 @@ export function createProjectConversationWorkspaceBrowserState(input: {
 
   const editorStore = createWorkspaceFileEditorStore({
     getConversationId: input.getConversationId,
-    getSelectedRepoPath: () => selectedRepoPath,
-    getSelectedFilePath: () => selectedFilePath,
-    getPreview: () => preview,
-    setPreview,
-    reloadSelectedFile: async () => {
-      if (selectedFilePath) {
-        await loadFile(selectedFilePath, { silent: true })
+    getSelectedRepoPath: () => getActiveTab()?.repoPath ?? '',
+    getSelectedFilePath: () => getActiveTab()?.filePath ?? '',
+    getPreview: (repoPath, filePath) => {
+      const key = workspaceTabKey({ repoPath, filePath })
+      return tabFileStates.get(key)?.preview ?? null
+    },
+    setPreview: (repoPath, filePath, preview) => {
+      const key = workspaceTabKey({ repoPath, filePath })
+      patchTabFileState(key, { preview })
+    },
+    reloadSelectedFile: async (repoPath, filePath) => {
+      if (repoPath && filePath) {
+        await loadFile(repoPath, filePath, { silent: true })
       }
     },
     refreshWorkspaceDiff,
   })
 
-  function clearSelectionState() {
-    selectedFilePath = ''
-    setPreview(null)
-    setPatch(null)
-    fileError = ''
-  }
-
-  function resetTreeState() {
-    treeNodes = new Map()
-    expandedDirs = new Set()
-    loadingDirs = new Set()
-  }
-
   function reset() {
     metadata = null
     metadataLoading = false
     metadataError = ''
-    resetTreeState()
-    clearSelectionState()
-    fileLoading = false
-    selectedRepoPath = ''
+    treeNodes = new Map()
+    expandedDirs = new Set()
+    loadingDirs = new Set()
+    treeRepoPath = ''
+    closeAllTabs()
     editorStore.reset()
   }
 
@@ -168,26 +207,29 @@ export function createProjectConversationWorkspaceBrowserState(input: {
 
       setMetadata(payload.workspace)
       if (!payload.workspace.available || payload.workspace.repos.length === 0) {
-        selectedRepoPath = ''
-        resetTreeState()
-        clearSelectionState()
+        treeRepoPath = ''
+        treeNodes = new Map()
+        expandedDirs = new Set()
+        loadingDirs = new Set()
+        closeAllTabs()
         return
       }
 
       const nextRepoPath =
         preserveSelection &&
-        payload.workspace.repos.some((repo) => repo.path === selectedRepoPath) &&
-        selectedRepoPath
-          ? selectedRepoPath
+        payload.workspace.repos.some((repo) => repo.path === treeRepoPath) &&
+        treeRepoPath
+          ? treeRepoPath
           : (payload.workspace.repos[0]?.path ?? '')
 
-      const repoChanged = nextRepoPath !== selectedRepoPath
+      const repoChanged = nextRepoPath !== treeRepoPath
       const prevExpanded = repoChanged ? [] : [...expandedDirs]
-      selectedRepoPath = nextRepoPath
+      treeRepoPath = nextRepoPath
 
       if (repoChanged) {
-        resetTreeState()
-        clearSelectionState()
+        treeNodes = new Map()
+        expandedDirs = new Set()
+        loadingDirs = new Set()
       }
 
       await loadDirEntries('', requestID, { silent: treeNodes.has('') })
@@ -203,19 +245,21 @@ export function createProjectConversationWorkspaceBrowserState(input: {
         )
       }
 
-      if (preserveSelection && selectedFilePath && !repoChanged) {
-        await loadFile(selectedFilePath, {
-          requestID,
-          silent: preview != null || patch != null,
-        })
+      // Refresh open tabs' file content silently after a workspace refresh.
+      if (preserveSelection && openTabs.length > 0) {
+        await Promise.all(
+          openTabs.map((tab) => loadFile(tab.repoPath, tab.filePath, { silent: true })),
+        )
       }
     } catch (error) {
       if (requestID !== loadRequestID || conversationId !== input.getConversationId()) {
         return
       }
       metadata = null
-      resetTreeState()
-      clearSelectionState()
+      treeNodes = new Map()
+      expandedDirs = new Set()
+      loadingDirs = new Set()
+      closeAllTabs()
       metadataError =
         error instanceof Error ? error.message : 'Failed to load the Project AI workspace.'
     } finally {
@@ -231,7 +275,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     options: { silent?: boolean } = {},
   ) {
     const conversationId = input.getConversationId()
-    const repoPath = selectedRepoPath
+    const repoPath = treeRepoPath
     if (!repoPath || !conversationId) {
       return
     }
@@ -247,7 +291,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
         repoPath,
         path: dirPath,
       })
-      if (requestID !== loadRequestID || repoPath !== selectedRepoPath) {
+      if (requestID !== loadRequestID || repoPath !== treeRepoPath) {
         return
       }
       setTreeEntries(dirPath, payload.workspaceTree.entries)
@@ -298,7 +342,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     }
 
     for (const dirPath of ancestorDirs) {
-      if (requestID !== loadRequestID || path !== selectedFilePath) {
+      if (requestID !== loadRequestID) {
         return
       }
       setDirExpanded(dirPath, true)
@@ -308,55 +352,29 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     }
   }
 
-  async function loadFile(path: string, options: { requestID?: number; silent?: boolean } = {}) {
-    const conversationId = input.getConversationId()
-    const repoPath = selectedRepoPath
-    if (!repoPath || !conversationId) {
-      clearSelectionState()
-      return
-    }
-
-    const requestID = options.requestID ?? ++loadRequestID
-    const silent = options.silent ?? false
-    if (!silent) {
-      fileLoading = true
-      fileError = ''
-    }
-    selectedFilePath = path
-
-    try {
-      const [previewPayload, patchPayload] = await Promise.all([
-        getProjectConversationWorkspaceFilePreview(conversationId, { repoPath, path }),
-        getProjectConversationWorkspaceFilePatch(conversationId, { repoPath, path }),
-      ])
-      if (requestID !== loadRequestID || path !== selectedFilePath) {
-        return
-      }
-      setPreview(previewPayload.filePreview)
-      setPatch(patchPayload.filePatch)
-      editorStore.syncFromPreview(repoPath, path, previewPayload.filePreview)
-    } catch (error) {
-      if (requestID !== loadRequestID || path !== selectedFilePath) {
-        return
-      }
-      setPreview(null)
-      setPatch(null)
-      fileError =
-        error instanceof Error ? error.message : 'Failed to load the workspace file details.'
-    } finally {
-      if (!silent && requestID === loadRequestID && path === selectedFilePath) {
-        fileLoading = false
-      }
-    }
+  function loadFile(repoPath: string, filePath: string, options: { silent?: boolean } = {}) {
+    return loadWorkspaceFile(
+      {
+        getConversationId: input.getConversationId,
+        hasOpenTab: (key) => openTabs.some((t) => workspaceTabKey(t) === key),
+        getCurrentLoading: (key) => tabFileStates.get(key)?.loading ?? false,
+        patchTabFileState,
+        syncEditorFromPreview: editorStore.syncFromPreview,
+      },
+      repoPath,
+      filePath,
+      options,
+    )
   }
 
   function openRepo(repoPath: string) {
-    if (!repoPath || repoPath === selectedRepoPath) {
+    if (!repoPath || repoPath === treeRepoPath) {
       return
     }
-    selectedRepoPath = repoPath
-    resetTreeState()
-    clearSelectionState()
+    treeRepoPath = repoPath
+    treeNodes = new Map()
+    expandedDirs = new Set()
+    loadingDirs = new Set()
     void loadDirEntries('')
   }
 
@@ -364,10 +382,23 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     if (!path) {
       return
     }
+    const repoPath = treeRepoPath
+    if (!repoPath) {
+      return
+    }
     const requestID = ++loadRequestID
-    selectedFilePath = path
     void revealFileInTree(path, { requestID, silent: true })
-    void loadFile(path, { requestID })
+    openTab(repoPath, path)
+  }
+
+  // Active-file projections kept for backwards compatibility with the rest of
+  // the workspace browser plumbing. Sidebar highlights the active file only
+  // when it lives in the currently browsed repo, matching VS Code's "explorer
+  // follows current tab" feel.
+  function activeFilePath(): string {
+    const tab = getActiveTab()
+    if (!tab || tab.repoPath !== treeRepoPath) return ''
+    return tab.filePath
   }
 
   return {
@@ -389,41 +420,61 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     get loadingDirs() {
       return loadingDirs
     },
+    get openTabs() {
+      return openTabs
+    },
+    get activeTabKey() {
+      return activeTabKey
+    },
+    get tabFileStates() {
+      return tabFileStates
+    },
+    get hasDirtyTabs() {
+      return openTabs.some(
+        (tab) => editorStore.getEditorState(tab.repoPath, tab.filePath)?.dirty === true,
+      )
+    },
     get preview() {
-      return preview
+      return getActiveTabFileState().preview
     },
     get patch() {
-      return patch
+      return getActiveTabFileState().patch
     },
     get fileLoading() {
-      return fileLoading
+      return getActiveTabFileState().loading
     },
     get fileError() {
-      return fileError
+      return getActiveTabFileState().error
     },
     get selectedRepoPath() {
-      return selectedRepoPath
+      return treeRepoPath
     },
     get selectedFilePath() {
-      return selectedFilePath
+      return activeFilePath()
     },
     get selectedEditorState() {
       return editorStore.selectedEditorState
     },
-    get selectedDraftDiff() {
-      return editorStore.selectedDraftDiff
+    get selectedDraftLineDiff() {
+      return editorStore.selectedDraftLineDiff
     },
+    getEditorState: editorStore.getEditorState,
     reset,
     refreshWorkspace,
     toggleDir,
     openRepo,
     selectFile,
-    setSelectedViewMode: editorStore.setSelectedViewMode,
+    openTab,
+    closeTab,
+    closeAllTabs,
+    activateTab,
     updateSelectedDraft: editorStore.updateSelectedDraft,
     revertSelectedDraft: editorStore.revertSelectedDraft,
     keepSelectedDraft: editorStore.keepSelectedDraft,
     reloadSelectedSavedVersion: editorStore.reloadSelectedSavedVersion,
     saveSelectedFile: editorStore.saveSelectedFile,
+    saveFile: editorStore.saveFile,
+    discardDraft: editorStore.discardDraft,
   }
 }
 

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from '@testing-library/svelte'
+
+import { ApiError } from '$lib/api/client'
+
+const {
+  getProjectConversationWorkspace,
+  getProjectConversationWorkspaceDiff,
+  getProjectConversationWorkspaceFilePatch,
+  getProjectConversationWorkspaceFilePreview,
+  listProjectConversationWorkspaceTree,
+  saveProjectConversationWorkspaceFile,
+} = vi.hoisted(() => ({
+  getProjectConversationWorkspace: vi.fn(),
+  getProjectConversationWorkspaceDiff: vi.fn(),
+  getProjectConversationWorkspaceFilePatch: vi.fn(),
+  getProjectConversationWorkspaceFilePreview: vi.fn(),
+  listProjectConversationWorkspaceTree: vi.fn(),
+  saveProjectConversationWorkspaceFile: vi.fn(),
+}))
+
+vi.mock('$lib/api/chat', () => ({
+  getProjectConversationWorkspace,
+  getProjectConversationWorkspaceDiff,
+  getProjectConversationWorkspaceFilePatch,
+  getProjectConversationWorkspaceFilePreview,
+  listProjectConversationWorkspaceTree,
+  saveProjectConversationWorkspaceFile,
+}))
+
+import { createProjectConversationWorkspaceBrowserState } from './project-conversation-workspace-browser-state.svelte'
+
+function mockWorkspaceMetadata() {
+  getProjectConversationWorkspace.mockResolvedValue({
+    workspace: {
+      conversationId: 'conversation-1',
+      available: true,
+      workspacePath: '/tmp/conversation-1',
+      repos: [
+        {
+          name: 'openase',
+          path: 'services/openase',
+          branch: 'feat/ase-162-workspace-editor',
+          headCommit: '123456789abc',
+          headSummary: 'Workspace editor',
+          dirty: true,
+          filesChanged: 1,
+          added: 1,
+          removed: 0,
+        },
+      ],
+    },
+  })
+}
+
+function mockTree() {
+  listProjectConversationWorkspaceTree.mockResolvedValue({
+    workspaceTree: {
+      conversationId: 'conversation-1',
+      repoPath: 'services/openase',
+      path: '',
+      entries: [{ path: 'README.md', name: 'README.md', kind: 'file', sizeBytes: 12 }],
+    },
+  })
+}
+
+function buildPreview(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    conversationId: 'conversation-1',
+    repoPath: 'services/openase',
+    path: 'README.md',
+    sizeBytes: 12,
+    mediaType: 'text/plain',
+    previewKind: 'text',
+    truncated: false,
+    content: 'line one\n',
+    revision: 'rev-1',
+    writable: true,
+    readOnlyReason: '',
+    encoding: 'utf-8',
+    lineEnding: 'lf',
+    ...overrides,
+  }
+}
+
+function mockPatch() {
+  getProjectConversationWorkspaceFilePatch.mockResolvedValue({
+    filePatch: {
+      conversationId: 'conversation-1',
+      repoPath: 'services/openase',
+      path: 'README.md',
+      status: 'modified',
+      diffKind: 'text',
+      truncated: false,
+      diff: '@@ -1 +1 @@\n-line one\n+line two\n',
+    },
+  })
+}
+
+describe('createProjectConversationWorkspaceBrowserState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+    mockWorkspaceMetadata()
+    mockTree()
+    mockPatch()
+    getProjectConversationWorkspaceFilePreview.mockResolvedValue({
+      filePreview: buildPreview(),
+    })
+    saveProjectConversationWorkspaceFile.mockResolvedValue({
+      file: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: 'README.md',
+        revision: 'rev-2',
+        sizeBytes: 21,
+        encoding: 'utf-8',
+        lineEnding: 'lf',
+      },
+    })
+    getProjectConversationWorkspaceDiff.mockResolvedValue({
+      workspaceDiff: {
+        conversationId: 'conversation-1',
+        workspacePath: '/tmp/conversation-1',
+        dirty: true,
+        reposChanged: 1,
+        filesChanged: 1,
+        added: 1,
+        removed: 0,
+        repos: [],
+      },
+    })
+  })
+
+  it('restores a persisted draft for the same conversation repo and file', async () => {
+    const state = createProjectConversationWorkspaceBrowserState({
+      getConversationId: () => 'conversation-1',
+    })
+
+    await state.refreshWorkspace(true)
+    state.selectFile('README.md')
+    await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
+
+    state.setSelectedViewMode('edit')
+    state.updateSelectedDraft('line one\nline two\n')
+
+    const restored = createProjectConversationWorkspaceBrowserState({
+      getConversationId: () => 'conversation-1',
+    })
+    await restored.refreshWorkspace(true)
+    restored.selectFile('README.md')
+
+    await waitFor(() =>
+      expect(restored.selectedEditorState).toMatchObject({
+        draftContent: 'line one\nline two\n',
+        dirty: true,
+        viewMode: 'edit',
+        baseSavedRevision: 'rev-1',
+      }),
+    )
+  })
+
+  it('keeps the local draft and enters conflict mode when save detects a stale revision', async () => {
+    const state = createProjectConversationWorkspaceBrowserState({
+      getConversationId: () => 'conversation-1',
+    })
+
+    await state.refreshWorkspace(true)
+    state.selectFile('README.md')
+    await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
+
+    state.setSelectedViewMode('edit')
+    state.updateSelectedDraft('my local draft\n')
+
+    saveProjectConversationWorkspaceFile.mockRejectedValue(
+      new ApiError(
+        409,
+        'The workspace file changed before your save completed.',
+        'PROJECT_CONVERSATION_WORKSPACE_FILE_CONFLICT',
+        {
+          current_file: buildPreview({
+            content: 'server version\n',
+            revision: 'rev-2',
+          }),
+        },
+      ),
+    )
+
+    await state.saveSelectedFile()
+
+    expect(state.selectedEditorState).toMatchObject({
+      draftContent: 'my local draft\n',
+      latestSavedContent: 'server version\n',
+      latestSavedRevision: 'rev-2',
+      dirty: true,
+      savePhase: 'conflict',
+      externalChange: true,
+      viewMode: 'diff',
+    })
+  })
+
+  it('clears the dirty draft and refreshes workspace diff after a successful save', async () => {
+    const onWorkspaceDiffUpdated = vi.fn()
+    const state = createProjectConversationWorkspaceBrowserState({
+      getConversationId: () => 'conversation-1',
+      onWorkspaceDiffUpdated,
+    })
+
+    getProjectConversationWorkspaceFilePreview.mockResolvedValueOnce({
+      filePreview: buildPreview(),
+    })
+    getProjectConversationWorkspaceFilePreview.mockResolvedValueOnce({
+      filePreview: buildPreview({
+        content: 'line one\nline two\n',
+        revision: 'rev-2',
+        sizeBytes: 21,
+      }),
+    })
+
+    await state.refreshWorkspace(true)
+    state.selectFile('README.md')
+    await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
+
+    state.setSelectedViewMode('edit')
+    state.updateSelectedDraft('line one\nline two\n')
+    await state.saveSelectedFile()
+
+    expect(saveProjectConversationWorkspaceFile).toHaveBeenCalledWith('conversation-1', {
+      repoPath: 'services/openase',
+      path: 'README.md',
+      baseRevision: 'rev-1',
+      content: 'line one\nline two\n',
+      encoding: 'utf-8',
+      lineEnding: 'lf',
+    })
+    await waitFor(() =>
+      expect(state.selectedEditorState).toMatchObject({
+        draftContent: 'line one\nline two\n',
+        baseSavedRevision: 'rev-2',
+        latestSavedRevision: 'rev-2',
+        dirty: false,
+        savePhase: 'idle',
+        externalChange: false,
+      }),
+    )
+    expect(onWorkspaceDiffUpdated).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem('openase.project-conversation.workspace-file-drafts')).toBe(
+      null,
+    )
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
@@ -141,7 +141,6 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
     state.selectFile('README.md')
     await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
 
-    state.setSelectedViewMode('edit')
     state.updateSelectedDraft('line one\nline two\n')
 
     const restored = createProjectConversationWorkspaceBrowserState({
@@ -154,7 +153,6 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
       expect(restored.selectedEditorState).toMatchObject({
         draftContent: 'line one\nline two\n',
         dirty: true,
-        viewMode: 'edit',
         baseSavedRevision: 'rev-1',
       }),
     )
@@ -169,7 +167,6 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
     state.selectFile('README.md')
     await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
 
-    state.setSelectedViewMode('edit')
     state.updateSelectedDraft('my local draft\n')
 
     saveProjectConversationWorkspaceFile.mockRejectedValue(
@@ -195,7 +192,6 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
       dirty: true,
       savePhase: 'conflict',
       externalChange: true,
-      viewMode: 'diff',
     })
   })
 
@@ -221,7 +217,6 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
     state.selectFile('README.md')
     await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
 
-    state.setSelectedViewMode('edit')
     state.updateSelectedDraft('line one\nline two\n')
     await state.saveSelectedFile()
 
@@ -247,5 +242,115 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
     expect(window.localStorage.getItem('openase.project-conversation.workspace-file-drafts')).toBe(
       null,
     )
+  })
+
+  it('keeps drafts isolated across tabs and can save a non-active dirty tab', async () => {
+    listProjectConversationWorkspaceTree.mockResolvedValue({
+      workspaceTree: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: '',
+        entries: [
+          { path: 'README.md', name: 'README.md', kind: 'file', sizeBytes: 12 },
+          { path: 'package.json', name: 'package.json', kind: 'file', sizeBytes: 18 },
+        ],
+      },
+    })
+    getProjectConversationWorkspaceFilePatch.mockImplementation(async (_conversationId, input) => {
+      return {
+        filePatch: {
+          conversationId: 'conversation-1',
+          repoPath: 'services/openase',
+          path: input.path,
+          status: 'modified',
+          diffKind: 'text',
+          truncated: false,
+          diff: '',
+        },
+      }
+    })
+    saveProjectConversationWorkspaceFile.mockResolvedValue({
+      file: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: 'README.md',
+        revision: 'rev-2',
+        sizeBytes: 13,
+        encoding: 'utf-8',
+        lineEnding: 'lf',
+      },
+    })
+
+    let readmeLoads = 0
+    getProjectConversationWorkspaceFilePreview.mockImplementation(async (_conversationId, input) => {
+      if (input.path === 'README.md') {
+        readmeLoads += 1
+        return {
+          filePreview:
+            readmeLoads === 1
+              ? buildPreview()
+              : buildPreview({
+                  content: 'readme updated\n',
+                  revision: 'rev-2',
+                  sizeBytes: 15,
+                }),
+        }
+      }
+      return {
+        filePreview: buildPreview({
+          path: 'package.json',
+          sizeBytes: 18,
+          mediaType: 'application/json',
+          content: '{"name":"pkg"}\n',
+          revision: 'pkg-rev-1',
+        }),
+      }
+    })
+
+    const state = createProjectConversationWorkspaceBrowserState({
+      getConversationId: () => 'conversation-1',
+    })
+
+    await state.refreshWorkspace(true)
+    state.selectFile('README.md')
+    await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('line one\n'))
+
+    state.updateSelectedDraft('readme updated\n')
+
+    state.selectFile('package.json')
+    await waitFor(() => expect(state.selectedEditorState?.draftContent).toBe('{"name":"pkg"}\n'))
+
+    expect(state.openTabs).toHaveLength(2)
+    expect(state.getEditorState('services/openase', 'README.md')).toMatchObject({
+      draftContent: 'readme updated\n',
+      dirty: true,
+    })
+    expect(state.getEditorState('services/openase', 'package.json')).toMatchObject({
+      draftContent: '{"name":"pkg"}\n',
+      dirty: false,
+    })
+
+    const saved = await state.saveFile('services/openase', 'README.md')
+    expect(saved).toBe(true)
+
+    expect(saveProjectConversationWorkspaceFile).toHaveBeenCalledWith('conversation-1', {
+      repoPath: 'services/openase',
+      path: 'README.md',
+      baseRevision: 'rev-1',
+      content: 'readme updated\n',
+      encoding: 'utf-8',
+      lineEnding: 'lf',
+    })
+    await waitFor(() =>
+      expect(state.getEditorState('services/openase', 'README.md')).toMatchObject({
+        draftContent: 'readme updated\n',
+        baseSavedRevision: 'rev-2',
+        dirty: false,
+      }),
+    )
+    expect(state.selectedEditorState).toMatchObject({
+      draftContent: '{"name":"pkg"}\n',
+      dirty: false,
+    })
   })
 })

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.test.ts
@@ -282,30 +282,32 @@ describe('createProjectConversationWorkspaceBrowserState', () => {
     })
 
     let readmeLoads = 0
-    getProjectConversationWorkspaceFilePreview.mockImplementation(async (_conversationId, input) => {
-      if (input.path === 'README.md') {
-        readmeLoads += 1
-        return {
-          filePreview:
-            readmeLoads === 1
-              ? buildPreview()
-              : buildPreview({
-                  content: 'readme updated\n',
-                  revision: 'rev-2',
-                  sizeBytes: 15,
-                }),
+    getProjectConversationWorkspaceFilePreview.mockImplementation(
+      async (_conversationId, input) => {
+        if (input.path === 'README.md') {
+          readmeLoads += 1
+          return {
+            filePreview:
+              readmeLoads === 1
+                ? buildPreview()
+                : buildPreview({
+                    content: 'readme updated\n',
+                    revision: 'rev-2',
+                    sizeBytes: 15,
+                  }),
+          }
         }
-      }
-      return {
-        filePreview: buildPreview({
-          path: 'package.json',
-          sizeBytes: 18,
-          mediaType: 'application/json',
-          content: '{"name":"pkg"}\n',
-          revision: 'pkg-rev-1',
-        }),
-      }
-    })
+        return {
+          filePreview: buildPreview({
+            path: 'package.json',
+            sizeBytes: 18,
+            mediaType: 'application/json',
+            content: '{"name":"pkg"}\n',
+            revision: 'pkg-rev-1',
+          }),
+        }
+      },
+    )
 
     const state = createProjectConversationWorkspaceBrowserState({
       getConversationId: () => 'conversation-1',

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -142,18 +142,31 @@
         }
         event.preventDefault()
         void browser.saveSelectedFile()
-        return
-      }
-
-      if (event.key === 'Escape' && editorState.viewMode === 'edit') {
-        event.preventDefault()
-        browser.setSelectedViewMode('preview')
       }
     }
 
     window.addEventListener('keydown', handleKeydown)
     return () => {
       window.removeEventListener('keydown', handleKeydown)
+    }
+  })
+
+  $effect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!browser.hasDirtyTabs) {
+        return
+      }
+      event.preventDefault()
+      event.returnValue = ''
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
     }
   })
 
@@ -179,7 +192,7 @@
         conversationId,
         repoPath: browser.selectedRepoPath,
         filePath: browser.selectedFilePath,
-        selectedArea: editorState.viewMode,
+        selectedArea: 'edit',
         hasDirtyDraft: editorState.dirty,
         draftContent: editorState.dirty ? editorState.draftContent : undefined,
         encoding: editorState.encoding,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -3,6 +3,7 @@
   import { untrack } from 'svelte'
   import { Button } from '$ui/button'
   import { cn } from '$lib/utils'
+  import { appStore } from '$lib/stores/app.svelte'
   import {
     AlertCircle,
     Check,
@@ -13,6 +14,7 @@
     X,
   } from '@lucide/svelte'
   import type { ProjectConversationWorkspaceDiff } from '$lib/api/chat'
+  import { PROJECT_AI_FOCUS_PRIORITY } from './project-ai-focus'
   import WorkspaceTerminalPanel from './workspace-terminal-panel.svelte'
   import ProjectConversationWorkspaceBrowserDetail from './project-conversation-workspace-browser-detail.svelte'
   import ProjectConversationWorkspaceBrowserSidebar from './project-conversation-workspace-browser-sidebar.svelte'
@@ -24,6 +26,7 @@
     conversationId = '',
     workspaceDiff = null,
     workspaceDiffLoading = false,
+    runtimeActive = false,
     pendingFilePath = '',
     onClose,
     onPendingFileConsumed,
@@ -31,14 +34,21 @@
     conversationId?: string
     workspaceDiff?: ProjectConversationWorkspaceDiff | null
     workspaceDiffLoading?: boolean
+    runtimeActive?: boolean
     /** File path to navigate to (consumed once on change). */
     pendingFilePath?: string
     onClose?: () => void
     onPendingFileConsumed?: () => void
   } = $props()
 
+  const projectAIFocusOwner = 'project-conversation-workspace-browser'
+  let liveWorkspaceDiff = $state<ProjectConversationWorkspaceDiff | null>(null)
+
   const browser = createProjectConversationWorkspaceBrowserState({
     getConversationId: () => conversationId,
+    onWorkspaceDiffUpdated: (nextWorkspaceDiff) => {
+      liveWorkspaceDiff = nextWorkspaceDiff
+    },
   })
 
   const terminalManager = createTerminalManager({
@@ -132,8 +142,12 @@
       null,
   )
   const selectedRepoDiff = $derived(
-    workspaceDiff?.repos.find((repo) => repo.path === browser.selectedRepoPath) ?? null,
+    liveWorkspaceDiff?.repos.find((repo) => repo.path === browser.selectedRepoPath) ?? null,
   )
+
+  $effect(() => {
+    liveWorkspaceDiff = workspaceDiff ?? null
+  })
 
   // Navigate to a pending file when set
   $effect(() => {
@@ -177,6 +191,74 @@
     untrack(() => {
       void browser.refreshWorkspace(true)
     })
+  })
+
+  $effect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      const editorState = browser.selectedEditorState
+      if (!editorState) {
+        return
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+        if (!editorState.dirty || !browser.preview?.writable) {
+          return
+        }
+        event.preventDefault()
+        void browser.saveSelectedFile()
+        return
+      }
+
+      if (event.key === 'Escape' && editorState.viewMode === 'edit') {
+        event.preventDefault()
+        browser.setSelectedViewMode('preview')
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  })
+
+  $effect(() => {
+    const projectId = appStore.currentProject?.id ?? ''
+    const editorState = browser.selectedEditorState
+    if (
+      !projectId ||
+      !conversationId ||
+      !browser.selectedRepoPath ||
+      !browser.selectedFilePath ||
+      !editorState
+    ) {
+      appStore.clearProjectAssistantFocus(projectAIFocusOwner)
+      return
+    }
+
+    appStore.setProjectAssistantFocus(
+      projectAIFocusOwner,
+      {
+        kind: 'workspace_file',
+        projectId,
+        conversationId,
+        repoPath: browser.selectedRepoPath,
+        filePath: browser.selectedFilePath,
+        selectedArea: editorState.viewMode,
+        hasDirtyDraft: editorState.dirty,
+        draftContent: editorState.dirty ? editorState.draftContent : undefined,
+        encoding: editorState.encoding,
+        lineEnding: editorState.lineEnding,
+      },
+      PROJECT_AI_FOCUS_PRIORITY.workspace,
+    )
+
+    return () => {
+      appStore.clearProjectAssistantFocus(projectAIFocusOwner)
+    }
   })
 </script>
 
@@ -319,8 +401,17 @@
             selectedFilePath={browser.selectedFilePath}
             preview={browser.preview}
             patch={browser.patch}
+            editorState={browser.selectedEditorState}
+            draftDiff={browser.selectedDraftDiff}
             fileLoading={browser.fileLoading}
             fileError={browser.fileError}
+            {runtimeActive}
+            onViewModeChange={browser.setSelectedViewMode}
+            onDraftChange={browser.updateSelectedDraft}
+            onSave={() => void browser.saveSelectedFile()}
+            onRevert={browser.revertSelectedDraft}
+            onKeepDraft={browser.keepSelectedDraft}
+            onReloadSavedVersion={browser.reloadSelectedSavedVersion}
           />
         </div>
       </div>

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -42,12 +42,13 @@
   } = $props()
 
   const projectAIFocusOwner = 'project-conversation-workspace-browser'
-  let liveWorkspaceDiff = $state<ProjectConversationWorkspaceDiff | null>(null)
+  let refreshedWorkspaceDiff = $state<ProjectConversationWorkspaceDiff | null>(null)
+  const liveWorkspaceDiff = $derived(refreshedWorkspaceDiff ?? workspaceDiff ?? null)
 
   const browser = createProjectConversationWorkspaceBrowserState({
     getConversationId: () => conversationId,
     onWorkspaceDiffUpdated: (nextWorkspaceDiff) => {
-      liveWorkspaceDiff = nextWorkspaceDiff
+      refreshedWorkspaceDiff = nextWorkspaceDiff
     },
   })
 
@@ -144,10 +145,6 @@
   const selectedRepoDiff = $derived(
     liveWorkspaceDiff?.repos.find((repo) => repo.path === browser.selectedRepoPath) ?? null,
   )
-
-  $effect(() => {
-    liveWorkspaceDiff = workspaceDiff ?? null
-  })
 
   // Navigate to a pending file when set
   $effect(() => {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
-  import { untrack } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import { Button } from '$ui/button'
   import { cn } from '$lib/utils'
   import { appStore } from '$lib/stores/app.svelte'
@@ -15,12 +14,9 @@
   } from '@lucide/svelte'
   import type { ProjectConversationWorkspaceDiff } from '$lib/api/chat'
   import { PROJECT_AI_FOCUS_PRIORITY } from './project-ai-focus'
-  import WorkspaceTerminalPanel from './workspace-terminal-panel.svelte'
-  import ProjectConversationWorkspaceBrowserDetail from './project-conversation-workspace-browser-detail.svelte'
-  import ProjectConversationWorkspaceBrowserSidebar from './project-conversation-workspace-browser-sidebar.svelte'
+  import ProjectConversationWorkspaceBrowserPane from './project-conversation-workspace-browser-pane.svelte'
   import { createProjectConversationWorkspaceBrowserState } from './project-conversation-workspace-browser-state.svelte'
   import { createTerminalManager } from './terminal-manager.svelte'
-  import { onDestroy } from 'svelte'
 
   let {
     conversationId = '',
@@ -69,67 +65,6 @@
     navigator.clipboard.writeText(path)
     pathCopied = true
     setTimeout(() => (pathCopied = false), 1500)
-  }
-
-  // -- Sidebar resize --
-  const MIN_SIDEBAR_WIDTH = 180
-  const MAX_SIDEBAR_WIDTH = 480
-  let sidebarWidth = $state(240)
-  let sidebarResizing = $state(false)
-
-  function handleSidebarResizeStart(event: PointerEvent) {
-    event.preventDefault()
-    sidebarResizing = true
-    const startX = event.clientX
-    const startWidth = sidebarWidth
-
-    function onMove(e: PointerEvent) {
-      sidebarWidth = Math.min(
-        MAX_SIDEBAR_WIDTH,
-        Math.max(MIN_SIDEBAR_WIDTH, startWidth + (e.clientX - startX)),
-      )
-    }
-
-    function onUp() {
-      sidebarResizing = false
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-    }
-
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-  }
-
-  // -- Terminal panel vertical resize --
-  const MIN_TERMINAL_HEIGHT = 120
-  const DEFAULT_TERMINAL_HEIGHT = 260
-  let terminalHeight = $state(DEFAULT_TERMINAL_HEIGHT)
-  let terminalResizing = $state(false)
-  let containerElement: HTMLDivElement | null = null
-
-  function handleTerminalResizeStart(event: PointerEvent) {
-    event.preventDefault()
-    terminalResizing = true
-    const startY = event.clientY
-    const startHeight = terminalHeight
-
-    function onMove(e: PointerEvent) {
-      const maxHeight = containerElement ? containerElement.clientHeight - 100 : 600
-      terminalHeight = Math.min(
-        maxHeight,
-        Math.max(MIN_TERMINAL_HEIGHT, startHeight - (e.clientY - startY)),
-      )
-    }
-
-    function onUp() {
-      terminalResizing = false
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-      terminalManager.refitAll()
-    }
-
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
   }
 
   let refreshGeneration = $state(0)
@@ -262,7 +197,6 @@
 <div
   class="bg-background flex h-full min-h-0 w-full flex-col"
   data-testid="project-conversation-workspace-browser"
-  bind:this={containerElement}
 >
   <!-- Compact toolbar -->
   <div class="border-border flex h-9 items-center gap-1.5 border-b px-3">
@@ -350,85 +284,12 @@
       The workspace will appear after Project AI provisions the conversation workdir.
     </div>
   {:else}
-    <div
-      class={cn(
-        'flex min-h-0 flex-1 flex-col',
-        (sidebarResizing || terminalResizing) && 'select-none',
-      )}
-    >
-      <!-- Files area -->
-      <div class="flex min-h-0 flex-1">
-        <!-- Sidebar (resizable) -->
-        <div
-          class="relative min-h-0 shrink-0 overflow-hidden"
-          style="width: {sidebarWidth}px"
-          data-testid="workspace-browser-sidebar-panel"
-        >
-          <ProjectConversationWorkspaceBrowserSidebar
-            repos={browser.metadata?.repos ?? []}
-            selectedRepoPath={browser.selectedRepoPath}
-            {selectedRepo}
-            {selectedRepoDiff}
-            treeNodes={browser.treeNodes}
-            expandedDirs={browser.expandedDirs}
-            loadingDirs={browser.loadingDirs}
-            selectedFilePath={browser.selectedFilePath}
-            onOpenRepo={browser.openRepo}
-            onToggleDir={browser.toggleDir}
-            onSelectFile={browser.selectFile}
-          />
-          <!-- Resize handle -->
-          <div
-            class={cn(
-              'absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize transition-colors',
-              sidebarResizing ? 'bg-primary' : 'bg-border hover:bg-primary/50',
-            )}
-            role="separator"
-            aria-orientation="vertical"
-            onpointerdown={handleSidebarResizeStart}
-          ></div>
-        </div>
-        <!-- Detail -->
-        <div
-          class="min-h-0 min-w-0 flex-1 overflow-hidden"
-          data-testid="workspace-browser-detail-panel"
-        >
-          <ProjectConversationWorkspaceBrowserDetail
-            {selectedRepo}
-            selectedFilePath={browser.selectedFilePath}
-            preview={browser.preview}
-            patch={browser.patch}
-            editorState={browser.selectedEditorState}
-            draftDiff={browser.selectedDraftDiff}
-            fileLoading={browser.fileLoading}
-            fileError={browser.fileError}
-            {runtimeActive}
-            onViewModeChange={browser.setSelectedViewMode}
-            onDraftChange={browser.updateSelectedDraft}
-            onSave={() => void browser.saveSelectedFile()}
-            onRevert={browser.revertSelectedDraft}
-            onKeepDraft={browser.keepSelectedDraft}
-            onReloadSavedVersion={browser.reloadSelectedSavedVersion}
-          />
-        </div>
-      </div>
-
-      <!-- Terminal panel (bottom, like VSCode) -->
-      {#if terminalManager.panelOpen}
-        <!-- Resize handle -->
-        <div
-          class={cn(
-            'h-[3px] shrink-0 cursor-row-resize transition-colors',
-            terminalResizing ? 'bg-primary' : 'bg-border hover:bg-primary/50',
-          )}
-          role="separator"
-          aria-orientation="horizontal"
-          onpointerdown={handleTerminalResizeStart}
-        ></div>
-        <div class="flex min-h-0 shrink-0 overflow-hidden" style="height: {terminalHeight}px">
-          <WorkspaceTerminalPanel manager={terminalManager} />
-        </div>
-      {/if}
-    </div>
+    <ProjectConversationWorkspaceBrowserPane
+      {browser}
+      {selectedRepo}
+      {selectedRepoDiff}
+      {runtimeActive}
+      {terminalManager}
+    />
   {/if}
 </div>

--- a/web/src/lib/features/chat/project-conversation-workspace-data-loader.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-data-loader.ts
@@ -1,0 +1,67 @@
+import {
+  getProjectConversationWorkspaceFilePatch,
+  getProjectConversationWorkspaceFilePreview,
+  type ProjectConversationWorkspaceFilePreview,
+} from '$lib/api/chat'
+import {
+  workspaceTabKey,
+  type WorkspaceTabFileState,
+} from './project-conversation-workspace-browser-state-helpers'
+
+/**
+ * Wiring needed by `loadWorkspaceFile` so it can be invoked from a stateful
+ * Svelte module while remaining a plain async function the harness can test in
+ * isolation.
+ */
+export type WorkspaceFileLoaderContext = {
+  getConversationId: () => string
+  hasOpenTab: (key: string) => boolean
+  getCurrentLoading: (key: string) => boolean
+  patchTabFileState: (key: string, patch: Partial<WorkspaceTabFileState>) => void
+  syncEditorFromPreview: (
+    repoPath: string,
+    filePath: string,
+    preview: ProjectConversationWorkspaceFilePreview,
+  ) => void
+}
+
+export async function loadWorkspaceFile(
+  ctx: WorkspaceFileLoaderContext,
+  repoPath: string,
+  filePath: string,
+  options: { silent?: boolean } = {},
+): Promise<void> {
+  const conversationId = ctx.getConversationId()
+  if (!repoPath || !filePath || !conversationId) return
+  const key = workspaceTabKey({ repoPath, filePath })
+  const silent = options.silent ?? false
+
+  if (silent) {
+    ctx.patchTabFileState(key, { loading: ctx.getCurrentLoading(key) })
+  } else {
+    ctx.patchTabFileState(key, { loading: true, error: '' })
+  }
+
+  try {
+    const [previewPayload, patchPayload] = await Promise.all([
+      getProjectConversationWorkspaceFilePreview(conversationId, { repoPath, path: filePath }),
+      getProjectConversationWorkspaceFilePatch(conversationId, { repoPath, path: filePath }),
+    ])
+    if (conversationId !== ctx.getConversationId() || !ctx.hasOpenTab(key)) return
+    ctx.patchTabFileState(key, {
+      preview: previewPayload.filePreview,
+      patch: patchPayload.filePatch,
+      loading: false,
+      error: '',
+    })
+    ctx.syncEditorFromPreview(repoPath, filePath, previewPayload.filePreview)
+  } catch (error) {
+    if (conversationId !== ctx.getConversationId() || !ctx.hasOpenTab(key)) return
+    ctx.patchTabFileState(key, {
+      preview: null,
+      patch: null,
+      loading: false,
+      error: error instanceof Error ? error.message : 'Failed to load the workspace file details.',
+    })
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-drafts.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-drafts.ts
@@ -1,12 +1,9 @@
-export type WorkspaceFileViewMode = 'preview' | 'edit' | 'diff'
-
 export type WorkspaceFileSavePhase = 'idle' | 'saving' | 'conflict' | 'error'
 
 export type PersistedWorkspaceFileDraft = {
   draftContent: string
   baseSavedContent: string
   baseSavedRevision: string
-  viewMode: WorkspaceFileViewMode
   encoding: 'utf-8'
   lineEnding: 'lf' | 'crlf'
   updatedAt: string

--- a/web/src/lib/features/chat/project-conversation-workspace-file-drafts.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-drafts.ts
@@ -1,0 +1,89 @@
+export type WorkspaceFileViewMode = 'preview' | 'edit' | 'diff'
+
+export type WorkspaceFileSavePhase = 'idle' | 'saving' | 'conflict' | 'error'
+
+export type PersistedWorkspaceFileDraft = {
+  draftContent: string
+  baseSavedContent: string
+  baseSavedRevision: string
+  viewMode: WorkspaceFileViewMode
+  encoding: 'utf-8'
+  lineEnding: 'lf' | 'crlf'
+  updatedAt: string
+}
+
+const STORAGE_KEY = 'openase.project-conversation.workspace-file-drafts'
+
+type DraftStorageShape = Record<string, PersistedWorkspaceFileDraft>
+
+export function workspaceFileDraftStorageKey(input: {
+  conversationId: string
+  repoPath: string
+  filePath: string
+}) {
+  return [input.conversationId.trim(), input.repoPath.trim(), input.filePath.trim()].join('::')
+}
+
+function readDraftStorage(): DraftStorageShape {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)?.trim() ?? ''
+    if (!raw) {
+      return {}
+    }
+    const parsed = JSON.parse(raw) as DraftStorageShape
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeDraftStorage(value: DraftStorageShape) {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    if (Object.keys(value).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY)
+      return
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
+export function loadPersistedWorkspaceFileDraft(key: string): PersistedWorkspaceFileDraft | null {
+  const storage = readDraftStorage()
+  return storage[key] ?? null
+}
+
+export function savePersistedWorkspaceFileDraft(key: string, value: PersistedWorkspaceFileDraft) {
+  const storage = readDraftStorage()
+  storage[key] = value
+  writeDraftStorage(storage)
+}
+
+export function deletePersistedWorkspaceFileDraft(key: string) {
+  const storage = readDraftStorage()
+  if (!(key in storage)) {
+    return
+  }
+  delete storage[key]
+  writeDraftStorage(storage)
+}
+
+export function workspaceFileReadOnlyMessage(reason: string) {
+  switch (reason) {
+    case 'binary_file':
+      return 'Binary files stay read-only in Project AI workspace editing.'
+    case 'file_too_large':
+      return 'This file is too large for the V1 editor and stays read-only.'
+    case 'unsupported_encoding':
+      return 'Only UTF-8 text files are editable in the V1 workspace editor.'
+    default:
+      return 'This file is read-only in the Project AI workspace editor.'
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -1,0 +1,350 @@
+import { ApiError } from '$lib/api/client'
+import {
+  saveProjectConversationWorkspaceFile,
+  type ProjectConversationWorkspaceFilePreview,
+} from '$lib/api/chat'
+import {
+  deletePersistedWorkspaceFileDraft,
+  loadPersistedWorkspaceFileDraft,
+  savePersistedWorkspaceFileDraft,
+  workspaceFileDraftStorageKey,
+  type WorkspaceFileViewMode,
+} from './project-conversation-workspace-file-drafts'
+import {
+  buildWholeFileDiff,
+  createInitialEditorState,
+  type WorkspaceFileEditorState,
+} from './project-conversation-workspace-browser-state-helpers'
+
+export function createWorkspaceFileEditorStore(input: {
+  getConversationId: () => string
+  getSelectedRepoPath: () => string
+  getSelectedFilePath: () => string
+  getPreview: () => ProjectConversationWorkspaceFilePreview | null
+  setPreview: (preview: ProjectConversationWorkspaceFilePreview | null) => void
+  reloadSelectedFile: () => Promise<void>
+  refreshWorkspaceDiff?: () => Promise<void>
+}) {
+  let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
+
+  function selectedFileStorageKey(
+    repoPath = input.getSelectedRepoPath(),
+    filePath = input.getSelectedFilePath(),
+  ) {
+    return workspaceFileDraftStorageKey({
+      conversationId: input.getConversationId(),
+      repoPath,
+      filePath,
+    })
+  }
+
+  function getEditorState(
+    repoPath = input.getSelectedRepoPath(),
+    filePath = input.getSelectedFilePath(),
+  ) {
+    if (!repoPath || !filePath) {
+      return null
+    }
+    return editorStates.get(selectedFileStorageKey(repoPath, filePath)) ?? null
+  }
+
+  function setEditorState(
+    repoPath: string,
+    filePath: string,
+    nextState: WorkspaceFileEditorState | null,
+  ) {
+    const key = selectedFileStorageKey(repoPath, filePath)
+    const nextEditorStates = new Map(editorStates)
+
+    if (nextState) {
+      nextEditorStates.set(key, nextState)
+      if (nextState.dirty) {
+        savePersistedWorkspaceFileDraft(key, {
+          draftContent: nextState.draftContent,
+          baseSavedContent: nextState.baseSavedContent,
+          baseSavedRevision: nextState.baseSavedRevision,
+          viewMode: nextState.viewMode,
+          encoding: nextState.encoding,
+          lineEnding: nextState.lineEnding,
+          updatedAt: new Date().toISOString(),
+        })
+      } else {
+        deletePersistedWorkspaceFileDraft(key)
+      }
+    } else {
+      nextEditorStates.delete(key)
+      deletePersistedWorkspaceFileDraft(key)
+    }
+
+    editorStates = nextEditorStates
+  }
+
+  function syncFromPreview(
+    repoPath: string,
+    filePath: string,
+    nextPreview: ProjectConversationWorkspaceFilePreview,
+  ) {
+    const key = selectedFileStorageKey(repoPath, filePath)
+    const existing = editorStates.get(key)
+
+    if (!existing) {
+      const persisted = loadPersistedWorkspaceFileDraft(key)
+      if (!persisted) {
+        setEditorState(repoPath, filePath, createInitialEditorState(nextPreview))
+        return
+      }
+
+      const dirty = persisted.draftContent !== nextPreview.content
+      setEditorState(repoPath, filePath, {
+        baseSavedContent: persisted.baseSavedContent,
+        baseSavedRevision: persisted.baseSavedRevision,
+        latestSavedContent: nextPreview.content,
+        latestSavedRevision: nextPreview.revision,
+        draftContent: persisted.draftContent,
+        dirty,
+        viewMode: dirty ? 'edit' : persisted.viewMode,
+        savePhase: 'idle',
+        externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
+        errorMessage: '',
+        encoding: nextPreview.encoding,
+        lineEnding: nextPreview.lineEnding,
+        lastSavedAt: '',
+      })
+      return
+    }
+
+    if (existing.dirty) {
+      const latestChanged = existing.latestSavedRevision !== nextPreview.revision
+      setEditorState(repoPath, filePath, {
+        ...existing,
+        latestSavedContent: nextPreview.content,
+        latestSavedRevision: nextPreview.revision,
+        dirty: existing.draftContent !== nextPreview.content,
+        externalChange: latestChanged || existing.baseSavedRevision !== nextPreview.revision,
+        encoding: nextPreview.encoding,
+        lineEnding: nextPreview.lineEnding,
+      })
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...existing,
+      baseSavedContent: nextPreview.content,
+      baseSavedRevision: nextPreview.revision,
+      latestSavedContent: nextPreview.content,
+      latestSavedRevision: nextPreview.revision,
+      draftContent: nextPreview.content,
+      dirty: false,
+      externalChange: false,
+      savePhase: 'idle',
+      errorMessage: '',
+      encoding: nextPreview.encoding,
+      lineEnding: nextPreview.lineEnding,
+    })
+  }
+
+  function reset() {
+    editorStates = new Map()
+  }
+
+  function setSelectedViewMode(viewMode: WorkspaceFileViewMode) {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const editor = getEditorState(repoPath, filePath)
+    if (!editor || !repoPath || !filePath) {
+      return
+    }
+    setEditorState(repoPath, filePath, { ...editor, viewMode })
+  }
+
+  function updateSelectedDraft(nextDraftContent: string) {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const editor = getEditorState(repoPath, filePath)
+    if (!editor || !repoPath || !filePath) {
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...editor,
+      draftContent: nextDraftContent,
+      dirty: nextDraftContent !== editor.latestSavedContent,
+      viewMode: 'edit',
+      savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
+      errorMessage: '',
+    })
+  }
+
+  function revertSelectedDraft() {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const editor = getEditorState(repoPath, filePath)
+    if (!editor || !repoPath || !filePath) {
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...editor,
+      baseSavedContent: editor.latestSavedContent,
+      baseSavedRevision: editor.latestSavedRevision,
+      draftContent: editor.latestSavedContent,
+      dirty: false,
+      savePhase: 'idle',
+      externalChange: false,
+      errorMessage: '',
+      viewMode: 'preview',
+    })
+  }
+
+  function keepSelectedDraft() {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const editor = getEditorState(repoPath, filePath)
+    if (!editor || !repoPath || !filePath) {
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...editor,
+      baseSavedContent: editor.latestSavedContent,
+      baseSavedRevision: editor.latestSavedRevision,
+      dirty: editor.draftContent !== editor.latestSavedContent,
+      savePhase: 'idle',
+      externalChange: false,
+      errorMessage: '',
+      viewMode: 'edit',
+    })
+  }
+
+  function reloadSelectedSavedVersion() {
+    revertSelectedDraft()
+  }
+
+  async function saveSelectedFile() {
+    const conversationId = input.getConversationId()
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const preview = input.getPreview()
+    const editor = getEditorState(repoPath, filePath)
+
+    if (!conversationId || !repoPath || !filePath || !editor || !preview?.writable) {
+      return
+    }
+    if (!editor.dirty || editor.savePhase === 'saving') {
+      return
+    }
+
+    setEditorState(repoPath, filePath, {
+      ...editor,
+      savePhase: 'saving',
+      errorMessage: '',
+    })
+
+    try {
+      const payload = await saveProjectConversationWorkspaceFile(conversationId, {
+        repoPath,
+        path: filePath,
+        baseRevision: editor.baseSavedRevision,
+        content: editor.draftContent,
+        encoding: editor.encoding,
+        lineEnding: editor.lineEnding,
+      })
+      const nextEditor = getEditorState(repoPath, filePath)
+      if (!nextEditor) {
+        return
+      }
+
+      setEditorState(repoPath, filePath, {
+        ...nextEditor,
+        baseSavedContent: nextEditor.draftContent,
+        baseSavedRevision: payload.file.revision,
+        latestSavedContent: nextEditor.draftContent,
+        latestSavedRevision: payload.file.revision,
+        dirty: false,
+        savePhase: 'idle',
+        externalChange: false,
+        errorMessage: '',
+        lastSavedAt: new Date().toISOString(),
+      })
+
+      await input.reloadSelectedFile()
+      try {
+        await input.refreshWorkspaceDiff?.()
+      } catch {
+        const refreshedEditor = getEditorState(repoPath, filePath)
+        if (refreshedEditor) {
+          setEditorState(repoPath, filePath, {
+            ...refreshedEditor,
+            errorMessage: 'Saved, but the workspace summary could not be refreshed.',
+          })
+        }
+      }
+    } catch (error) {
+      const latestEditor = getEditorState(repoPath, filePath)
+      if (!latestEditor) {
+        return
+      }
+
+      if (
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.code === 'PROJECT_CONVERSATION_WORKSPACE_FILE_CONFLICT'
+      ) {
+        const currentFile = (
+          error.details as { current_file?: ProjectConversationWorkspaceFilePreview } | undefined
+        )?.current_file
+        if (currentFile) {
+          setEditorState(repoPath, filePath, {
+            ...latestEditor,
+            latestSavedContent: currentFile.content,
+            latestSavedRevision: currentFile.revision,
+            dirty: latestEditor.draftContent !== currentFile.content,
+            savePhase: 'conflict',
+            externalChange: true,
+            errorMessage: 'The workspace file changed before your save completed.',
+            encoding: currentFile.encoding,
+            lineEnding: currentFile.lineEnding,
+            viewMode: 'diff',
+          })
+          input.setPreview(currentFile)
+        } else {
+          setEditorState(repoPath, filePath, {
+            ...latestEditor,
+            savePhase: 'conflict',
+            externalChange: true,
+            errorMessage: error.message,
+          })
+        }
+        return
+      }
+
+      setEditorState(repoPath, filePath, {
+        ...latestEditor,
+        savePhase: 'error',
+        errorMessage: error instanceof Error ? error.message : 'Failed to save the workspace file.',
+      })
+    }
+  }
+
+  return {
+    get selectedEditorState() {
+      return getEditorState()
+    },
+    get selectedDraftDiff() {
+      const filePath = input.getSelectedFilePath()
+      const editor = getEditorState(input.getSelectedRepoPath(), filePath)
+      if (!editor || !filePath) {
+        return ''
+      }
+      return buildWholeFileDiff(filePath, editor.latestSavedContent, editor.draftContent)
+    },
+    reset,
+    syncFromPreview,
+    setSelectedViewMode,
+    updateSelectedDraft,
+    revertSelectedDraft,
+    keepSelectedDraft,
+    reloadSelectedSavedVersion,
+    saveSelectedFile,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -8,21 +8,25 @@ import {
   loadPersistedWorkspaceFileDraft,
   savePersistedWorkspaceFileDraft,
   workspaceFileDraftStorageKey,
-  type WorkspaceFileViewMode,
 } from './project-conversation-workspace-file-drafts'
 import {
-  buildWholeFileDiff,
+  computeDraftLineDiff,
   createInitialEditorState,
   type WorkspaceFileEditorState,
+  type WorkspaceFileLineDiffMarkers,
 } from './project-conversation-workspace-browser-state-helpers'
 
 export function createWorkspaceFileEditorStore(input: {
   getConversationId: () => string
   getSelectedRepoPath: () => string
   getSelectedFilePath: () => string
-  getPreview: () => ProjectConversationWorkspaceFilePreview | null
-  setPreview: (preview: ProjectConversationWorkspaceFilePreview | null) => void
-  reloadSelectedFile: () => Promise<void>
+  getPreview: (repoPath: string, filePath: string) => ProjectConversationWorkspaceFilePreview | null
+  setPreview: (
+    repoPath: string,
+    filePath: string,
+    preview: ProjectConversationWorkspaceFilePreview | null,
+  ) => void
+  reloadSelectedFile: (repoPath: string, filePath: string) => Promise<void>
   refreshWorkspaceDiff?: () => Promise<void>
 }) {
   let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
@@ -63,7 +67,6 @@ export function createWorkspaceFileEditorStore(input: {
           draftContent: nextState.draftContent,
           baseSavedContent: nextState.baseSavedContent,
           baseSavedRevision: nextState.baseSavedRevision,
-          viewMode: nextState.viewMode,
           encoding: nextState.encoding,
           lineEnding: nextState.lineEnding,
           updatedAt: new Date().toISOString(),
@@ -102,7 +105,6 @@ export function createWorkspaceFileEditorStore(input: {
         latestSavedRevision: nextPreview.revision,
         draftContent: persisted.draftContent,
         dirty,
-        viewMode: dirty ? 'edit' : persisted.viewMode,
         savePhase: 'idle',
         externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
         errorMessage: '',
@@ -147,16 +149,6 @@ export function createWorkspaceFileEditorStore(input: {
     editorStates = new Map()
   }
 
-  function setSelectedViewMode(viewMode: WorkspaceFileViewMode) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, { ...editor, viewMode })
-  }
-
   function updateSelectedDraft(nextDraftContent: string) {
     const repoPath = input.getSelectedRepoPath()
     const filePath = input.getSelectedFilePath()
@@ -169,7 +161,6 @@ export function createWorkspaceFileEditorStore(input: {
       ...editor,
       draftContent: nextDraftContent,
       dirty: nextDraftContent !== editor.latestSavedContent,
-      viewMode: 'edit',
       savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
       errorMessage: '',
     })
@@ -192,7 +183,6 @@ export function createWorkspaceFileEditorStore(input: {
       savePhase: 'idle',
       externalChange: false,
       errorMessage: '',
-      viewMode: 'preview',
     })
   }
 
@@ -212,26 +202,37 @@ export function createWorkspaceFileEditorStore(input: {
       savePhase: 'idle',
       externalChange: false,
       errorMessage: '',
-      viewMode: 'edit',
     })
+  }
+
+  function discardSelectedDraft() {
+    // Drop the in-memory + persisted draft entirely. Used when the user closes
+    // a tab and chooses "Don't save".
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    if (!repoPath || !filePath) return
+    setEditorState(repoPath, filePath, null)
+  }
+
+  function discardDraft(repoPath: string, filePath: string) {
+    if (!repoPath || !filePath) return
+    setEditorState(repoPath, filePath, null)
   }
 
   function reloadSelectedSavedVersion() {
     revertSelectedDraft()
   }
 
-  async function saveSelectedFile() {
+  async function saveFile(repoPath: string, filePath: string): Promise<boolean> {
     const conversationId = input.getConversationId()
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const preview = input.getPreview()
+    const preview = input.getPreview(repoPath, filePath)
     const editor = getEditorState(repoPath, filePath)
 
     if (!conversationId || !repoPath || !filePath || !editor || !preview?.writable) {
-      return
+      return false
     }
     if (!editor.dirty || editor.savePhase === 'saving') {
-      return
+      return !editor.dirty
     }
 
     setEditorState(repoPath, filePath, {
@@ -251,7 +252,7 @@ export function createWorkspaceFileEditorStore(input: {
       })
       const nextEditor = getEditorState(repoPath, filePath)
       if (!nextEditor) {
-        return
+        return false
       }
 
       setEditorState(repoPath, filePath, {
@@ -267,7 +268,7 @@ export function createWorkspaceFileEditorStore(input: {
         lastSavedAt: new Date().toISOString(),
       })
 
-      await input.reloadSelectedFile()
+      await input.reloadSelectedFile(repoPath, filePath)
       try {
         await input.refreshWorkspaceDiff?.()
       } catch {
@@ -279,10 +280,11 @@ export function createWorkspaceFileEditorStore(input: {
           })
         }
       }
+      return true
     } catch (error) {
       const latestEditor = getEditorState(repoPath, filePath)
       if (!latestEditor) {
-        return
+        return false
       }
 
       if (
@@ -304,9 +306,8 @@ export function createWorkspaceFileEditorStore(input: {
             errorMessage: 'The workspace file changed before your save completed.',
             encoding: currentFile.encoding,
             lineEnding: currentFile.lineEnding,
-            viewMode: 'diff',
           })
-          input.setPreview(currentFile)
+          input.setPreview(repoPath, filePath, currentFile)
         } else {
           setEditorState(repoPath, filePath, {
             ...latestEditor,
@@ -315,7 +316,7 @@ export function createWorkspaceFileEditorStore(input: {
             errorMessage: error.message,
           })
         }
-        return
+        return false
       }
 
       setEditorState(repoPath, filePath, {
@@ -323,28 +324,35 @@ export function createWorkspaceFileEditorStore(input: {
         savePhase: 'error',
         errorMessage: error instanceof Error ? error.message : 'Failed to save the workspace file.',
       })
+      return false
     }
+  }
+
+  async function saveSelectedFile(): Promise<boolean> {
+    return saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
   }
 
   return {
     get selectedEditorState() {
       return getEditorState()
     },
-    get selectedDraftDiff() {
+    get selectedDraftLineDiff(): WorkspaceFileLineDiffMarkers | null {
+      const repoPath = input.getSelectedRepoPath()
       const filePath = input.getSelectedFilePath()
-      const editor = getEditorState(input.getSelectedRepoPath(), filePath)
-      if (!editor || !filePath) {
-        return ''
-      }
-      return buildWholeFileDiff(filePath, editor.latestSavedContent, editor.draftContent)
+      const editor = getEditorState(repoPath, filePath)
+      if (!editor || !filePath) return null
+      return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
     },
+    getEditorState,
     reset,
     syncFromPreview,
-    setSelectedViewMode,
     updateSelectedDraft,
     revertSelectedDraft,
     keepSelectedDraft,
     reloadSelectedSavedVersion,
     saveSelectedFile,
+    saveFile,
+    discardSelectedDraft,
+    discardDraft,
   }
 }

--- a/web/src/lib/features/chat/project-conversation-workspace-line-diff.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-line-diff.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeDraftLineDiff } from './project-conversation-workspace-line-diff'
+
+describe('computeDraftLineDiff', () => {
+  it('returns empty markers when the draft matches the saved file', () => {
+    expect(computeDraftLineDiff('line one\nline two\n', 'line one\nline two\n')).toEqual({
+      added: [],
+      modified: [],
+      deletionAbove: [],
+      deletionAtEnd: false,
+    })
+  })
+
+  it('marks modified and added draft lines separately', () => {
+    expect(
+      computeDraftLineDiff('alpha\nbeta\ngamma\n', 'alpha\nbeta changed\ngamma\nextra\n'),
+    ).toEqual({
+      added: [4],
+      modified: [2],
+      deletionAbove: [],
+      deletionAtEnd: false,
+    })
+  })
+
+  it('anchors deletions above the next surviving draft line', () => {
+    expect(computeDraftLineDiff('alpha\nbeta\ngamma\ndelta\n', 'alpha\ndelta\n')).toEqual({
+      added: [],
+      modified: [],
+      deletionAbove: [2],
+      deletionAtEnd: false,
+    })
+  })
+
+  it('marks deletions at end-of-file when removed content has no following line', () => {
+    expect(computeDraftLineDiff('alpha\n', '')).toEqual({
+      added: [],
+      modified: [],
+      deletionAbove: [],
+      deletionAtEnd: true,
+    })
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-workspace-line-diff.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-line-diff.ts
@@ -1,0 +1,155 @@
+/**
+ * Per-line diff markers for the in-editor gutter, computed against the latest
+ * saved content. All line numbers are 1-based, referencing the draft document.
+ */
+export type WorkspaceFileLineDiffMarkers = {
+  /** Lines that exist in the draft but not in the saved version. */
+  added: number[]
+  /** Lines that replace a saved line at (roughly) the same position. */
+  modified: number[]
+  /** Lines where deletion happened *immediately above* the marked line. */
+  deletionAbove: number[]
+  /** True when content was deleted past the end of the draft document. */
+  deletionAtEnd: boolean
+}
+
+const EMPTY_LINE_DIFF: WorkspaceFileLineDiffMarkers = Object.freeze({
+  added: [],
+  modified: [],
+  deletionAbove: [],
+  deletionAtEnd: false,
+}) as WorkspaceFileLineDiffMarkers
+
+type DiffOp =
+  | { kind: 'eq'; oldIdx: number; newIdx: number }
+  | { kind: 'del'; oldIdx: number }
+  | { kind: 'add'; newIdx: number }
+
+function lcsDiff(oldLines: string[], newLines: string[]): DiffOp[] {
+  const m = oldLines.length
+  const n = newLines.length
+  const dp: number[][] = []
+  for (let i = 0; i <= m; i++) {
+    dp.push(new Array<number>(n + 1).fill(0))
+  }
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])
+      }
+    }
+  }
+  const ops: DiffOp[] = []
+  let i = m
+  let j = n
+  while (i > 0 && j > 0) {
+    if (oldLines[i - 1] === newLines[j - 1]) {
+      ops.push({ kind: 'eq', oldIdx: i - 1, newIdx: j - 1 })
+      i--
+      j--
+    } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+      ops.push({ kind: 'del', oldIdx: i - 1 })
+      i--
+    } else {
+      ops.push({ kind: 'add', newIdx: j - 1 })
+      j--
+    }
+  }
+  while (i > 0) {
+    ops.push({ kind: 'del', oldIdx: i - 1 })
+    i--
+  }
+  while (j > 0) {
+    ops.push({ kind: 'add', newIdx: j - 1 })
+    j--
+  }
+  ops.reverse()
+  return ops
+}
+
+type Hunk = {
+  dels: Array<Extract<DiffOp, { kind: 'del' }>>
+  adds: Array<Extract<DiffOp, { kind: 'add' }>>
+  end: number
+}
+
+function gatherHunk(ops: DiffOp[], start: number): Hunk {
+  let end = start
+  while (end < ops.length && ops[end].kind !== 'eq') {
+    end++
+  }
+  const dels: Hunk['dels'] = []
+  const adds: Hunk['adds'] = []
+  for (let i = start; i < end; i++) {
+    const op = ops[i]
+    if (op.kind === 'del') dels.push(op)
+    else if (op.kind === 'add') adds.push(op)
+  }
+  return { dels, adds, end }
+}
+
+function leftoverDeletionAnchor(
+  ops: DiffOp[],
+  hunk: Hunk,
+  newLineCount: number,
+): { aboveLine: number | null; atEnd: boolean } {
+  if (hunk.adds.length > 0) {
+    const lastAddNewIdx = hunk.adds[hunk.adds.length - 1].newIdx
+    const candidate = lastAddNewIdx + 2
+    if (candidate <= newLineCount) return { aboveLine: candidate, atEnd: false }
+    return { aboveLine: null, atEnd: true }
+  }
+  if (hunk.end < ops.length) {
+    const nextEq = ops[hunk.end] as Extract<DiffOp, { kind: 'eq' }>
+    return { aboveLine: nextEq.newIdx + 1, atEnd: false }
+  }
+  return { aboveLine: null, atEnd: true }
+}
+
+export function computeDraftLineDiff(
+  savedContent: string,
+  draftContent: string,
+): WorkspaceFileLineDiffMarkers {
+  if (savedContent === draftContent) {
+    return EMPTY_LINE_DIFF
+  }
+  const oldLines = savedContent === '' ? [] : savedContent.split('\n')
+  const newLines = draftContent === '' ? [] : draftContent.split('\n')
+  const ops = lcsDiff(oldLines, newLines)
+
+  const added = new Set<number>()
+  const modified = new Set<number>()
+  const deletionAbove = new Set<number>()
+  let deletionAtEnd = false
+
+  let k = 0
+  while (k < ops.length) {
+    if (ops[k].kind === 'eq') {
+      k++
+      continue
+    }
+    const hunk = gatherHunk(ops, k)
+    const pairCount = Math.min(hunk.dels.length, hunk.adds.length)
+    for (let p = 0; p < pairCount; p++) {
+      modified.add(hunk.adds[p].newIdx + 1)
+    }
+    for (let p = pairCount; p < hunk.adds.length; p++) {
+      added.add(hunk.adds[p].newIdx + 1)
+    }
+    if (hunk.dels.length > hunk.adds.length) {
+      const anchor = leftoverDeletionAnchor(ops, hunk, newLines.length)
+      if (anchor.aboveLine !== null) deletionAbove.add(anchor.aboveLine)
+      else if (anchor.atEnd) deletionAtEnd = true
+    }
+    k = hunk.end
+  }
+
+  return {
+    added: [...added].sort((a, b) => a - b),
+    modified: [...modified].sort((a, b) => a - b),
+    deletionAbove: [...deletionAbove].sort((a, b) => a - b),
+    deletionAtEnd,
+  }
+}

--- a/web/src/lib/features/chat/workspace-browser-portal.svelte.ts
+++ b/web/src/lib/features/chat/workspace-browser-portal.svelte.ts
@@ -13,6 +13,7 @@ class WorkspaceBrowserPortal {
   conversationId = $state('')
   workspaceDiff: ProjectConversationWorkspaceDiff | null = $state(null)
   workspaceDiffLoading = $state(false)
+  runtimeActive = $state(false)
   /** File path to navigate to when the browser opens (consumed once). */
   pendingFilePath = $state('')
 


### PR DESCRIPTION
## Summary
- add editable Project AI workspace files with a multi-tab browser/editor flow
- preserve per-file drafts across tab switches, show in-editor line diff markers,
  and keep sidebar git status badges readable
- guard dirty drafts with close-confirm flows, browser unload prompts, and
  expanded workspace browser test coverage

## Validation
- `source $HOME/.nvm/nvm.sh && nvm use 22 >/dev/null && .codex/skills/push/scripts/openase_ci_gate.sh`
  - passed openapi generation, frontend API audit, web install, format/lint/check,
    targeted Vitest suite, and production build
  - hit a local Playwright environment conflict because port `127.0.0.1:4173`
    was already in use in this workspace
- `source $HOME/.nvm/nvm.sh && nvm use 22 >/dev/null && PLAYWRIGHT_PORT=4174 corepack pnpm --dir web exec playwright test --reporter=dot --quiet`
- in a clean detached worktree at `HEAD`:
  - `env OPENASE_BACKEND_TEST_GROUP_SIZE=8 make check`
  - `make build`
  - `make LINT_BASE_REV=c8bb8305c44f1a6bab672670dab92294c63c349d lint`
  - `make lint-depguard`
  - `make lint-architecture`

## Risks / Follow-up
- workspace editor files in this branch are still large in a few places; follow-up
  refactors could split browser/detail/editor state further once behavior settles
- the default Playwright config still expects port `4173`, so crowded local
  workspaces need the documented alternate-port workaround for validation
