### PR TITLE
fix(chat): prompt to sync newly bound repos before browse/diff

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6121,6 +6121,29 @@
                           },
                           "type": "array"
                         },
+                        "sync_prompt": {
+                          "nullable": true,
+                          "properties": {
+                            "missing_repos": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
                         "workspace_path": {
                           "type": "string"
                         }
@@ -6320,6 +6343,29 @@
                         },
                         "repos_changed": {
                           "type": "integer"
+                        },
+                        "sync_prompt": {
+                          "nullable": true,
+                          "properties": {
+                            "missing_repos": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
                         },
                         "workspace_path": {
                           "type": "string"
@@ -6746,6 +6792,203 @@
           }
         },
         "summary": "Read one project conversation workspace file diff",
+        "tags": [
+          "chat"
+        ]
+      }
+    },
+    "/api/v1/chat/conversations/{conversationId}/workspace/sync": {
+      "post": {
+        "operationId": "syncProjectConversationWorkspace",
+        "parameters": [
+          {
+            "description": "Stable OpenASE conversation ID.",
+            "in": "path",
+            "name": "conversationId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "workspace": {
+                      "properties": {
+                        "available": {
+                          "type": "boolean"
+                        },
+                        "conversation_id": {
+                          "type": "string"
+                        },
+                        "repos": {
+                          "items": {
+                            "properties": {
+                              "added": {
+                                "type": "integer"
+                              },
+                              "branch": {
+                                "type": "string"
+                              },
+                              "dirty": {
+                                "type": "boolean"
+                              },
+                              "files_changed": {
+                                "type": "integer"
+                              },
+                              "head_commit": {
+                                "type": "string"
+                              },
+                              "head_summary": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "removed": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "sync_prompt": {
+                          "nullable": true,
+                          "properties": {
+                            "missing_repos": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "reason": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "workspace_path": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sync newly bound project repos into the current conversation workspace response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found response."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Internal Server Error response."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Service Unavailable response."
+          }
+        },
+        "summary": "Sync newly bound project repos into the current conversation workspace",
         "tags": [
           "chat"
         ]

--- a/internal/chat/project_conversation_retention.go
+++ b/internal/chat/project_conversation_retention.go
@@ -447,7 +447,7 @@ func (s *ProjectConversationService) conversationWorkspaceDirty(
 	target projectConversationWorkspaceTarget,
 	conversation domain.Conversation,
 ) (bool, error) {
-	location, err := s.resolveConversationWorkspaceLocation(ctx, target.project, target.provider, conversation.ID)
+	location, err := s.resolveConversationWorkspaceLocation(ctx, conversation, target.project, target.provider)
 	if err != nil {
 		return false, err
 	}

--- a/internal/chat/project_conversation_service_test.go
+++ b/internal/chat/project_conversation_service_test.go
@@ -5363,20 +5363,20 @@ func TestProjectConversationWorkspaceBrowser(t *testing.T) {
 		remoteRepoPath, _ := createConversationRemoteRepo(t, "main", map[string]string{
 			"README.md": "docs\n",
 		})
-		fixture.catalog.fakeCatalogReader.projectRepos = append(
-			fixture.catalog.fakeCatalogReader.projectRepos,
+		fixture.catalog.projectRepos = append(
+			fixture.catalog.projectRepos,
 			catalogdomain.ProjectRepo{
 				ID:               repoID,
-				ProjectID:        fixture.catalog.fakeCatalogReader.project.ID,
+				ProjectID:        fixture.catalog.project.ID,
 				Name:             "docs",
 				RepositoryURL:    remoteRepoPath,
 				DefaultBranch:    "main",
 				WorkspaceDirname: "docs",
 			},
 		)
-		fixture.catalog.fakeCatalogReader.activityEvents = []catalogdomain.ActivityEvent{{
+		fixture.catalog.activityEvents = []catalogdomain.ActivityEvent{{
 			ID:        uuid.New(),
-			ProjectID: fixture.catalog.fakeCatalogReader.project.ID,
+			ProjectID: fixture.catalog.project.ID,
 			EventType: activityevent.TypeProjectRepoCreated,
 			Metadata: map[string]any{
 				"repo_id":        repoID.String(),

--- a/internal/chat/project_conversation_service_test.go
+++ b/internal/chat/project_conversation_service_test.go
@@ -5345,6 +5345,116 @@ func TestProjectConversationWorkspaceBrowser(t *testing.T) {
 			t.Fatalf("ReadWorkspaceFilePreview(symlink escape) error = %v, want ErrProjectConversationWorkspacePathInvalid", err)
 		}
 	})
+
+	t.Run("prompts to sync repos added after workspace materialization", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := setupProjectConversationWorkspaceDiffFixture(t, []projectConversationWorkspaceRepoFixture{
+			{
+				name:  "backend",
+				files: map[string]string{"README.md": "line one\n"},
+			},
+		})
+
+		repoID := uuid.New()
+		remoteRepoPath, _ := createConversationRemoteRepo(t, "main", map[string]string{
+			"README.md": "docs\n",
+		})
+		fixture.catalog.fakeCatalogReader.projectRepos = append(
+			fixture.catalog.fakeCatalogReader.projectRepos,
+			catalogdomain.ProjectRepo{
+				ID:               repoID,
+				ProjectID:        fixture.catalog.fakeCatalogReader.project.ID,
+				Name:             "docs",
+				RepositoryURL:    remoteRepoPath,
+				DefaultBranch:    "main",
+				WorkspaceDirname: "docs",
+			},
+		)
+		fixture.catalog.fakeCatalogReader.activityEvents = []catalogdomain.ActivityEvent{{
+			ID:        uuid.New(),
+			ProjectID: fixture.catalog.fakeCatalogReader.project.ID,
+			EventType: activityevent.TypeProjectRepoCreated,
+			Metadata: map[string]any{
+				"repo_id":        repoID.String(),
+				"repo_name":      "docs",
+				"changed_fields": []string{"repo"},
+			},
+			CreatedAt: fixture.conversation.CreatedAt.Add(time.Minute),
+		}}
+
+		metadata, err := fixture.service.GetWorkspaceMetadata(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+		)
+		if err != nil {
+			t.Fatalf("GetWorkspaceMetadata() error = %v", err)
+		}
+		if metadata.SyncPrompt == nil || metadata.SyncPrompt.Reason != ProjectConversationWorkspaceSyncReasonRepoBindingChanged {
+			t.Fatalf("expected sync prompt for metadata, got %+v", metadata.SyncPrompt)
+		}
+		if len(metadata.SyncPrompt.MissingRepos) != 1 || metadata.SyncPrompt.MissingRepos[0].Path != "docs" {
+			t.Fatalf("unexpected missing repos: %+v", metadata.SyncPrompt)
+		}
+		if len(metadata.Repos) != 1 || metadata.Repos[0].Name != "backend" {
+			t.Fatalf("expected only prepared repos in metadata, got %+v", metadata.Repos)
+		}
+
+		summary, err := fixture.service.GetWorkspaceDiff(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+		)
+		if err != nil {
+			t.Fatalf("GetWorkspaceDiff() error = %v", err)
+		}
+		if summary.SyncPrompt == nil || summary.SyncPrompt.Reason != ProjectConversationWorkspaceSyncReasonRepoBindingChanged {
+			t.Fatalf("expected sync prompt for diff, got %+v", summary.SyncPrompt)
+		}
+
+		_, err = fixture.service.ListWorkspaceTree(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			"docs",
+			"",
+		)
+		var syncErr *ProjectConversationWorkspaceSyncRequiredError
+		if !errors.As(err, &syncErr) {
+			t.Fatalf("ListWorkspaceTree(missing repo) error = %v, want sync required", err)
+		}
+		if syncErr.Prompt.Reason != ProjectConversationWorkspaceSyncReasonRepoBindingChanged {
+			t.Fatalf("unexpected sync required prompt: %+v", syncErr.Prompt)
+		}
+
+		synced, err := fixture.service.SyncWorkspace(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+		)
+		if err != nil {
+			t.Fatalf("SyncWorkspace() error = %v", err)
+		}
+		if synced.SyncPrompt != nil {
+			t.Fatalf("expected sync prompt to clear after sync, got %+v", synced.SyncPrompt)
+		}
+		if len(synced.Repos) != 2 {
+			t.Fatalf("expected synced metadata to expose both repos, got %+v", synced.Repos)
+		}
+
+		summaryAfterSync, err := fixture.service.GetWorkspaceDiff(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+		)
+		if err != nil {
+			t.Fatalf("GetWorkspaceDiff(after sync) error = %v", err)
+		}
+		if summaryAfterSync.SyncPrompt != nil {
+			t.Fatalf("expected sync prompt to clear from diff, got %+v", summaryAfterSync.SyncPrompt)
+		}
+	})
 }
 
 type fakeProjectConversationCatalog struct {
@@ -5932,6 +6042,7 @@ func TestProjectConversationServiceGetConversationUsesStableLocalPrincipal(t *te
 type projectConversationWorkspaceDiffFixture struct {
 	ctx           context.Context
 	service       *ProjectConversationService
+	catalog       *fakeProjectConversationCatalog
 	conversation  chatdomain.Conversation
 	workspacePath string
 	repoPaths     map[string]string
@@ -6002,7 +6113,7 @@ func setupProjectConversationWorkspaceDiffFixture(
 		AdapterType:    catalogdomain.AgentProviderAdapterTypeGeminiCLI,
 		CliCommand:     "gemini",
 	}
-	catalog := fakeProjectConversationCatalog{
+	catalog := &fakeProjectConversationCatalog{
 		fakeCatalogReader: fakeCatalogReader{
 			project:      projectItem,
 			projectRepos: projectRepos,
@@ -6040,6 +6151,7 @@ func setupProjectConversationWorkspaceDiffFixture(
 	return projectConversationWorkspaceDiffFixture{
 		ctx:           ctx,
 		service:       service,
+		catalog:       catalog,
 		conversation:  conversation,
 		workspacePath: workspace.String(),
 		repoPaths:     repoPaths,

--- a/internal/chat/project_conversation_workspace_browser.go
+++ b/internal/chat/project_conversation_workspace_browser.go
@@ -31,6 +31,7 @@ type ProjectConversationWorkspaceMetadata struct {
 	Available      bool
 	WorkspacePath  string
 	Repos          []ProjectConversationWorkspaceRepoMetadata
+	SyncPrompt     *ProjectConversationWorkspaceSyncPrompt
 }
 
 type ProjectConversationWorkspaceRepoMetadata struct {
@@ -138,6 +139,7 @@ func (s *ProjectConversationService) GetWorkspaceMetadata(
 		Available:      true,
 		WorkspacePath:  location.workspacePath,
 		Repos:          make([]ProjectConversationWorkspaceRepoMetadata, 0, len(location.repos)),
+		SyncPrompt:     location.syncPrompt,
 	}
 	for _, repo := range location.repos {
 		item, err := s.readConversationWorkspaceRepoMetadata(ctx, location.machine, repo)
@@ -237,7 +239,7 @@ func (s *ProjectConversationService) resolveConversationWorkspace(
 	if err != nil {
 		return chatdomain.Conversation{}, projectConversationWorkspaceLocation{}, fmt.Errorf("get provider for workspace browser: %w", err)
 	}
-	location, err := s.resolveConversationWorkspaceLocation(ctx, project, providerItem, conversationID)
+	location, err := s.resolveConversationWorkspaceLocation(ctx, conversation, project, providerItem)
 	if err != nil {
 		return conversation, projectConversationWorkspaceLocation{}, err
 	}
@@ -276,6 +278,14 @@ func (s *ProjectConversationService) resolveConversationWorkspaceRepoPath(
 			workspacePath:  location.workspacePath,
 			repo:           repo,
 		}, relativePath, nil
+	}
+	if location.syncPrompt != nil {
+		if _, ok := location.missingRepos[relativeRepoPath]; ok {
+			return projectConversationWorkspaceResolvedRepo{}, "", &ProjectConversationWorkspaceSyncRequiredError{
+				Prompt:   *location.syncPrompt,
+				RepoPath: relativeRepoPath,
+			}
+		}
 	}
 	return projectConversationWorkspaceResolvedRepo{}, "", ErrProjectConversationWorkspaceRepoNotFound
 }

--- a/internal/chat/project_conversation_workspace_diff.go
+++ b/internal/chat/project_conversation_workspace_diff.go
@@ -27,6 +27,7 @@ type ProjectConversationWorkspaceDiff struct {
 	Added          int
 	Removed        int
 	Repos          []ProjectConversationWorkspaceRepoDiff
+	SyncPrompt     *ProjectConversationWorkspaceSyncPrompt
 }
 
 type ProjectConversationWorkspaceRepoDiff struct {
@@ -63,6 +64,8 @@ type projectConversationWorkspaceLocation struct {
 	machine       catalogdomain.Machine
 	workspacePath string
 	repos         []projectConversationWorkspaceRepoLocation
+	syncPrompt    *ProjectConversationWorkspaceSyncPrompt
+	missingRepos  map[string]ProjectConversationWorkspaceMissingRepo
 }
 
 type projectConversationWorkspaceRepoLocation struct {
@@ -102,7 +105,7 @@ func (s *ProjectConversationService) GetWorkspaceDiff(
 		return ProjectConversationWorkspaceDiff{}, fmt.Errorf("get provider for workspace diff: %w", err)
 	}
 
-	location, err := s.resolveConversationWorkspaceLocation(ctx, project, providerItem, conversationID)
+	location, err := s.resolveConversationWorkspaceLocation(ctx, conversation, project, providerItem)
 	if err != nil {
 		if errors.Is(err, errProjectConversationWorkspaceLocationUnavailable) &&
 			projectConversationWorkspaceMayNotExistYet(conversation) {
@@ -115,6 +118,7 @@ func (s *ProjectConversationService) GetWorkspaceDiff(
 		ConversationID: conversationID,
 		WorkspacePath:  location.workspacePath,
 		Repos:          make([]ProjectConversationWorkspaceRepoDiff, 0, len(location.repos)),
+		SyncPrompt:     location.syncPrompt,
 	}
 
 	for _, repo := range location.repos {
@@ -141,16 +145,16 @@ func (s *ProjectConversationService) GetWorkspaceDiff(
 
 func (s *ProjectConversationService) resolveConversationWorkspaceLocation(
 	ctx context.Context,
+	conversation chatdomain.Conversation,
 	project catalogdomain.Project,
 	providerItem catalogdomain.AgentProvider,
-	conversationID uuid.UUID,
 ) (projectConversationWorkspaceLocation, error) {
 	machine, err := s.catalog.GetMachine(ctx, providerItem.MachineID)
 	if err != nil {
 		return projectConversationWorkspaceLocation{}, fmt.Errorf("get chat provider machine for workspace diff: %w", err)
 	}
 
-	workspacePath, err := s.resolveConversationWorkspacePath(machine, project, conversationID)
+	workspacePath, err := s.resolveConversationWorkspacePath(machine, project, conversation.ID)
 	if err != nil {
 		return projectConversationWorkspaceLocation{}, err
 	}
@@ -160,24 +164,24 @@ func (s *ProjectConversationService) resolveConversationWorkspaceLocation(
 		return projectConversationWorkspaceLocation{}, fmt.Errorf("list project repos for workspace diff: %w", err)
 	}
 
-	repos := make([]projectConversationWorkspaceRepoLocation, 0, len(projectRepos))
-	for _, repo := range projectRepos {
-		repoPath := workspaceinfra.RepoPath(workspacePath, repo.WorkspaceDirname, repo.Name)
-		relativePath, err := filepath.Rel(workspacePath, repoPath)
-		if err != nil {
-			return projectConversationWorkspaceLocation{}, fmt.Errorf("derive relative repo path for %s: %w", repo.Name, err)
-		}
-		repos = append(repos, projectConversationWorkspaceRepoLocation{
-			name:         repo.Name,
-			repoPath:     repoPath,
-			relativePath: filepath.ToSlash(relativePath),
-		})
+	repos, syncPrompt, missingRepos, err := s.buildConversationWorkspaceRepoLocations(
+		ctx,
+		conversation,
+		project,
+		machine,
+		workspacePath,
+		projectRepos,
+	)
+	if err != nil {
+		return projectConversationWorkspaceLocation{}, err
 	}
 
 	return projectConversationWorkspaceLocation{
 		machine:       machine,
 		workspacePath: workspacePath,
 		repos:         repos,
+		syncPrompt:    syncPrompt,
+		missingRepos:  missingRepos,
 	}, nil
 }
 

--- a/internal/chat/project_conversation_workspace_sync.go
+++ b/internal/chat/project_conversation_workspace_sync.go
@@ -1,0 +1,287 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	activityevent "github.com/BetterAndBetterII/openase/internal/domain/activityevent"
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	chatdomain "github.com/BetterAndBetterII/openase/internal/domain/chatconversation"
+	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
+	"github.com/google/uuid"
+)
+
+type ProjectConversationWorkspaceSyncReason string
+
+const (
+	ProjectConversationWorkspaceSyncReasonRepoBindingChanged ProjectConversationWorkspaceSyncReason = "repo_binding_changed"
+	ProjectConversationWorkspaceSyncReasonRepoMissing        ProjectConversationWorkspaceSyncReason = "repo_missing"
+)
+
+type ProjectConversationWorkspaceMissingRepo struct {
+	Name string
+	Path string
+}
+
+type ProjectConversationWorkspaceSyncPrompt struct {
+	Reason       ProjectConversationWorkspaceSyncReason
+	MissingRepos []ProjectConversationWorkspaceMissingRepo
+}
+
+var ErrProjectConversationWorkspaceSyncRequired = errors.New("project conversation workspace sync required")
+
+type ProjectConversationWorkspaceSyncRequiredError struct {
+	Prompt   ProjectConversationWorkspaceSyncPrompt
+	RepoPath string
+}
+
+func (e *ProjectConversationWorkspaceSyncRequiredError) Error() string {
+	if e == nil {
+		return ErrProjectConversationWorkspaceSyncRequired.Error()
+	}
+	repoNames := make([]string, 0, len(e.Prompt.MissingRepos))
+	for _, repo := range e.Prompt.MissingRepos {
+		if name := strings.TrimSpace(repo.Name); name != "" {
+			repoNames = append(repoNames, name)
+		}
+	}
+	if len(repoNames) == 0 {
+		return "project conversation workspace is out of sync with the project's repo bindings; sync the workspace before browsing or diffing"
+	}
+	return fmt.Sprintf(
+		"project conversation workspace is out of sync with the project's repo bindings; sync the workspace before browsing or diffing missing repo(s): %s",
+		strings.Join(repoNames, ", "),
+	)
+}
+
+func (e *ProjectConversationWorkspaceSyncRequiredError) Is(target error) bool {
+	return target == ErrProjectConversationWorkspaceSyncRequired
+}
+
+func (s *ProjectConversationService) SyncWorkspace(
+	ctx context.Context,
+	userID UserID,
+	conversationID uuid.UUID,
+) (ProjectConversationWorkspaceMetadata, error) {
+	conversation, err := s.GetConversation(ctx, userID, conversationID)
+	if err != nil {
+		return ProjectConversationWorkspaceMetadata{}, err
+	}
+	project, err := s.catalog.GetProject(ctx, conversation.ProjectID)
+	if err != nil {
+		return ProjectConversationWorkspaceMetadata{}, fmt.Errorf("get project for workspace sync: %w", err)
+	}
+	providerItem, err := s.catalog.GetAgentProvider(ctx, conversation.ProviderID)
+	if err != nil {
+		return ProjectConversationWorkspaceMetadata{}, fmt.Errorf("get provider for workspace sync: %w", err)
+	}
+	machine, err := s.catalog.GetMachine(ctx, providerItem.MachineID)
+	if err != nil {
+		return ProjectConversationWorkspaceMetadata{}, fmt.Errorf("get machine for workspace sync: %w", err)
+	}
+	if _, err := s.ensureConversationWorkspace(ctx, machine, project, providerItem, conversationID); err != nil {
+		return ProjectConversationWorkspaceMetadata{}, err
+	}
+	return s.GetWorkspaceMetadata(ctx, userID, conversationID)
+}
+
+func (s *ProjectConversationService) buildConversationWorkspaceRepoLocations(
+	ctx context.Context,
+	conversation chatdomain.Conversation,
+	project catalogdomain.Project,
+	machine catalogdomain.Machine,
+	workspacePath string,
+	projectRepos []catalogdomain.ProjectRepo,
+) ([]projectConversationWorkspaceRepoLocation, *ProjectConversationWorkspaceSyncPrompt, map[string]ProjectConversationWorkspaceMissingRepo, error) {
+	changedRepoIDs, err := s.listConversationWorkspaceRepoBindingChanges(ctx, project.ID, conversation.CreatedAt)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	repos := make([]projectConversationWorkspaceRepoLocation, 0, len(projectRepos))
+	missingByPath := make(map[string]ProjectConversationWorkspaceMissingRepo)
+	missingRepos := make([]ProjectConversationWorkspaceMissingRepo, 0)
+	reason := ProjectConversationWorkspaceSyncReasonRepoMissing
+
+	for _, repo := range projectRepos {
+		repoLocation, err := buildConversationWorkspaceRepoLocation(workspacePath, repo)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		available, err := s.conversationWorkspaceRepoPrepared(ctx, machine, repoLocation.repoPath)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("inspect workspace repo %s: %w", repo.Name, err)
+		}
+		if available {
+			repos = append(repos, repoLocation)
+			continue
+		}
+
+		missing := ProjectConversationWorkspaceMissingRepo{
+			Name: repoLocation.name,
+			Path: repoLocation.relativePath,
+		}
+		missingRepos = append(missingRepos, missing)
+		missingByPath[repoLocation.relativePath] = missing
+		if _, ok := changedRepoIDs[repo.ID]; ok {
+			reason = ProjectConversationWorkspaceSyncReasonRepoBindingChanged
+		}
+	}
+
+	sort.Slice(missingRepos, func(i, j int) bool {
+		return missingRepos[i].Path < missingRepos[j].Path
+	})
+	if len(missingRepos) == 0 {
+		return repos, nil, missingByPath, nil
+	}
+	return repos, &ProjectConversationWorkspaceSyncPrompt{
+		Reason:       reason,
+		MissingRepos: missingRepos,
+	}, missingByPath, nil
+}
+
+func buildConversationWorkspaceRepoLocation(
+	workspacePath string,
+	repo catalogdomain.ProjectRepo,
+) (projectConversationWorkspaceRepoLocation, error) {
+	repoPath := workspaceinfra.RepoPath(workspacePath, repo.WorkspaceDirname, repo.Name)
+	relativePath, err := filepath.Rel(workspacePath, repoPath)
+	if err != nil {
+		return projectConversationWorkspaceRepoLocation{}, fmt.Errorf("derive relative repo path for %s: %w", repo.Name, err)
+	}
+	return projectConversationWorkspaceRepoLocation{
+		name:         repo.Name,
+		repoPath:     repoPath,
+		relativePath: filepath.ToSlash(relativePath),
+	}, nil
+}
+
+func (s *ProjectConversationService) conversationWorkspaceRepoPrepared(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	repoPath string,
+) (bool, error) {
+	_, err := workspaceinfra.ReadWorkspaceGitBranch(ctx, repoPath, func(
+		ctx context.Context,
+		args []string,
+		allowExitCodeOne bool,
+	) ([]byte, error) {
+		return s.runProjectConversationGitCommand(ctx, machine, args, allowExitCodeOne)
+	})
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, workspaceinfra.ErrGitWorkspaceUnavailable) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (s *ProjectConversationService) listConversationWorkspaceRepoBindingChanges(
+	ctx context.Context,
+	projectID uuid.UUID,
+	since time.Time,
+) (map[uuid.UUID]struct{}, error) {
+	changes := make(map[uuid.UUID]struct{})
+	before := ""
+	since = since.UTC()
+
+	for {
+		input, err := catalogdomain.ParseListActivityEvents(projectID, catalogdomain.ActivityEventListInput{
+			Limit:  strconv.Itoa(catalogdomain.MaxActivityEventLimit),
+			Before: before,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("build activity filter for workspace repo sync: %w", err)
+		}
+		page, err := s.catalog.ListActivityEvents(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("list project activity for workspace repo sync: %w", err)
+		}
+
+		reachedHistoryBeforeConversation := false
+		for _, event := range page.Events {
+			if !event.CreatedAt.UTC().After(since) {
+				reachedHistoryBeforeConversation = true
+				break
+			}
+			repoID, ok := projectConversationWorkspaceBindingChangeRepoID(event)
+			if ok {
+				changes[repoID] = struct{}{}
+			}
+		}
+
+		if reachedHistoryBeforeConversation || !page.HasMore || strings.TrimSpace(page.NextCursor) == "" {
+			break
+		}
+		before = page.NextCursor
+	}
+
+	return changes, nil
+}
+
+func projectConversationWorkspaceBindingChangeRepoID(
+	event catalogdomain.ActivityEvent,
+) (uuid.UUID, bool) {
+	switch event.EventType {
+	case activityevent.TypeProjectRepoCreated:
+	case activityevent.TypeProjectRepoUpdated:
+		if !projectConversationWorkspaceActivityTouchesBinding(event.Metadata) {
+			return uuid.UUID{}, false
+		}
+	default:
+		return uuid.UUID{}, false
+	}
+
+	rawRepoID, ok := event.Metadata["repo_id"].(string)
+	if !ok {
+		return uuid.UUID{}, false
+	}
+	repoID, err := uuid.Parse(strings.TrimSpace(rawRepoID))
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return repoID, true
+}
+
+func projectConversationWorkspaceActivityTouchesBinding(metadata map[string]any) bool {
+	changedFields, ok := metadata["changed_fields"]
+	if !ok {
+		return false
+	}
+	for _, field := range projectConversationWorkspaceChangedFields(changedFields) {
+		switch field {
+		case "repo", "name", "repository_url", "default_branch", "workspace_dirname":
+			return true
+		}
+	}
+	return false
+}
+
+func projectConversationWorkspaceChangedFields(raw any) []string {
+	switch typed := raw.(type) {
+	case []string:
+		return append([]string(nil), typed...)
+	case []any:
+		fields := make([]string, 0, len(typed))
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				continue
+			}
+			text = strings.TrimSpace(text)
+			if text != "" {
+				fields = append(fields, text)
+			}
+		}
+		return fields
+	default:
+		return nil
+	}
+}

--- a/internal/cli/api_parity_test.go
+++ b/internal/cli/api_parity_test.go
@@ -25,6 +25,7 @@ var intentionalCLIOpenAPIGaps = map[string]string{
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/file"):                               "project conversation workspace file preview has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/file-patch"):                         "project conversation workspace file diff has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/workspace/tree"):                               "project conversation workspace tree browsing has no first-class CLI yet",
+	contractKey("POST", "/api/v1/chat/conversations/{conversationId}/workspace/sync"):                              "project conversation workspace sync has no first-class CLI yet",
 	contractKey("POST", "/api/v1/chat/conversations/{conversationId}/terminal-sessions"):                           "project conversation terminal session creation has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/conversations/{conversationId}/terminal-sessions/{terminalSessionId}/attach"): "project conversation terminal websocket attach has no first-class CLI yet",
 	contractKey("GET", "/api/v1/chat/projects/{projectId}/conversations/stream"):                                   "project-scoped conversation stream has no first-class CLI yet",

--- a/internal/httpapi/authorization.go
+++ b/internal/httpapi/authorization.go
@@ -325,6 +325,7 @@ func humanRouteAuthorizationRuleFor(path string, method string) (humanRouteAutho
 		"/api/v1/chat/conversations/:conversationId/entries",
 		"/api/v1/chat/conversations/:conversationId/stream",
 		"/api/v1/chat/conversations/:conversationId/workspace",
+		"/api/v1/chat/conversations/:conversationId/workspace/sync",
 		"/api/v1/chat/conversations/:conversationId/workspace/tree",
 		"/api/v1/chat/conversations/:conversationId/workspace/file",
 		"/api/v1/chat/conversations/:conversationId/workspace/file-patch",
@@ -762,7 +763,7 @@ func ticketPermissionForPath(path, method string) humanauthdomain.PermissionKey 
 }
 
 func chatPermissionForPath(path, method string) humanauthdomain.PermissionKey {
-	if strings.Contains(path, "/terminal-sessions") {
+	if strings.Contains(path, "/terminal-sessions") || strings.HasSuffix(path, "/workspace/sync") {
 		return humanauthdomain.PermissionConversationUpdate
 	}
 	switch method {

--- a/internal/httpapi/chat_api.go
+++ b/internal/httpapi/chat_api.go
@@ -38,6 +38,7 @@ func (s *Server) registerChatRoutes(api *echo.Group) {
 	api.GET("/chat/conversations/:conversationId", s.handleGetProjectConversation)
 	api.GET("/chat/conversations/:conversationId/entries", s.handleListProjectConversationEntries)
 	api.GET("/chat/conversations/:conversationId/workspace", s.handleGetProjectConversationWorkspace)
+	api.POST("/chat/conversations/:conversationId/workspace/sync", s.handleSyncProjectConversationWorkspace)
 	api.GET("/chat/conversations/:conversationId/workspace/tree", s.handleListProjectConversationWorkspaceTree)
 	api.GET("/chat/conversations/:conversationId/workspace/file", s.handleGetProjectConversationWorkspaceFile)
 	api.GET("/chat/conversations/:conversationId/workspace/file-patch", s.handleGetProjectConversationWorkspaceFilePatch)
@@ -543,6 +544,25 @@ func (s *Server) handleGetProjectConversationWorkspace(c echo.Context) error {
 		return writeChatUserError(c, err)
 	}
 	item, err := s.projectConversationService.GetWorkspaceMetadata(c.Request().Context(), userID, conversationID)
+	if err != nil {
+		return writeProjectConversationError(c, err)
+	}
+	return c.JSON(http.StatusOK, map[string]any{"workspace": mapProjectConversationWorkspaceMetadataResponse(item)})
+}
+
+func (s *Server) handleSyncProjectConversationWorkspace(c echo.Context) error {
+	if s.projectConversationService == nil {
+		return writeAPIError(c, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "project conversation service unavailable")
+	}
+	conversationID, err := parseUUIDString("conversation_id", c.Param("conversationId"))
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_CONVERSATION_ID", err.Error())
+	}
+	userID, err := s.currentProjectConversationUserID(c)
+	if err != nil {
+		return writeChatUserError(c, err)
+	}
+	item, err := s.projectConversationService.SyncWorkspace(c.Request().Context(), userID, conversationID)
 	if err != nil {
 		return writeProjectConversationError(c, err)
 	}
@@ -1067,6 +1087,18 @@ func writeProjectConversationError(c echo.Context, err error) error {
 		return writeAPIError(c, http.StatusConflict, "CHAT_CONVERSATION_RUNTIME_UNAVAILABLE", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspaceUnavailable):
 		return writeAPIError(c, http.StatusConflict, "PROJECT_CONVERSATION_WORKSPACE_UNAVAILABLE", err.Error())
+	case errors.Is(err, chatservice.ErrProjectConversationWorkspaceSyncRequired):
+		var syncErr *chatservice.ProjectConversationWorkspaceSyncRequiredError
+		if errors.As(err, &syncErr) {
+			return writeAPIErrorWithDetails(
+				c,
+				http.StatusConflict,
+				"PROJECT_CONVERSATION_WORKSPACE_SYNC_REQUIRED",
+				err.Error(),
+				mapProjectConversationWorkspaceSyncPromptResponse(&syncErr.Prompt),
+			)
+		}
+		return writeAPIError(c, http.StatusConflict, "PROJECT_CONVERSATION_WORKSPACE_SYNC_REQUIRED", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspacePathInvalid):
 		return writeAPIError(c, http.StatusBadRequest, "PROJECT_CONVERSATION_WORKSPACE_PATH_INVALID", err.Error())
 	case errors.Is(err, chatservice.ErrProjectConversationWorkspaceRepoNotFound), errors.Is(err, chatservice.ErrProjectConversationWorkspaceEntryNotFound):
@@ -1205,7 +1237,7 @@ func mapProjectConversationWorkspaceDiffResponse(
 		})
 	}
 
-	return map[string]any{
+	response := map[string]any{
 		"conversation_id": item.ConversationID.String(),
 		"workspace_path":  item.WorkspacePath,
 		"dirty":           item.Dirty,
@@ -1215,6 +1247,10 @@ func mapProjectConversationWorkspaceDiffResponse(
 		"removed":         item.Removed,
 		"repos":           repos,
 	}
+	if item.SyncPrompt != nil {
+		response["sync_prompt"] = mapProjectConversationWorkspaceSyncPromptResponse(item.SyncPrompt)
+	}
+	return response
 }
 
 func mapProjectConversationTerminalSessionResponse(
@@ -1251,11 +1287,34 @@ func mapProjectConversationWorkspaceMetadataResponse(
 			"removed":       repo.Removed,
 		})
 	}
-	return map[string]any{
+	response := map[string]any{
 		"conversation_id": item.ConversationID.String(),
 		"available":       item.Available,
 		"workspace_path":  item.WorkspacePath,
 		"repos":           repos,
+	}
+	if item.SyncPrompt != nil {
+		response["sync_prompt"] = mapProjectConversationWorkspaceSyncPromptResponse(item.SyncPrompt)
+	}
+	return response
+}
+
+func mapProjectConversationWorkspaceSyncPromptResponse(
+	item *chatservice.ProjectConversationWorkspaceSyncPrompt,
+) map[string]any {
+	if item == nil {
+		return nil
+	}
+	missingRepos := make([]map[string]any, 0, len(item.MissingRepos))
+	for _, repo := range item.MissingRepos {
+		missingRepos = append(missingRepos, map[string]any{
+			"name": repo.Name,
+			"path": repo.Path,
+		})
+	}
+	return map[string]any{
+		"reason":        string(item.Reason),
+		"missing_repos": missingRepos,
 	}
 }
 

--- a/internal/httpapi/chat_api_test.go
+++ b/internal/httpapi/chat_api_test.go
@@ -35,6 +35,8 @@ import (
 	humanauthservice "github.com/BetterAndBetterII/openase/internal/service/humanauth"
 	ticketservice "github.com/BetterAndBetterII/openase/internal/ticket"
 	workflowservice "github.com/BetterAndBetterII/openase/internal/workflow"
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
@@ -222,6 +224,11 @@ func TestProjectConversationRoutesRequireHumanPrincipalInOIDCMode(t *testing.T) 
 			name:   "workspace metadata",
 			method: http.MethodGet,
 			target: "/api/v1/chat/conversations/" + conversationID + "/workspace",
+		},
+		{
+			name:   "workspace sync",
+			method: http.MethodPost,
+			target: "/api/v1/chat/conversations/" + conversationID + "/workspace/sync",
 		},
 		{
 			name:   "workspace tree",
@@ -2023,6 +2030,29 @@ func setupProjectConversationTerminalRouteFixture(t *testing.T, client *ent.Clie
 	repoPath := workspaceinfra.RepoPath(workspacePath, "", "backend")
 	if err := os.MkdirAll(filepath.Join(repoPath, "src"), 0o750); err != nil {
 		t.Fatalf("mkdir repo path: %v", err)
+	}
+	repository, err := git.PlainInit(repoPath, false)
+	if err != nil {
+		t.Fatalf("git init repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "src", "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write repo seed file: %v", err)
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		t.Fatalf("load repo worktree: %v", err)
+	}
+	if _, err := worktree.Add("src/main.go"); err != nil {
+		t.Fatalf("git add repo seed file: %v", err)
+	}
+	if _, err := worktree.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Codex",
+			Email: "codex@openai.com",
+			When:  time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC),
+		},
+	}); err != nil {
+		t.Fatalf("git commit repo seed file: %v", err)
 	}
 
 	return projectConversationTerminalRouteFixture{

--- a/internal/httpapi/openapi.go
+++ b/internal/httpapi/openapi.go
@@ -503,15 +503,26 @@ type OpenAPIProjectConversationWorkspaceDiffRepo struct {
 	Files        []OpenAPIProjectConversationWorkspaceDiffFile `json:"files"`
 }
 
+type OpenAPIProjectConversationWorkspaceMissingRepo struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type OpenAPIProjectConversationWorkspaceSyncPrompt struct {
+	Reason       string                                           `json:"reason"`
+	MissingRepos []OpenAPIProjectConversationWorkspaceMissingRepo `json:"missing_repos"`
+}
+
 type OpenAPIProjectConversationWorkspaceDiff struct {
-	ConversationID string                                        `json:"conversation_id"`
-	WorkspacePath  string                                        `json:"workspace_path"`
-	Dirty          bool                                          `json:"dirty"`
-	ReposChanged   int                                           `json:"repos_changed"`
-	FilesChanged   int                                           `json:"files_changed"`
-	Added          int                                           `json:"added"`
-	Removed        int                                           `json:"removed"`
-	Repos          []OpenAPIProjectConversationWorkspaceDiffRepo `json:"repos"`
+	ConversationID string                                         `json:"conversation_id"`
+	WorkspacePath  string                                         `json:"workspace_path"`
+	Dirty          bool                                           `json:"dirty"`
+	ReposChanged   int                                            `json:"repos_changed"`
+	FilesChanged   int                                            `json:"files_changed"`
+	Added          int                                            `json:"added"`
+	Removed        int                                            `json:"removed"`
+	Repos          []OpenAPIProjectConversationWorkspaceDiffRepo  `json:"repos"`
+	SyncPrompt     *OpenAPIProjectConversationWorkspaceSyncPrompt `json:"sync_prompt,omitempty"`
 }
 
 type OpenAPIProjectConversationWorkspaceDiffResponse struct {
@@ -535,6 +546,7 @@ type OpenAPIProjectConversationWorkspaceMetadata struct {
 	Available      bool                                              `json:"available"`
 	WorkspacePath  string                                            `json:"workspace_path"`
 	Repos          []OpenAPIProjectConversationWorkspaceRepoMetadata `json:"repos"`
+	SyncPrompt     *OpenAPIProjectConversationWorkspaceSyncPrompt    `json:"sync_prompt,omitempty"`
 }
 
 type OpenAPIProjectConversationWorkspaceMetadataResponse struct {
@@ -6398,6 +6410,25 @@ func (b openAPISpecBuilder) addChatOperations() error {
 	}
 	projectConversationWorkspace.AddParameter(uuidPathParameter("conversationId", "Stable OpenASE conversation ID."))
 	b.doc.AddOperation("/api/v1/chat/conversations/{conversationId}/workspace", http.MethodGet, projectConversationWorkspace)
+
+	projectConversationWorkspaceSync, err := b.jsonOperation(
+		"syncProjectConversationWorkspace",
+		"Sync newly bound project repos into the current conversation workspace",
+		[]string{"chat"},
+		http.StatusOK,
+		OpenAPIProjectConversationWorkspaceMetadataResponse{},
+		nil,
+		http.StatusBadRequest,
+		http.StatusConflict,
+		http.StatusNotFound,
+		http.StatusServiceUnavailable,
+		http.StatusInternalServerError,
+	)
+	if err != nil {
+		return err
+	}
+	projectConversationWorkspaceSync.AddParameter(uuidPathParameter("conversationId", "Stable OpenASE conversation ID."))
+	b.doc.AddOperation("/api/v1/chat/conversations/{conversationId}/workspace/sync", http.MethodPost, projectConversationWorkspaceSync)
 
 	projectConversationWorkspaceTree, err := b.jsonOperation(
 		"listProjectConversationWorkspaceTree",

--- a/web/src/lib/api/chat.ts
+++ b/web/src/lib/api/chat.ts
@@ -144,6 +144,18 @@ export type ProjectConversationWorkspaceDiffFile = {
   removed: number
 }
 
+export type ProjectConversationWorkspaceMissingRepo = {
+  name: string
+  path: string
+}
+
+export type ProjectConversationWorkspaceSyncReason = 'repo_binding_changed' | 'repo_missing'
+
+export type ProjectConversationWorkspaceSyncPrompt = {
+  reason: ProjectConversationWorkspaceSyncReason
+  missingRepos: ProjectConversationWorkspaceMissingRepo[]
+}
+
 export type ProjectConversationWorkspaceDiffRepo = {
   name: string
   path: string
@@ -164,6 +176,7 @@ export type ProjectConversationWorkspaceDiff = {
   added: number
   removed: number
   repos: ProjectConversationWorkspaceDiffRepo[]
+  syncPrompt?: ProjectConversationWorkspaceSyncPrompt
 }
 
 export type ProjectConversationWorkspaceRepoMetadata = {
@@ -183,6 +196,7 @@ export type ProjectConversationWorkspaceMetadata = {
   available: boolean
   workspacePath: string
   repos: ProjectConversationWorkspaceRepoMetadata[]
+  syncPrompt?: ProjectConversationWorkspaceSyncPrompt
 }
 
 export type ProjectConversationWorkspaceTreeEntryKind = 'directory' | 'file'
@@ -489,6 +503,17 @@ export async function getProjectConversationWorkspaceDiff(conversationId: string
 export async function getProjectConversationWorkspace(conversationId: string) {
   const payload = await fetchJSON<{ workspace?: unknown }>(
     `/api/v1/chat/conversations/${encodeURIComponent(conversationId)}/workspace`,
+  )
+  const object = parseRequiredObject(payload as Record<string, unknown>)
+  return {
+    workspace: parseProjectConversationWorkspaceMetadata(object.workspace ?? object),
+  }
+}
+
+export async function syncProjectConversationWorkspace(conversationId: string) {
+  const payload = await fetchJSON<{ workspace?: unknown }>(
+    `/api/v1/chat/conversations/${encodeURIComponent(conversationId)}/workspace/sync`,
+    { method: 'POST' },
   )
   const object = parseRequiredObject(payload as Record<string, unknown>)
   return {
@@ -1058,6 +1083,9 @@ function parseProjectConversationWorkspaceDiff(value: unknown): ProjectConversat
     added: readRequiredNumber(object, 'added'),
     removed: readRequiredNumber(object, 'removed'),
     repos: readProjectConversationWorkspaceDiffRepos(object),
+    syncPrompt: parseProjectConversationWorkspaceSyncPrompt(
+      readOptionalObject(object, 'sync_prompt'),
+    ),
   }
 }
 
@@ -1087,6 +1115,34 @@ function parseProjectConversationWorkspaceMetadata(
     available: readRequiredBoolean(object, 'available'),
     workspacePath: readOptionalString(object, 'workspace_path') ?? '',
     repos,
+    syncPrompt: parseProjectConversationWorkspaceSyncPrompt(
+      readOptionalObject(object, 'sync_prompt'),
+    ),
+  }
+}
+
+function parseProjectConversationWorkspaceSyncPrompt(
+  value?: Record<string, unknown>,
+): ProjectConversationWorkspaceSyncPrompt | undefined {
+  if (!value) {
+    return undefined
+  }
+  const reason = readRequiredString(value, 'reason')
+  if (reason !== 'repo_binding_changed' && reason !== 'repo_missing') {
+    throw new Error(`project conversation workspace sync reason ${reason} is unsupported`)
+  }
+  const missingRepos = Array.isArray(value.missing_repos)
+    ? value.missing_repos.map((item) => {
+        const repo = parseRequiredObject(item)
+        return {
+          name: readRequiredString(repo, 'name'),
+          path: readRequiredString(repo, 'path'),
+        } satisfies ProjectConversationWorkspaceMissingRepo
+      })
+    : []
+  return {
+    reason,
+    missingRepos,
   }
 }
 

--- a/web/src/lib/api/generated/openapi.d.ts
+++ b/web/src/lib/api/generated/openapi.d.ts
@@ -620,6 +620,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/chat/conversations/{conversationId}/workspace/sync': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Sync newly bound project repos into the current conversation workspace */
+    post: operations['syncProjectConversationWorkspace']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/chat/conversations/{conversationId}/workspace/tree': {
     parameters: {
       query?: never
@@ -6170,6 +6187,13 @@ export interface operations {
                 path?: string
                 removed?: number
               }[]
+              sync_prompt?: {
+                missing_repos?: {
+                  name?: string
+                  path?: string
+                }[]
+                reason?: string
+              } | null
               workspace_path?: string
             }
           }
@@ -6278,6 +6302,13 @@ export interface operations {
                 removed?: number
               }[]
               repos_changed?: number
+              sync_prompt?: {
+                missing_repos?: {
+                  name?: string
+                  path?: string
+                }[]
+                reason?: string
+              } | null
               workspace_path?: string
             }
           }
@@ -6465,6 +6496,113 @@ export interface operations {
               repo_path?: string
               status?: string
               truncated?: boolean
+            }
+          }
+        }
+      }
+      /** @description Bad Request response. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Not Found response. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Conflict response. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Internal Server Error response. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+      /** @description Service Unavailable response. */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            code?: string
+            message?: string
+          }
+        }
+      }
+    }
+  }
+  syncProjectConversationWorkspace: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Stable OpenASE conversation ID. */
+        conversationId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Sync newly bound project repos into the current conversation workspace response. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            workspace?: {
+              available?: boolean
+              conversation_id?: string
+              repos?: {
+                added?: number
+                branch?: string
+                dirty?: boolean
+                files_changed?: number
+                head_commit?: string
+                head_summary?: string
+                name?: string
+                path?: string
+                removed?: number
+              }[]
+              sync_prompt?: {
+                missing_repos?: {
+                  name?: string
+                  path?: string
+                }[]
+                reason?: string
+              } | null
+              workspace_path?: string
             }
           }
         }

--- a/web/src/lib/features/app-shell/components/project-shell-frame.svelte
+++ b/web/src/lib/features/app-shell/components/project-shell-frame.svelte
@@ -194,6 +194,7 @@
             conversationId={workspaceBrowserPortal.conversationId}
             workspaceDiff={workspaceBrowserPortal.workspaceDiff}
             workspaceDiffLoading={workspaceBrowserPortal.workspaceDiffLoading}
+            syncGeneration={workspaceBrowserPortal.syncGeneration}
             pendingFilePath={workspaceBrowserPortal.pendingFilePath}
             onClose={() => workspaceBrowserPortal.close()}
             onPendingFileConsumed={() => workspaceBrowserPortal.consumePendingFile()}

--- a/web/src/lib/features/chat/project-conversation-content.svelte
+++ b/web/src/lib/features/chat/project-conversation-content.svelte
@@ -20,6 +20,7 @@
     workspaceDiffError = '',
     entries = [],
     pending = false,
+    onSyncWorkspace,
     onSelectTab,
     onCloseTab,
     onRespondInterrupt,
@@ -34,6 +35,7 @@
     workspaceDiffError?: string
     entries?: ProjectConversationTranscriptEntry[]
     pending?: boolean
+    onSyncWorkspace?: () => Promise<void> | void
     onSelectTab: (tabId: string) => void
     onCloseTab: (tabId: string) => void
     onRespondInterrupt: (input: {
@@ -49,17 +51,24 @@
     workspaceBrowserPortal.conversationId = conversationId
     workspaceBrowserPortal.workspaceDiff = workspaceDiff ?? null
     workspaceBrowserPortal.workspaceDiffLoading = workspaceDiffLoading
+    workspaceBrowserPortal.onSyncWorkspace = conversationId
+      ? async () => {
+          await (onSyncWorkspace?.() ?? Promise.resolve())
+        }
+      : null
   })
 
   $effect(() => {
     if (!conversationId) {
       workspaceBrowserPortal.close()
+      workspaceBrowserPortal.onSyncWorkspace = null
     }
   })
 
   $effect(() => {
     return () => {
       workspaceBrowserPortal.close()
+      workspaceBrowserPortal.onSyncWorkspace = null
     }
   })
 </script>

--- a/web/src/lib/features/chat/project-conversation-controller-actions.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-actions.ts
@@ -95,6 +95,7 @@ type ProjectConversationControllerActionsInput = {
       message: string,
       focus?: ProjectAIFocus | null,
     ) => Promise<boolean>
+    refreshWorkspaceDiff: () => Promise<void>
     resetConversation: () => Promise<void>
     stopTurn: () => Promise<void>
     respondInterrupt: (inputValue: {
@@ -181,6 +182,9 @@ export function createProjectConversationControllerActions(
     },
     async sendTurn(message: string, focus?: ProjectAIFocus | null) {
       await input.operations.sendTurnInTab(input.getActiveTab(), message, focus)
+    },
+    async refreshWorkspaceDiff() {
+      await input.operations.refreshWorkspaceDiff()
     },
     async resetConversation() {
       await input.operations.resetConversation()

--- a/web/src/lib/features/chat/project-conversation-controller-operations.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-operations.ts
@@ -136,6 +136,15 @@ export function createProjectConversationControllerOperations(
     await runtime.resetConversation()
   }
 
+  async function refreshWorkspaceDiff() {
+    const activeTab = input.getActiveTab()
+    const conversationId = activeTab?.conversationId ?? ''
+    if (!activeTab || !conversationId) {
+      return
+    }
+    await runtime.refreshWorkspaceDiff(activeTab, conversationId)
+  }
+
   async function stopTurn() {
     const activeTab = input.getActiveTab()
     if (
@@ -217,6 +226,7 @@ export function createProjectConversationControllerOperations(
     createTab,
     selectTab,
     closeTab,
+    refreshWorkspaceDiff,
     resetConversation,
     stopTurn,
     respondInterrupt,

--- a/web/src/lib/features/chat/project-conversation-controller-runtime.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-runtime.ts
@@ -240,6 +240,12 @@ export function createProjectConversationControllerRuntime(
   return {
     sortProjectConversations: conversations.sortProjectConversations,
     loadTabConversation,
+    async refreshWorkspaceDiff(tab: ProjectConversationTabState | null, conversationId: string) {
+      if (!tab || !conversationId) {
+        return
+      }
+      await refreshTabWorkspaceDiff(tab, conversationId, touchTabs)
+    },
     restoreTabConversationMetadata: tabOps.restoreTabConversationMetadata,
     hydrateTabIfNeeded: tabOps.hydrateTabIfNeeded,
     openConversationInTab: tabOps.openConversationInTab,

--- a/web/src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts
+++ b/web/src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts
@@ -11,6 +11,7 @@ const {
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   getProjectConversationWorkspaceDiff,
+  syncProjectConversationWorkspace,
   listProjectConversationEntries,
   listProjectConversations,
   listProjectConversationWorkspaceTree,
@@ -28,6 +29,7 @@ const {
   getProjectConversationWorkspaceFilePatch: vi.fn(),
   getProjectConversationWorkspaceFilePreview: vi.fn(),
   getProjectConversationWorkspaceDiff: vi.fn(),
+  syncProjectConversationWorkspace: vi.fn(),
   listProjectConversationEntries: vi.fn(),
   listProjectConversations: vi.fn(),
   listProjectConversationWorkspaceTree: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock('$lib/api/chat', () => ({
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   getProjectConversationWorkspaceDiff,
+  syncProjectConversationWorkspace,
   listProjectConversationEntries,
   listProjectConversations,
   listProjectConversationWorkspaceTree,
@@ -293,5 +296,74 @@ describe('ProjectConversationPanel workspace summary', () => {
 
     await waitFor(() => expect(container.textContent).toContain('1 repo changed · +4 -1'))
     expect(getProjectConversationWorkspaceDiff).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces repo sync guidance and refreshes workspace diff after syncing', async () => {
+    listProjectConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: 'conversation-1',
+          rollingSummary: 'Current conversation',
+          lastActivityAt: '2026-04-01T10:00:00Z',
+          providerId: 'provider-1',
+        },
+      ],
+    })
+    getProjectConversationWorkspaceDiff
+      .mockResolvedValueOnce({
+        workspaceDiff: {
+          conversationId: 'conversation-1',
+          workspacePath: '/tmp/conversation-1',
+          dirty: false,
+          reposChanged: 0,
+          filesChanged: 0,
+          added: 0,
+          removed: 0,
+          repos: [],
+          syncPrompt: {
+            reason: 'repo_binding_changed',
+            missingRepos: [{ name: 'docs', path: 'docs' }],
+          },
+        },
+      })
+      .mockResolvedValueOnce(createWorkspaceDiff('conversation-1'))
+    syncProjectConversationWorkspace.mockResolvedValue({
+      workspace: {
+        conversationId: 'conversation-1',
+        available: true,
+        workspacePath: '/tmp/conversation-1',
+        repos: [],
+      },
+    })
+    listProjectConversationEntries.mockResolvedValue({
+      entries: [
+        {
+          id: 'entry-1',
+          conversationId: 'conversation-1',
+          turnId: 'turn-1',
+          seq: 1,
+          kind: 'user_message',
+          payload: { content: 'Current conversation' },
+          createdAt: '2026-04-01T10:00:00Z',
+        },
+      ],
+    })
+    watchProjectConversation.mockResolvedValue(undefined)
+
+    const { findByText, getByText } = render(ProjectConversationPanel, {
+      props: {
+        context: { projectId: 'project-1' },
+        providers: providerFixtures,
+        defaultProviderId: 'provider-1',
+      },
+    })
+
+    await findByText('1 repo needs sync')
+    await fireEvent.click(getByText('Sync repos'))
+
+    await waitFor(() => {
+      expect(syncProjectConversationWorkspace).toHaveBeenCalledWith('conversation-1')
+      expect(getProjectConversationWorkspaceDiff).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/web/src/lib/features/chat/project-conversation-panel.svelte
+++ b/web/src/lib/features/chat/project-conversation-panel.svelte
@@ -276,6 +276,7 @@
     {workspaceDiffError}
     {entries}
     {pending}
+    onSyncWorkspace={() => controller.refreshWorkspaceDiff()}
     onSelectTab={controller.selectTab}
     onCloseTab={controller.closeTab}
     onRespondInterrupt={controller.respondInterrupt}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
@@ -102,10 +102,8 @@ describe('ProjectConversationWorkspaceBrowser', () => {
         workspaceDiffLoading: false,
       },
     })
-
     await view.findByText('Workspace sync required')
     await fireEvent.click(view.getByRole('button', { name: 'Sync repos' }))
-
     await waitFor(() => {
       expect(syncProjectConversationWorkspace).toHaveBeenCalledWith('conversation-1')
       expect(getProjectConversationWorkspace).toHaveBeenCalledTimes(2)
@@ -159,14 +157,11 @@ describe('ProjectConversationWorkspaceBrowser', () => {
 
     await fireEvent.click(await view.findByRole('button', { name: 'src' }, { timeout: 3000 }))
     await fireEvent.click(await view.findByRole('button', { name: 'main.ts' }, { timeout: 3000 }))
-
     await waitFor(() => {
       expect(getProjectConversationWorkspaceFilePreview).toHaveBeenCalledTimes(1)
       expect(getProjectConversationWorkspaceFilePatch).toHaveBeenCalledTimes(1)
     })
-
     await fireEvent.click(view.getByRole('button', { name: 'Refresh workspace browser' }))
-
     await waitFor(() => {
       expect(getProjectConversationWorkspace).toHaveBeenCalledTimes(2)
       expect(listProjectConversationWorkspaceTree).toHaveBeenCalledWith('conversation-1', {
@@ -180,7 +175,6 @@ describe('ProjectConversationWorkspaceBrowser', () => {
       expect(getProjectConversationWorkspaceFilePreview).toHaveBeenCalledTimes(2)
       expect(getProjectConversationWorkspaceFilePatch).toHaveBeenCalledTimes(2)
     })
-
     expect(view.container.textContent).toContain('main.ts')
     expect(view.container.textContent).toContain('export const refreshed = true;')
   })
@@ -233,19 +227,15 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     await fireEvent.click(await view.findByRole('button', { name: 'src' }, { timeout: 3000 }))
     const mainFileButton = await view.findByRole('button', { name: 'main.ts' }, { timeout: 3000 })
     await fireEvent.click(mainFileButton)
-
     await waitFor(() => {
       expect(view.container.textContent).toContain('export const stable = true;')
     })
-
     await fireEvent.click(view.getByRole('button', { name: 'Refresh workspace browser' }))
-
     await waitFor(() => {
       expect(getProjectConversationWorkspace).toHaveBeenCalledTimes(2)
       expect(getProjectConversationWorkspaceFilePreview).toHaveBeenCalledTimes(2)
       expect(getProjectConversationWorkspaceFilePatch).toHaveBeenCalledTimes(2)
     })
-
     expect(view.getByRole('button', { name: 'main.ts' })).toBe(mainFileButton)
     expect(view.container.textContent).toContain('export const stable = true;')
     expect(view.container.textContent).not.toContain('Loading files…')
@@ -363,20 +353,16 @@ describe('ProjectConversationWorkspaceBrowser', () => {
     await fireEvent.click(await view.findByRole('button', { name: 'src' }, { timeout: 3000 }))
     const mainFileButton = await view.findByRole('button', { name: 'main.ts' }, { timeout: 3000 })
     await fireEvent.click(mainFileButton)
-
     await waitFor(() => {
       expect(view.container.textContent).toContain('export const stable = true;')
     })
-
     await fireEvent.click(view.getByRole('button', { name: 'Refresh workspace browser' }))
-
     await waitFor(() =>
       expect(listProjectConversationWorkspaceTree).toHaveBeenCalledWith('conversation-1', {
         repoPath: 'services/openase',
         path: 'src',
       }),
     )
-
     expect(view.getByRole('button', { name: 'main.ts' })).toBe(mainFileButton)
     expect(view.container.textContent).toContain('export const stable = true;')
     expect(view.container.textContent).not.toContain('Loading files…')
@@ -396,7 +382,6 @@ describe('ProjectConversationWorkspaceBrowser', () => {
       expect(getProjectConversationWorkspaceFilePreview).toHaveBeenCalledTimes(2)
       expect(getProjectConversationWorkspaceFilePatch).toHaveBeenCalledTimes(2)
     })
-
     expect(view.getByRole('button', { name: 'main.ts' })).toBe(mainFileButton)
     expect(view.container.textContent).toContain('export const stable = true;')
     expect(view.container.textContent).not.toContain('Loading…')

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts
@@ -7,11 +7,13 @@ const {
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
+  syncProjectConversationWorkspace,
 } = vi.hoisted(() => ({
   getProjectConversationWorkspace: vi.fn(),
   getProjectConversationWorkspaceFilePatch: vi.fn(),
   getProjectConversationWorkspaceFilePreview: vi.fn(),
   listProjectConversationWorkspaceTree: vi.fn(),
+  syncProjectConversationWorkspace: vi.fn(),
 }))
 
 vi.mock('$lib/api/chat', () => ({
@@ -19,6 +21,7 @@ vi.mock('$lib/api/chat', () => ({
   getProjectConversationWorkspaceFilePatch,
   getProjectConversationWorkspaceFilePreview,
   listProjectConversationWorkspaceTree,
+  syncProjectConversationWorkspace,
 }))
 
 vi.mock('@xterm/xterm', () => ({
@@ -65,6 +68,48 @@ describe('ProjectConversationWorkspaceBrowser', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+  })
+
+  it('shows a sync prompt when repo bindings changed and refreshes the browser after syncing', async () => {
+    mockWorkspaceMetadata(getProjectConversationWorkspace)
+    listProjectConversationWorkspaceTree.mockResolvedValue({
+      workspaceTree: {
+        conversationId: 'conversation-1',
+        repoPath: 'services/openase',
+        path: '',
+        entries: [],
+      },
+    })
+    syncProjectConversationWorkspace.mockResolvedValue({
+      workspace: structuredClone(workspaceMetadata),
+    })
+
+    const syncedMetadata = structuredClone(workspaceMetadata)
+    getProjectConversationWorkspace
+      .mockResolvedValueOnce({ workspace: structuredClone(workspaceMetadata) })
+      .mockResolvedValueOnce({ workspace: syncedMetadata })
+
+    const view = render(ProjectConversationWorkspaceBrowser, {
+      props: {
+        conversationId: 'conversation-1',
+        workspaceDiff: {
+          ...workspaceDiff,
+          syncPrompt: {
+            reason: 'repo_binding_changed',
+            missingRepos: [{ name: 'docs', path: 'docs' }],
+          },
+        },
+        workspaceDiffLoading: false,
+      },
+    })
+
+    await view.findByText('Workspace sync required')
+    await fireEvent.click(view.getByRole('button', { name: 'Sync repos' }))
+
+    await waitFor(() => {
+      expect(syncProjectConversationWorkspace).toHaveBeenCalledWith('conversation-1')
+      expect(getProjectConversationWorkspace).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('preserves the expanded directory and selected file when the toolbar refresh is clicked', async () => {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -48,6 +48,27 @@ function areWorkspaceMetadataEqual(
     return false
   }
 
+  const leftSync = left.syncPrompt
+  const rightSync = right.syncPrompt
+  if (!!leftSync !== !!rightSync) {
+    return false
+  }
+  if (leftSync && rightSync) {
+    if (
+      leftSync.reason !== rightSync.reason ||
+      leftSync.missingRepos.length !== rightSync.missingRepos.length
+    ) {
+      return false
+    }
+    for (let index = 0; index < leftSync.missingRepos.length; index += 1) {
+      const leftRepo = leftSync.missingRepos[index]
+      const rightRepo = rightSync.missingRepos[index]
+      if (!rightRepo || leftRepo.name !== rightRepo.name || leftRepo.path !== rightRepo.path) {
+        return false
+      }
+    }
+  }
+
   return left.repos.every((repo, index) => {
     const next = right.repos[index]
     return (

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-toolbar.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-toolbar.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import { Button } from '$ui/button'
+  import { cn } from '$lib/utils'
+  import { Check, Copy, FolderTree, RefreshCcw, SquareTerminal, X } from '@lucide/svelte'
+
+  let {
+    workspacePath = '',
+    pathCopied = false,
+    showTerminalButton = false,
+    terminalPanelOpen = false,
+    conversationId = '',
+    metadataLoading = false,
+    onCopyWorkspacePath,
+    onToggleTerminal,
+    onRefreshWorkspace,
+    onClose,
+  }: {
+    workspacePath?: string
+    pathCopied?: boolean
+    showTerminalButton?: boolean
+    terminalPanelOpen?: boolean
+    conversationId?: string
+    metadataLoading?: boolean
+    onCopyWorkspacePath?: () => void
+    onToggleTerminal?: () => void
+    onRefreshWorkspace?: () => void
+    onClose?: () => void
+  } = $props()
+</script>
+
+<div class="border-border flex h-9 items-center gap-1.5 border-b px-3">
+  <FolderTree class="text-muted-foreground size-3 shrink-0" />
+  <span class="text-[12px] font-semibold">Workspace</span>
+  {#if workspacePath}
+    <button
+      type="button"
+      class="text-muted-foreground/50 hover:text-muted-foreground group flex min-w-0 items-center gap-1 truncate text-[11px] transition-colors"
+      title="Click to copy path"
+      onclick={onCopyWorkspacePath}
+    >
+      <span class="min-w-0 truncate">{workspacePath}</span>
+      {#if pathCopied}
+        <Check class="size-2.5 shrink-0 text-emerald-500" />
+      {:else}
+        <Copy class="size-2.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+      {/if}
+    </button>
+  {/if}
+  <div class="flex-1"></div>
+  {#if showTerminalButton}
+    <Button
+      variant={terminalPanelOpen ? 'secondary' : 'ghost'}
+      size="icon-xs"
+      class={cn('text-muted-foreground size-6', terminalPanelOpen && 'text-foreground')}
+      aria-label="Toggle terminal"
+      onclick={onToggleTerminal}
+      disabled={!conversationId}
+    >
+      <SquareTerminal class="size-3" />
+    </Button>
+  {/if}
+  <Button
+    variant="ghost"
+    size="icon-xs"
+    class="text-muted-foreground size-6"
+    aria-label="Refresh workspace browser"
+    onclick={onRefreshWorkspace}
+    disabled={!conversationId || metadataLoading}
+  >
+    <RefreshCcw class={cn('size-3', metadataLoading && 'animate-spin')} />
+  </Button>
+  {#if onClose}
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      class="text-muted-foreground size-6"
+      aria-label="Close workspace browser"
+      onclick={onClose}
+    >
+      <X class="size-3" />
+    </Button>
+  {/if}
+</div>

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -1,29 +1,17 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
-  import { untrack } from 'svelte'
-  import { Button } from '$ui/button'
-  import {
-    syncProjectConversationWorkspace,
-    type ProjectConversationWorkspaceSyncPrompt,
-  } from '$lib/api/chat'
+  import { onDestroy, untrack } from 'svelte'
+  import { syncProjectConversationWorkspace } from '$lib/api/chat'
   import { cn } from '$lib/utils'
-  import {
-    AlertCircle,
-    Check,
-    Copy,
-    FolderTree,
-    RefreshCcw,
-    SquareTerminal,
-    X,
-  } from '@lucide/svelte'
+  import { AlertCircle } from '@lucide/svelte'
   import type { ProjectConversationWorkspaceDiff } from '$lib/api/chat'
   import WorkspaceTerminalPanel from './workspace-terminal-panel.svelte'
   import ProjectConversationWorkspaceBrowserDetail from './project-conversation-workspace-browser-detail.svelte'
   import ProjectConversationWorkspaceBrowserSidebar from './project-conversation-workspace-browser-sidebar.svelte'
+  import ProjectConversationWorkspaceSyncBanner from './project-conversation-workspace-sync-banner.svelte'
+  import ProjectConversationWorkspaceBrowserToolbar from './project-conversation-workspace-browser-toolbar.svelte'
   import { createProjectConversationWorkspaceBrowserState } from './project-conversation-workspace-browser-state.svelte'
   import { createTerminalManager } from './terminal-manager.svelte'
   import { workspaceBrowserPortal } from './workspace-browser-portal.svelte'
-  import { onDestroy } from 'svelte'
 
   let {
     conversationId = '',
@@ -67,7 +55,6 @@
     setTimeout(() => (pathCopied = false), 1500)
   }
 
-  // -- Sidebar resize --
   const MIN_SIDEBAR_WIDTH = 180
   const MAX_SIDEBAR_WIDTH = 480
   let sidebarWidth = $state(240)
@@ -96,7 +83,6 @@
     window.addEventListener('pointerup', onUp)
   }
 
-  // -- Terminal panel vertical resize --
   const MIN_TERMINAL_HEIGHT = 120
   const DEFAULT_TERMINAL_HEIGHT = 260
   let terminalHeight = $state(DEFAULT_TERMINAL_HEIGHT)
@@ -145,21 +131,6 @@
     workspaceDiff?.repos.find((repo) => repo.path === browser.selectedRepoPath) ?? null,
   )
   const syncPrompt = $derived(workspaceDiff?.syncPrompt ?? browser.metadata?.syncPrompt ?? null)
-
-  function syncPromptTitle(prompt: ProjectConversationWorkspaceSyncPrompt | null) {
-    if (!prompt) return ''
-    return prompt.reason === 'repo_binding_changed'
-      ? 'Workspace sync required'
-      : 'Some project repos are missing from this workspace'
-  }
-
-  function syncPromptDescription(prompt: ProjectConversationWorkspaceSyncPrompt | null) {
-    if (!prompt) return ''
-    if (prompt.reason === 'repo_binding_changed') {
-      return 'This conversation workspace was prepared before the latest project repo binding changes. Newly bound repos have not been cloned into this workspace yet, so browse and diff can be incomplete until you sync.'
-    }
-    return 'One or more repos are bound to this project but are still missing from the current conversation workspace. Sync the workspace to clone them before browsing or diffing.'
-  }
 
   async function handleSyncWorkspace() {
     if (!conversationId || syncInFlight) {
@@ -243,60 +214,18 @@
   data-testid="project-conversation-workspace-browser"
   bind:this={containerElement}
 >
-  <!-- Compact toolbar -->
-  <div class="border-border flex h-9 items-center gap-1.5 border-b px-3">
-    <FolderTree class="text-muted-foreground size-3 shrink-0" />
-    <span class="text-[12px] font-semibold">Workspace</span>
-    {#if browser.metadata?.workspacePath}
-      <button
-        type="button"
-        class="text-muted-foreground/50 hover:text-muted-foreground group flex min-w-0 items-center gap-1 truncate text-[11px] transition-colors"
-        title="Click to copy path"
-        onclick={copyWorkspacePath}
-      >
-        <span class="min-w-0 truncate">{browser.metadata.workspacePath}</span>
-        {#if pathCopied}
-          <Check class="size-2.5 shrink-0 text-emerald-500" />
-        {:else}
-          <Copy class="size-2.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
-        {/if}
-      </button>
-    {/if}
-    <div class="flex-1"></div>
-    {#if browser.metadata?.available}
-      <Button
-        variant={terminalManager.panelOpen ? 'secondary' : 'ghost'}
-        size="icon-xs"
-        class={cn('text-muted-foreground size-6', terminalManager.panelOpen && 'text-foreground')}
-        aria-label="Toggle terminal"
-        onclick={() => terminalManager.togglePanel()}
-        disabled={!conversationId}
-      >
-        <SquareTerminal class="size-3" />
-      </Button>
-    {/if}
-    <Button
-      variant="ghost"
-      size="icon-xs"
-      class="text-muted-foreground size-6"
-      aria-label="Refresh workspace browser"
-      onclick={() => void browser.refreshWorkspace(true)}
-      disabled={!conversationId || browser.metadataLoading}
-    >
-      <RefreshCcw class={cn('size-3', browser.metadataLoading && 'animate-spin')} />
-    </Button>
-    {#if onClose}
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        class="text-muted-foreground size-6"
-        aria-label="Close workspace browser"
-        onclick={onClose}
-      >
-        <X class="size-3" />
-      </Button>
-    {/if}
-  </div>
+  <ProjectConversationWorkspaceBrowserToolbar
+    workspacePath={browser.metadata?.workspacePath ?? ''}
+    {pathCopied}
+    showTerminalButton={Boolean(browser.metadata?.available)}
+    terminalPanelOpen={terminalManager.panelOpen}
+    {conversationId}
+    metadataLoading={browser.metadataLoading}
+    onCopyWorkspacePath={copyWorkspacePath}
+    onToggleTerminal={() => terminalManager.togglePanel()}
+    onRefreshWorkspace={() => void browser.refreshWorkspace(true)}
+    {onClose}
+  />
 
   {#if !conversationId}
     <div
@@ -329,24 +258,13 @@
       The workspace will appear after Project AI provisions the conversation workdir.
     </div>
   {:else if syncPrompt && (browser.metadata?.repos.length ?? 0) === 0}
-    <div class="flex flex-1 items-center justify-center px-6">
-      <div class="border-border bg-muted/20 max-w-lg rounded-xl border p-5 text-left">
-        <p class="text-sm font-medium">{syncPromptTitle(syncPrompt)}</p>
-        <p class="text-muted-foreground mt-2 text-sm">{syncPromptDescription(syncPrompt)}</p>
-        <p class="text-muted-foreground mt-3 text-xs">
-          Missing repos:
-          {syncPrompt.missingRepos.map((repo) => repo.path).join(', ')}
-        </p>
-        {#if syncError}
-          <p class="text-destructive mt-3 text-xs">{syncError}</p>
-        {/if}
-        <div class="mt-4 flex gap-2">
-          <Button size="sm" onclick={() => void handleSyncWorkspace()} disabled={syncInFlight}>
-            {syncInFlight ? 'Syncing repos...' : 'Sync repos'}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <ProjectConversationWorkspaceSyncBanner
+      prompt={syncPrompt}
+      {syncError}
+      {syncInFlight}
+      centered
+      onSync={handleSyncWorkspace}
+    />
   {:else}
     <div
       class={cn(
@@ -355,32 +273,12 @@
       )}
     >
       {#if syncPrompt}
-        <div
-          class="border-border border-b bg-amber-50/80 px-3 py-2 text-amber-950 dark:bg-amber-500/10 dark:text-amber-100"
-        >
-          <div class="flex items-start gap-3">
-            <AlertCircle class="mt-0.5 size-4 shrink-0" />
-            <div class="min-w-0 flex-1">
-              <p class="text-sm font-medium">{syncPromptTitle(syncPrompt)}</p>
-              <p class="mt-1 text-xs leading-5">{syncPromptDescription(syncPrompt)}</p>
-              <p class="mt-2 text-xs">
-                Missing repos: {syncPrompt.missingRepos.map((repo) => repo.path).join(', ')}
-              </p>
-              {#if syncError}
-                <p class="text-destructive mt-2 text-xs">{syncError}</p>
-              {/if}
-            </div>
-            <Button
-              size="sm"
-              variant="secondary"
-              class="shrink-0"
-              onclick={() => void handleSyncWorkspace()}
-              disabled={syncInFlight}
-            >
-              {syncInFlight ? 'Syncing...' : 'Sync repos'}
-            </Button>
-          </div>
-        </div>
+        <ProjectConversationWorkspaceSyncBanner
+          prompt={syncPrompt}
+          {syncError}
+          {syncInFlight}
+          onSync={handleSyncWorkspace}
+        />
       {/if}
       <!-- Files area -->
       <div class="flex min-h-0 flex-1">

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.svelte
@@ -2,6 +2,10 @@
   /* eslint-disable max-lines */
   import { untrack } from 'svelte'
   import { Button } from '$ui/button'
+  import {
+    syncProjectConversationWorkspace,
+    type ProjectConversationWorkspaceSyncPrompt,
+  } from '$lib/api/chat'
   import { cn } from '$lib/utils'
   import {
     AlertCircle,
@@ -18,12 +22,14 @@
   import ProjectConversationWorkspaceBrowserSidebar from './project-conversation-workspace-browser-sidebar.svelte'
   import { createProjectConversationWorkspaceBrowserState } from './project-conversation-workspace-browser-state.svelte'
   import { createTerminalManager } from './terminal-manager.svelte'
+  import { workspaceBrowserPortal } from './workspace-browser-portal.svelte'
   import { onDestroy } from 'svelte'
 
   let {
     conversationId = '',
     workspaceDiff = null,
     workspaceDiffLoading = false,
+    syncGeneration = 0,
     pendingFilePath = '',
     onClose,
     onPendingFileConsumed,
@@ -31,6 +37,7 @@
     conversationId?: string
     workspaceDiff?: ProjectConversationWorkspaceDiff | null
     workspaceDiffLoading?: boolean
+    syncGeneration?: number
     /** File path to navigate to (consumed once on change). */
     pendingFilePath?: string
     onClose?: () => void
@@ -125,6 +132,9 @@
   let lastRefreshKey = $state('')
   let lastWorkspaceDiffLoading = $state(false)
   let lastConversationId = $state('')
+  let lastSyncGeneration = $state(0)
+  let syncInFlight = $state(false)
+  let syncError = $state('')
 
   const selectedRepo = $derived(
     browser.metadata?.repos.find((repo) => repo.path === browser.selectedRepoPath) ??
@@ -134,6 +144,41 @@
   const selectedRepoDiff = $derived(
     workspaceDiff?.repos.find((repo) => repo.path === browser.selectedRepoPath) ?? null,
   )
+  const syncPrompt = $derived(workspaceDiff?.syncPrompt ?? browser.metadata?.syncPrompt ?? null)
+
+  function syncPromptTitle(prompt: ProjectConversationWorkspaceSyncPrompt | null) {
+    if (!prompt) return ''
+    return prompt.reason === 'repo_binding_changed'
+      ? 'Workspace sync required'
+      : 'Some project repos are missing from this workspace'
+  }
+
+  function syncPromptDescription(prompt: ProjectConversationWorkspaceSyncPrompt | null) {
+    if (!prompt) return ''
+    if (prompt.reason === 'repo_binding_changed') {
+      return 'This conversation workspace was prepared before the latest project repo binding changes. Newly bound repos have not been cloned into this workspace yet, so browse and diff can be incomplete until you sync.'
+    }
+    return 'One or more repos are bound to this project but are still missing from the current conversation workspace. Sync the workspace to clone them before browsing or diffing.'
+  }
+
+  async function handleSyncWorkspace() {
+    if (!conversationId || syncInFlight) {
+      return
+    }
+    syncInFlight = true
+    syncError = ''
+    try {
+      await syncProjectConversationWorkspace(conversationId)
+      workspaceBrowserPortal.markWorkspaceSynced()
+      await Promise.resolve(workspaceBrowserPortal.onSyncWorkspace?.())
+      await browser.refreshWorkspace(true)
+    } catch (error) {
+      syncError =
+        error instanceof Error ? error.message : 'Failed to sync the Project AI workspace.'
+    } finally {
+      syncInFlight = false
+    }
+  }
 
   // Navigate to a pending file when set
   $effect(() => {
@@ -158,6 +203,19 @@
       refreshGeneration += 1
     }
     lastWorkspaceDiffLoading = nextLoading
+  })
+
+  $effect(() => {
+    if (!conversationId) {
+      lastSyncGeneration = syncGeneration
+      return
+    }
+    if (syncGeneration !== lastSyncGeneration) {
+      lastSyncGeneration = syncGeneration
+      untrack(() => {
+        void browser.refreshWorkspace(true)
+      })
+    }
   })
 
   $effect(() => {
@@ -270,6 +328,25 @@
     >
       The workspace will appear after Project AI provisions the conversation workdir.
     </div>
+  {:else if syncPrompt && (browser.metadata?.repos.length ?? 0) === 0}
+    <div class="flex flex-1 items-center justify-center px-6">
+      <div class="border-border bg-muted/20 max-w-lg rounded-xl border p-5 text-left">
+        <p class="text-sm font-medium">{syncPromptTitle(syncPrompt)}</p>
+        <p class="text-muted-foreground mt-2 text-sm">{syncPromptDescription(syncPrompt)}</p>
+        <p class="text-muted-foreground mt-3 text-xs">
+          Missing repos:
+          {syncPrompt.missingRepos.map((repo) => repo.path).join(', ')}
+        </p>
+        {#if syncError}
+          <p class="text-destructive mt-3 text-xs">{syncError}</p>
+        {/if}
+        <div class="mt-4 flex gap-2">
+          <Button size="sm" onclick={() => void handleSyncWorkspace()} disabled={syncInFlight}>
+            {syncInFlight ? 'Syncing repos...' : 'Sync repos'}
+          </Button>
+        </div>
+      </div>
+    </div>
   {:else}
     <div
       class={cn(
@@ -277,6 +354,34 @@
         (sidebarResizing || terminalResizing) && 'select-none',
       )}
     >
+      {#if syncPrompt}
+        <div
+          class="border-border border-b bg-amber-50/80 px-3 py-2 text-amber-950 dark:bg-amber-500/10 dark:text-amber-100"
+        >
+          <div class="flex items-start gap-3">
+            <AlertCircle class="mt-0.5 size-4 shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium">{syncPromptTitle(syncPrompt)}</p>
+              <p class="mt-1 text-xs leading-5">{syncPromptDescription(syncPrompt)}</p>
+              <p class="mt-2 text-xs">
+                Missing repos: {syncPrompt.missingRepos.map((repo) => repo.path).join(', ')}
+              </p>
+              {#if syncError}
+                <p class="text-destructive mt-2 text-xs">{syncError}</p>
+              {/if}
+            </div>
+            <Button
+              size="sm"
+              variant="secondary"
+              class="shrink-0"
+              onclick={() => void handleSyncWorkspace()}
+              disabled={syncInFlight}
+            >
+              {syncInFlight ? 'Syncing...' : 'Sync repos'}
+            </Button>
+          </div>
+        </div>
+      {/if}
       <!-- Files area -->
       <div class="flex min-h-0 flex-1">
         <!-- Sidebar (resizable) -->

--- a/web/src/lib/features/chat/project-conversation-workspace-summary.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-summary.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import {
+    syncProjectConversationWorkspace,
+    type ProjectConversationWorkspaceSyncPrompt,
+  } from '$lib/api/chat'
   import { cn } from '$lib/utils'
   import { ChevronRight, GitBranch } from '@lucide/svelte'
   import type {
     ProjectConversationWorkspaceDiff,
     ProjectConversationWorkspaceFileStatus,
   } from '$lib/api/chat'
+  import { workspaceBrowserPortal } from './workspace-browser-portal.svelte'
 
   let {
     conversationId = '',
@@ -25,6 +30,8 @@
   } = $props()
 
   let expanded = $state(false)
+  let syncInFlight = $state(false)
+  let syncError = $state('')
 
   function formatTotals(added: number, removed: number) {
     return `+${added} -${removed}`
@@ -64,8 +71,46 @@
     }
   }
 
+  function syncPromptSummary(prompt: ProjectConversationWorkspaceSyncPrompt | undefined) {
+    if (!prompt) {
+      return ''
+    }
+    const repoCount = prompt.missingRepos.length
+    const label = repoCount === 1 ? 'repo needs sync' : 'repos need sync'
+    return `${repoCount} ${label}`
+  }
+
+  function syncPromptDescription(prompt: ProjectConversationWorkspaceSyncPrompt | undefined) {
+    if (!prompt) {
+      return ''
+    }
+    if (prompt.reason === 'repo_binding_changed') {
+      return 'Project repo bindings changed after this conversation workspace was prepared. Sync repos to clone the missing checkout(s) before browsing or diffing.'
+    }
+    return 'Some project repos are missing from the current conversation workspace. Sync repos to clone them before browsing or diffing.'
+  }
+
+  async function handleSyncWorkspace() {
+    if (!conversationId || syncInFlight) {
+      return
+    }
+    syncInFlight = true
+    syncError = ''
+    try {
+      await syncProjectConversationWorkspace(conversationId)
+      workspaceBrowserPortal.markWorkspaceSynced()
+      await Promise.resolve(workspaceBrowserPortal.onSyncWorkspace?.())
+    } catch (error) {
+      syncError =
+        error instanceof Error ? error.message : 'Failed to sync the Project AI workspace.'
+    } finally {
+      syncInFlight = false
+    }
+  }
+
   const hasContent = $derived(!!conversationId && !loading && !error && !!workspaceDiff)
   const isDirty = $derived(workspaceDiff?.dirty ?? false)
+  const syncPrompt = $derived(workspaceDiff?.syncPrompt)
 </script>
 
 {#if !conversationId && !loading && !error}
@@ -96,6 +141,10 @@
           <span class="text-muted-foreground/60">Loading...</span>
         {:else if error}
           <span class="text-destructive truncate">{error}</span>
+        {:else if syncPrompt}
+          <span class="truncate font-medium text-amber-700 dark:text-amber-300">
+            {syncPromptSummary(syncPrompt)}
+          </span>
         {:else if workspaceDiff}
           {#if isDirty}
             <span class="font-medium">{formatRepoSummary(workspaceDiff)}</span>
@@ -122,10 +171,38 @@
           {browserOpen ? 'Hide browser' : 'Browse'}
         </button>
       {/if}
+
+      {#if conversationId && syncPrompt}
+        <button
+          type="button"
+          class="rounded px-1.5 py-0.5 text-[11px] font-medium text-amber-700 transition-colors hover:bg-amber-500/10 hover:text-amber-800 dark:text-amber-300 dark:hover:bg-amber-500/10"
+          onclick={(event) => {
+            event.stopPropagation()
+            void handleSyncWorkspace()
+          }}
+          disabled={syncInFlight}
+        >
+          {syncInFlight ? 'Syncing...' : 'Sync repos'}
+        </button>
+      {/if}
     </div>
 
     {#if expanded && workspaceDiff}
       <div class="border-border border-t text-[11px]">
+        {#if syncPrompt}
+          <div class="px-3 py-2">
+            <p class="text-foreground text-[11px] font-medium">Workspace sync required</p>
+            <p class="text-muted-foreground mt-1 text-[11px]">
+              {syncPromptDescription(syncPrompt)}
+            </p>
+            <p class="text-muted-foreground mt-2 text-[11px]">
+              Missing repos: {syncPrompt.missingRepos.map((repo) => repo.path).join(', ')}
+            </p>
+            {#if syncError}
+              <p class="text-destructive mt-2 text-[11px]">{syncError}</p>
+            {/if}
+          </div>
+        {/if}
         {#if workspaceDiff.repos.length === 0}
           <p class="text-muted-foreground px-3 py-1.5">No repo changes detected.</p>
         {:else}

--- a/web/src/lib/features/chat/project-conversation-workspace-sync-banner.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-sync-banner.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { ProjectConversationWorkspaceSyncPrompt } from '$lib/api/chat'
+  import { Button } from '$ui/button'
+  import { AlertCircle } from '@lucide/svelte'
+
+  let {
+    prompt,
+    syncError = '',
+    syncInFlight = false,
+    centered = false,
+    onSync,
+  }: {
+    prompt: ProjectConversationWorkspaceSyncPrompt
+    syncError?: string
+    syncInFlight?: boolean
+    centered?: boolean
+    onSync?: () => void | Promise<void>
+  } = $props()
+
+  const title = $derived(
+    prompt.reason === 'repo_binding_changed'
+      ? 'Workspace sync required'
+      : 'Some project repos are missing from this workspace',
+  )
+  const description = $derived(
+    prompt.reason === 'repo_binding_changed'
+      ? 'This conversation workspace was prepared before the latest project repo binding changes. Newly bound repos have not been cloned into this workspace yet, so browse and diff can be incomplete until you sync.'
+      : 'One or more repos are bound to this project but are still missing from the current conversation workspace. Sync the workspace to clone them before browsing or diffing.',
+  )
+  const missingRepos = $derived(prompt.missingRepos.map((repo) => repo.path).join(', '))
+</script>
+
+{#if centered}
+  <div class="flex flex-1 items-center justify-center px-6">
+    <div class="border-border bg-muted/20 max-w-lg rounded-xl border p-5 text-left">
+      <p class="text-sm font-medium">{title}</p>
+      <p class="text-muted-foreground mt-2 text-sm">{description}</p>
+      <p class="text-muted-foreground mt-3 text-xs">Missing repos: {missingRepos}</p>
+      {#if syncError}
+        <p class="text-destructive mt-3 text-xs">{syncError}</p>
+      {/if}
+      <div class="mt-4 flex gap-2">
+        <Button size="sm" onclick={() => void onSync?.()} disabled={syncInFlight}>
+          {syncInFlight ? 'Syncing repos...' : 'Sync repos'}
+        </Button>
+      </div>
+    </div>
+  </div>
+{:else}
+  <div
+    class="border-border border-b bg-amber-50/80 px-3 py-2 text-amber-950 dark:bg-amber-500/10 dark:text-amber-100"
+  >
+    <div class="flex items-start gap-3">
+      <AlertCircle class="mt-0.5 size-4 shrink-0" />
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-medium">{title}</p>
+        <p class="mt-1 text-xs leading-5">{description}</p>
+        <p class="mt-2 text-xs">Missing repos: {missingRepos}</p>
+        {#if syncError}
+          <p class="text-destructive mt-2 text-xs">{syncError}</p>
+        {/if}
+      </div>
+      <Button
+        size="sm"
+        variant="secondary"
+        class="shrink-0"
+        onclick={() => void onSync?.()}
+        disabled={syncInFlight}
+      >
+        {syncInFlight ? 'Syncing...' : 'Sync repos'}
+      </Button>
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/features/chat/workspace-browser-portal.svelte.ts
+++ b/web/src/lib/features/chat/workspace-browser-portal.svelte.ts
@@ -13,6 +13,8 @@ class WorkspaceBrowserPortal {
   conversationId = $state('')
   workspaceDiff: ProjectConversationWorkspaceDiff | null = $state(null)
   workspaceDiffLoading = $state(false)
+  syncGeneration = $state(0)
+  onSyncWorkspace: null | (() => Promise<void> | void) = null
   /** File path to navigate to when the browser opens (consumed once). */
   pendingFilePath = $state('')
 
@@ -35,6 +37,10 @@ class WorkspaceBrowserPortal {
     const path = this.pendingFilePath
     this.pendingFilePath = ''
     return path
+  }
+
+  markWorkspaceSynced() {
+    this.syncGeneration += 1
   }
 }
 


### PR DESCRIPTION
## Summary
- detect when a Project AI conversation workspace is missing repos that were bound later in the same conversation and surface a sync prompt instead of raw browse/diff git errors
- add the explicit workspace sync API flow, backend drift detection, HTTP/OpenAPI wiring, and frontend browser/panel affordances for syncing newly bound repos
- cover the regression path with backend tests, frontend tests, and follow-up parity/lint fixes after syncing to the latest `main`

## Validation
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/cli -run TestRootCLIAPICoverageMatchesOpenAPI -count=1`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator -run TestWorkspaceInitLeaseManagerHeartbeatRenewsLease -count=1`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest OPENASE_GO_TEST_PROGRESS_MODE=json OPENASE_BACKEND_TEST_GROUP_SIZE=8 make check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd web && pnpm exec vitest run src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd web && pnpm run check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH PATH=$HOME/.local/go1.26.1/bin:$PATH OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest OPENASE_GO_TEST_PROGRESS_MODE=json .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- the new workspace sync endpoint is intentionally listed as a CLI/OpenAPI parity gap until a first-class CLI command exists
