### PR TITLE
feat(platform): add project-scoped Project AI ticket routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,11 @@ jobs:
 
           cached_go_bin="/home/docker/actions-runner/_work/_tool/go/1.26.1/x64/bin"
           if [[ -d "${cached_go_bin}" ]]; then
+            export PATH="${cached_go_bin}:${PATH}"
             echo "${cached_go_bin}" >> "${GITHUB_PATH}"
           fi
+          export GOTOOLCHAIN=local
+          echo "GOTOOLCHAIN=local" >> "${GITHUB_ENV}"
 
           command -v go
           go version

--- a/internal/cli/platform.go
+++ b/internal/cli/platform.go
@@ -953,8 +953,20 @@ func (platform platformContext) hasScope(scope string) bool {
 	return slicesContains(platform.scopes, strings.TrimSpace(scope))
 }
 
+func (platform platformContext) useProjectScopedTicketRead() bool {
+	return strings.TrimSpace(platform.projectID) != "" && platform.hasScope("tickets.list")
+}
+
 func (platform platformContext) useProjectScopedTicketUpdate() bool {
-	return platform.hasScope("tickets.update")
+	return strings.TrimSpace(platform.projectID) != "" && platform.hasScope("tickets.update")
+}
+
+func (platform platformContext) useProjectScopedTicketCommentWrite() bool {
+	return platform.useProjectScopedTicketUpdate()
+}
+
+func (platform platformContext) useProjectScopedTicketReportUsage() bool {
+	return strings.TrimSpace(platform.projectID) != "" && platform.hasScope("tickets.report_usage")
 }
 
 func (platform platformContext) parseTicketListInput(raw ticketListInput) (ticketListInput, error) {
@@ -1337,21 +1349,33 @@ func (client platformClient) createTicket(ctx context.Context, platform platform
 }
 
 func (client platformClient) listTicketComments(ctx context.Context, platform platformContext, input ticketCommentListInput) ([]byte, error) {
-	return client.doJSON(ctx, platform, http.MethodGet, "/tickets/"+url.PathEscape(input.ticketID)+"/comments", nil)
+	path := "/tickets/" + url.PathEscape(input.ticketID) + "/comments"
+	if platform.useProjectScopedTicketRead() {
+		path = "/projects/" + url.PathEscape(platform.projectID) + "/tickets/" + url.PathEscape(input.ticketID) + "/comments"
+	}
+	return client.doJSON(ctx, platform, http.MethodGet, path, nil)
 }
 
 func (client platformClient) createTicketComment(ctx context.Context, platform platformContext, input ticketCommentCreateInput) ([]byte, error) {
-	return client.doJSON(ctx, platform, http.MethodPost, "/tickets/"+url.PathEscape(input.ticketID)+"/comments", map[string]any{
+	path := "/tickets/" + url.PathEscape(input.ticketID) + "/comments"
+	if platform.useProjectScopedTicketCommentWrite() {
+		path = "/projects/" + url.PathEscape(platform.projectID) + "/tickets/" + url.PathEscape(input.ticketID) + "/comments"
+	}
+	return client.doJSON(ctx, platform, http.MethodPost, path, map[string]any{
 		"body": input.body,
 	})
 }
 
 func (client platformClient) updateTicketComment(ctx context.Context, platform platformContext, input ticketCommentUpdateInput) ([]byte, error) {
+	path := "/tickets/" + url.PathEscape(input.ticketID) + "/comments/" + url.PathEscape(input.commentID)
+	if platform.useProjectScopedTicketCommentWrite() {
+		path = "/projects/" + url.PathEscape(platform.projectID) + "/tickets/" + url.PathEscape(input.ticketID) + "/comments/" + url.PathEscape(input.commentID)
+	}
 	return client.doJSON(
 		ctx,
 		platform,
 		http.MethodPatch,
-		"/tickets/"+url.PathEscape(input.ticketID)+"/comments/"+url.PathEscape(input.commentID),
+		path,
 		map[string]any{"body": input.body},
 	)
 }
@@ -1415,7 +1439,12 @@ func (client platformClient) reportTicketUsage(ctx context.Context, platform pla
 		payload["cost_usd"] = *input.costUSD
 	}
 
-	return client.doJSON(ctx, platform, http.MethodPost, "/tickets/"+url.PathEscape(input.ticketID)+"/usage", payload)
+	path := "/tickets/" + url.PathEscape(input.ticketID) + "/usage"
+	if platform.useProjectScopedTicketReportUsage() {
+		path = "/projects/" + url.PathEscape(platform.projectID) + "/tickets/" + url.PathEscape(input.ticketID) + "/usage"
+	}
+
+	return client.doJSON(ctx, platform, http.MethodPost, path, payload)
 }
 
 func (client platformClient) updateProject(ctx context.Context, platform platformContext, input projectUpdateInput) ([]byte, error) {

--- a/internal/cli/platform_test.go
+++ b/internal/cli/platform_test.go
@@ -551,6 +551,101 @@ func TestTicketCommentUpdateCommandAcceptsTicketIDPositionalAndBodyFileAlias(t *
 	}
 }
 
+func TestTicketCommentListCommandUsesProjectScopedRouteWhenTicketsListScopePresent(t *testing.T) {
+	var path string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"comments":[{"id":"comment-7","body":"Current progress"}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENASE_API_URL", server.URL)
+	t.Setenv("OPENASE_AGENT_TOKEN", "ase_agent_test")
+	t.Setenv("OPENASE_PROJECT_ID", "project-123")
+	t.Setenv("OPENASE_AGENT_SCOPES", "tickets.list")
+
+	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: server.Client()})
+	command.SetArgs([]string{"comment", "list", "ticket-9"})
+
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+
+	if path != "/projects/project-123/tickets/ticket-9/comments" {
+		t.Fatalf("expected project-scoped ticket comment list path, got %q", path)
+	}
+}
+
+func TestTicketCommentCreateCommandUsesProjectScopedRouteWhenTicketsUpdateScopePresent(t *testing.T) {
+	var path string
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.RequestURI()
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode returned error: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"comment":{"id":"comment-8","body":"Created from project route"}}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENASE_API_URL", server.URL)
+	t.Setenv("OPENASE_AGENT_TOKEN", "ase_agent_test")
+	t.Setenv("OPENASE_PROJECT_ID", "project-123")
+	t.Setenv("OPENASE_AGENT_SCOPES", "tickets.update")
+
+	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: server.Client()})
+	command.SetArgs([]string{"comment", "create", "ticket-9", "--body", "Created from project route"})
+
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+
+	if path != "/projects/project-123/tickets/ticket-9/comments" {
+		t.Fatalf("expected project-scoped ticket comment create path, got %q", path)
+	}
+	if payload["body"] != "Created from project route" {
+		t.Fatalf("unexpected comment create payload: %+v", payload)
+	}
+}
+
+func TestTicketCommentUpdateCommandUsesProjectScopedRouteWhenTicketsUpdateScopePresent(t *testing.T) {
+	var path string
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.RequestURI()
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode returned error: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"comment":{"id":"comment-7","body":"Updated from project route"}}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENASE_API_URL", server.URL)
+	t.Setenv("OPENASE_AGENT_TOKEN", "ase_agent_test")
+	t.Setenv("OPENASE_PROJECT_ID", "project-123")
+	t.Setenv("OPENASE_AGENT_SCOPES", "tickets.update")
+
+	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: server.Client()})
+	command.SetArgs([]string{"comment", "update", "ticket-9", "comment-7", "--body", "Updated from project route"})
+
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+
+	if path != "/projects/project-123/tickets/ticket-9/comments/comment-7" {
+		t.Fatalf("expected project-scoped ticket comment update path, got %q", path)
+	}
+	if payload["body"] != "Updated from project route" {
+		t.Fatalf("unexpected comment update payload: %+v", payload)
+	}
+}
+
 func TestTicketReportUsageCommandPostsUsagePayload(t *testing.T) {
 	var method string
 	var path string
@@ -586,6 +681,33 @@ func TestTicketReportUsageCommandPostsUsagePayload(t *testing.T) {
 	}
 	if payload["input_tokens"] != float64(120) || payload["output_tokens"] != float64(45) || payload["cost_usd"] != 0.21 {
 		t.Fatalf("unexpected usage payload: %+v", payload)
+	}
+}
+
+func TestTicketReportUsageCommandUsesProjectScopedRouteWhenScopePresent(t *testing.T) {
+	var path string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ticket":{"id":"ticket-9"},"applied":{"input_tokens":12,"output_tokens":4,"cost_usd":0.03}}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENASE_API_URL", server.URL)
+	t.Setenv("OPENASE_AGENT_TOKEN", "ase_agent_test")
+	t.Setenv("OPENASE_PROJECT_ID", "project-123")
+	t.Setenv("OPENASE_AGENT_SCOPES", "tickets.report_usage")
+
+	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: server.Client()})
+	command.SetArgs([]string{"report-usage", "ticket-9", "--input-tokens", "12", "--output-tokens", "4", "--cost-usd", "0.03"})
+
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+
+	if path != "/projects/project-123/tickets/ticket-9/usage" {
+		t.Fatalf("expected project-scoped ticket usage path, got %q", path)
 	}
 }
 

--- a/internal/cli/resource_runtime_test.go
+++ b/internal/cli/resource_runtime_test.go
@@ -164,3 +164,81 @@ func TestProjectUpdatesCRUDUsesRuntimeDefaults(t *testing.T) {
 		t.Fatalf("delete request = %+v", requests[3])
 	}
 }
+
+func TestTypedCommandsPreservePlatformBaseForProjectAIRoutes(t *testing.T) {
+	projectID := "550e8400-e29b-41d4-a716-446655440000"
+	ticketID := "8c44cdd8-02d2-4bc9-aefa-e8c5ca7dd87e"
+	agentID := "1eeb5f8b-6679-4694-b890-d79044f52ef1"
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantPath string
+		body     string
+	}{
+		{
+			name:     "activity list",
+			args:     []string{"activity", "list"},
+			wantPath: "/api/v1/platform/projects/" + projectID + "/activity",
+			body:     `{"events":[]}`,
+		},
+		{
+			name:     "repo list",
+			args:     []string{"repo", "list"},
+			wantPath: "/api/v1/platform/projects/" + projectID + "/repos",
+			body:     `{"repos":[]}`,
+		},
+		{
+			name:     "scheduled-job list",
+			args:     []string{"scheduled-job", "list"},
+			wantPath: "/api/v1/platform/projects/" + projectID + "/scheduled-jobs",
+			body:     `{"jobs":[]}`,
+		},
+		{
+			name:     "skill list",
+			args:     []string{"skill", "list"},
+			wantPath: "/api/v1/platform/projects/" + projectID + "/skills",
+			body:     `{"skills":[]}`,
+		},
+		{
+			name:     "ticket run list",
+			args:     []string{"ticket", "run", "list", projectID, ticketID},
+			wantPath: "/api/v1/platform/projects/" + projectID + "/tickets/" + ticketID + "/runs",
+			body:     `{"runs":[]}`,
+		},
+		{
+			name:     "agent interrupt",
+			args:     []string{"agent", "interrupt", agentID},
+			wantPath: "/api/v1/platform/agents/" + agentID + "/interrupt",
+			body:     `{"agent":{"id":"` + agentID + `","runtime_control_state":"interrupt_requested"}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestPath = r.URL.RequestURI()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			t.Setenv("OPENASE_API_URL", server.URL+"/api/v1/platform")
+			t.Setenv("OPENASE_AGENT_TOKEN", "ase_agent_test")
+			t.Setenv("OPENASE_PROJECT_ID", projectID)
+
+			root := NewRootCommand("dev")
+			var stdout bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stdout)
+			root.SetArgs(tc.args)
+
+			if err := root.ExecuteContext(context.Background()); err != nil {
+				t.Fatalf("ExecuteContext returned error: %v", err)
+			}
+			if requestPath != tc.wantPath {
+				t.Fatalf("request path = %q, want %q", requestPath, tc.wantPath)
+			}
+		})
+	}
+}

--- a/internal/cli/typed_commands.go
+++ b/internal/cli/typed_commands.go
@@ -216,11 +216,12 @@ func newTicketCommand() *cobra.Command {
 }
 
 func newActivityCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "activity",
 		Short: "Read project activity events through the OpenASE API.",
 	}
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "list [projectId]",
 		Short:            "List project activity events.",
 		Method:           http.MethodGet,
@@ -230,7 +231,7 @@ func newActivityCommand() *cobra.Command {
 			"Use this to inspect the project event timeline, including workflow edits, ticket transitions, and runtime activity.",
 		},
 		Example: "openase activity list $OPENASE_PROJECT_ID --json events",
-	}))
+	}, deps))
 	return command
 }
 
@@ -611,11 +612,12 @@ func newTypedTicketExternalLinkCommand() *cobra.Command {
 }
 
 func newTypedTicketRunCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "run",
 		Short: "Inspect ticket run history.",
 	}
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "list [projectId] [ticketId]",
 		Short:            "List ticket runs.",
 		Method:           http.MethodGet,
@@ -625,8 +627,8 @@ func newTypedTicketRunCommand() *cobra.Command {
 			"Use this to inspect execution history, retry chains, and current runtime state for one ticket.",
 		},
 		Example: "openase ticket run list $OPENASE_PROJECT_ID $OPENASE_TICKET_ID",
-	}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "get [projectId] [ticketId] [runId]",
 		Short:            "Get a ticket run.",
 		Method:           http.MethodGet,
@@ -636,7 +638,7 @@ func newTypedTicketRunCommand() *cobra.Command {
 			"This returns the stored runtime snapshot for one run, including status, lifecycle timestamps, and retry metadata.",
 		},
 		Example: "openase ticket run get $OPENASE_PROJECT_ID $OPENASE_TICKET_ID $OPENASE_RUN_ID",
-	}))
+	}, deps))
 	return command
 }
 
@@ -853,11 +855,12 @@ project scope fall back to OPENASE_PROJECT_ID.
 }
 
 func newRepoCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "repo",
 		Short: "Operate on project repositories through the OpenASE API.",
 	}
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "list [projectId]",
 		Short:            "List project repositories.",
 		Method:           http.MethodGet,
@@ -866,28 +869,28 @@ func newRepoCommand() *cobra.Command {
 		HelpNotes: []string{
 			"Use this to inspect repositories currently bound to a project before wiring workflows, repo scopes, or GitHub imports.",
 		},
-	}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "create [projectId]",
 		Short:            "Create a project repository.",
 		Method:           http.MethodPost,
 		Path:             "/api/v1/projects/{projectId}/repos",
 		PositionalParams: []string{"projectId"},
-	}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "update [projectId] [repoId]",
 		Short:            "Update a project repository.",
 		Method:           http.MethodPatch,
 		Path:             "/api/v1/projects/{projectId}/repos/{repoId}",
 		PositionalParams: []string{"projectId", "repoId"},
-	}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "delete [projectId] [repoId]",
 		Short:            "Delete a project repository.",
 		Method:           http.MethodDelete,
 		Path:             "/api/v1/projects/{projectId}/repos/{repoId}",
 		PositionalParams: []string{"projectId", "repoId"},
-	}))
+	}, deps))
 
 	github := &cobra.Command{
 		Use:   "github",
@@ -920,34 +923,34 @@ func newRepoCommand() *cobra.Command {
 		Use:   "scope",
 		Short: "Operate on ticket repository scopes.",
 	}
-	scope.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	scope.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "list [projectId] [ticketId]",
 		Short:            "List ticket repository scopes.",
 		Method:           http.MethodGet,
 		Path:             "/api/v1/projects/{projectId}/tickets/{ticketId}/repo-scopes",
 		PositionalParams: []string{"projectId", "ticketId"},
-	}))
-	scope.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	scope.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "create [projectId] [ticketId]",
 		Short:            "Create a ticket repository scope.",
 		Method:           http.MethodPost,
 		Path:             "/api/v1/projects/{projectId}/tickets/{ticketId}/repo-scopes",
 		PositionalParams: []string{"projectId", "ticketId"},
-	}))
-	scope.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	scope.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "update [projectId] [ticketId] [scopeId]",
 		Short:            "Update a ticket repository scope.",
 		Method:           http.MethodPatch,
 		Path:             "/api/v1/projects/{projectId}/tickets/{ticketId}/repo-scopes/{scopeId}",
 		PositionalParams: []string{"projectId", "ticketId", "scopeId"},
-	}))
-	scope.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{
+	}, deps))
+	scope.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{
 		Use:              "delete [projectId] [ticketId] [scopeId]",
 		Short:            "Delete a ticket repository scope.",
 		Method:           http.MethodDelete,
 		Path:             "/api/v1/projects/{projectId}/tickets/{ticketId}/repo-scopes/{scopeId}",
 		PositionalParams: []string{"projectId", "ticketId", "scopeId"},
-	}))
+	}, deps))
 	command.AddCommand(scope)
 
 	return command
@@ -1006,15 +1009,16 @@ func newWorkflowCommand() *cobra.Command {
 }
 
 func newScheduledJobCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "scheduled-job",
 		Short: "Operate on scheduled jobs through the OpenASE API.",
 	}
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "list [projectId]", Short: "List scheduled jobs.", Method: http.MethodGet, Path: "/api/v1/projects/{projectId}/scheduled-jobs", PositionalParams: []string{"projectId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "create [projectId]", Short: "Create a scheduled job.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/scheduled-jobs", PositionalParams: []string{"projectId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "update [jobId]", Short: "Update a scheduled job.", Method: http.MethodPatch, Path: "/api/v1/scheduled-jobs/{jobId}", PositionalParams: []string{"jobId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "delete [jobId]", Short: "Delete a scheduled job.", Method: http.MethodDelete, Path: "/api/v1/scheduled-jobs/{jobId}", PositionalParams: []string{"jobId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "trigger [jobId]", Short: "Trigger a scheduled job once.", Method: http.MethodPost, Path: "/api/v1/scheduled-jobs/{jobId}/trigger", PositionalParams: []string{"jobId"}}))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "list [projectId]", Short: "List scheduled jobs.", Method: http.MethodGet, Path: "/api/v1/projects/{projectId}/scheduled-jobs", PositionalParams: []string{"projectId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "create [projectId]", Short: "Create a scheduled job.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/scheduled-jobs", PositionalParams: []string{"projectId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "update [jobId]", Short: "Update a scheduled job.", Method: http.MethodPatch, Path: "/api/v1/scheduled-jobs/{jobId}", PositionalParams: []string{"jobId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "delete [jobId]", Short: "Delete a scheduled job.", Method: http.MethodDelete, Path: "/api/v1/scheduled-jobs/{jobId}", PositionalParams: []string{"jobId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "trigger [jobId]", Short: "Trigger a scheduled job once.", Method: http.MethodPost, Path: "/api/v1/scheduled-jobs/{jobId}/trigger", PositionalParams: []string{"jobId"}}, deps))
 	return command
 }
 
@@ -1371,6 +1375,7 @@ func newProviderCommand() *cobra.Command {
 }
 
 func newAgentCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "agent",
 		Short: "Operate on agents through the OpenASE API.",
@@ -1380,7 +1385,7 @@ func newAgentCommand() *cobra.Command {
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "create [projectId]", Short: "Create an agent.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/agents", PositionalParams: []string{"projectId"}}))
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "update [agentId]", Short: "Update an agent.", Method: http.MethodPatch, Path: "/api/v1/agents/{agentId}", PositionalParams: []string{"agentId"}}))
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "delete [agentId]", Short: "Delete an agent.", Method: http.MethodDelete, Path: "/api/v1/agents/{agentId}", PositionalParams: []string{"agentId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "interrupt [agentId]", Short: "Interrupt an agent runtime.", Method: http.MethodPost, Path: "/api/v1/agents/{agentId}/interrupt", PositionalParams: []string{"agentId"}}))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "interrupt [agentId]", Short: "Interrupt an agent runtime.", Method: http.MethodPost, Path: "/api/v1/agents/{agentId}/interrupt", PositionalParams: []string{"agentId"}}, deps))
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "pause [agentId]", Short: "Pause an agent.", Method: http.MethodPost, Path: "/api/v1/agents/{agentId}/pause", PositionalParams: []string{"agentId"}}))
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "resume [agentId]", Short: "Resume an agent.", Method: http.MethodPost, Path: "/api/v1/agents/{agentId}/resume", PositionalParams: []string{"agentId"}}))
 	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "output [projectId] [agentId]", Short: "List agent output entries.", Method: http.MethodGet, Path: "/api/v1/projects/{projectId}/agents/{agentId}/output", PositionalParams: []string{"projectId", "agentId"}}))
@@ -1441,23 +1446,24 @@ func newNotificationRuleCommand() *cobra.Command {
 }
 
 func newSkillCommand() *cobra.Command {
+	deps := apiCommandDeps{httpClient: http.DefaultClient}
 	command := &cobra.Command{
 		Use:   "skill",
 		Short: "Operate on skills through the OpenASE API.",
 	}
 	command.AddCommand(newSkillImportCommand())
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "list [projectId]", Short: "List project skills.", Method: http.MethodGet, Path: "/api/v1/projects/{projectId}/skills", PositionalParams: []string{"projectId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "create [projectId]", Short: "Create a skill.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/skills", PositionalParams: []string{"projectId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "refresh [projectId]", Short: "Refresh workspace skills.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/skills/refresh", PositionalParams: []string{"projectId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "get [skillId]", Short: "Get a skill.", Method: http.MethodGet, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "update [skillId]", Short: "Update a skill.", Method: http.MethodPut, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "delete [skillId]", Short: "Delete a skill.", Method: http.MethodDelete, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "enable [skillId]", Short: "Enable a skill.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/enable", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "disable [skillId]", Short: "Disable a skill.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/disable", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "bind [skillId]", Short: "Bind a skill to workflows.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/bind", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "unbind [skillId]", Short: "Unbind a skill from workflows.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/unbind", PositionalParams: []string{"skillId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "bind-workflow [workflowId]", Short: "Bind skills to a workflow.", Method: http.MethodPost, Path: "/api/v1/workflows/{workflowId}/skills/bind", PositionalParams: []string{"workflowId"}}))
-	command.AddCommand(newOpenAPIOperationCommand(openAPICommandSpec{Use: "unbind-workflow [workflowId]", Short: "Unbind skills from a workflow.", Method: http.MethodPost, Path: "/api/v1/workflows/{workflowId}/skills/unbind", PositionalParams: []string{"workflowId"}}))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "list [projectId]", Short: "List project skills.", Method: http.MethodGet, Path: "/api/v1/projects/{projectId}/skills", PositionalParams: []string{"projectId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "create [projectId]", Short: "Create a skill.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/skills", PositionalParams: []string{"projectId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "refresh [projectId]", Short: "Refresh workspace skills.", Method: http.MethodPost, Path: "/api/v1/projects/{projectId}/skills/refresh", PositionalParams: []string{"projectId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "get [skillId]", Short: "Get a skill.", Method: http.MethodGet, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "update [skillId]", Short: "Update a skill.", Method: http.MethodPut, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "delete [skillId]", Short: "Delete a skill.", Method: http.MethodDelete, Path: "/api/v1/skills/{skillId}", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "enable [skillId]", Short: "Enable a skill.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/enable", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "disable [skillId]", Short: "Disable a skill.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/disable", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "bind [skillId]", Short: "Bind a skill to workflows.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/bind", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "unbind [skillId]", Short: "Unbind a skill from workflows.", Method: http.MethodPost, Path: "/api/v1/skills/{skillId}/unbind", PositionalParams: []string{"skillId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "bind-workflow [workflowId]", Short: "Bind skills to a workflow.", Method: http.MethodPost, Path: "/api/v1/workflows/{workflowId}/skills/bind", PositionalParams: []string{"workflowId"}}, deps))
+	command.AddCommand(newAgentPlatformOpenAPIOperationCommandWithDeps(openAPICommandSpec{Use: "unbind-workflow [workflowId]", Short: "Unbind skills from a workflow.", Method: http.MethodPost, Path: "/api/v1/workflows/{workflowId}/skills/unbind", PositionalParams: []string{"workflowId"}}, deps))
 	return command
 }
 

--- a/internal/domain/agentplatform/contracts.go
+++ b/internal/domain/agentplatform/contracts.go
@@ -399,8 +399,8 @@ func BuildCapabilityContract(input RuntimeContractInput) string {
 	switch input.PrincipalKind {
 	case PrincipalKindProjectConversation:
 		builder.WriteString("- Treat this as a project-scoped conversation runtime, not a ticket runtime.\n")
-		builder.WriteString("- Use project-scoped ticket mutation routes when `tickets.update` is granted.\n")
-		builder.WriteString("- Do not assume current-ticket comment/update/report-usage endpoints are available.\n")
+		builder.WriteString("- Use project-scoped ticket routes when `tickets.list`, `tickets.update`, or `tickets.report_usage` are granted.\n")
+		builder.WriteString("- Do not assume current-ticket-only endpoints are available.\n")
 		builder.WriteString("- Ticket-runtime-only routes can reject this principal kind even when `OPENASE_TICKET_ID` is present.\n")
 	default:
 		builder.WriteString("- Treat this as the current ticket runtime.\n")

--- a/internal/domain/agentplatform/contracts_test.go
+++ b/internal/domain/agentplatform/contracts_test.go
@@ -312,11 +312,56 @@ func TestPrincipalKindScopeHelpers(t *testing.T) {
 
 	t.Run("project conversation supported scopes exclude ticket self update", func(t *testing.T) {
 		got := SupportedScopesForPrincipalKind(PrincipalKindProjectConversation)
-		if slices.Contains(got, string(ScopeTicketsUpdateSelf)) {
-			t.Fatalf("SupportedScopesForPrincipalKind(project conversation) unexpectedly included %q", ScopeTicketsUpdateSelf)
+		want := []string{
+			string(ScopeAgentsInterrupt),
+			string(ScopeActivityRead),
+			string(ScopeProjectsAddRepo),
+			string(ScopeProjectsUpdate),
+			string(ScopeReposCreate),
+			string(ScopeReposDelete),
+			string(ScopeReposRead),
+			string(ScopeReposUpdate),
+			string(ScopeScheduledJobsCreate),
+			string(ScopeScheduledJobsDelete),
+			string(ScopeScheduledJobsList),
+			string(ScopeScheduledJobsTrigger),
+			string(ScopeScheduledJobsUpdate),
+			string(ScopeSkillsBind),
+			string(ScopeSkillsCreate),
+			string(ScopeSkillsDelete),
+			string(ScopeSkillsDisable),
+			string(ScopeSkillsEnable),
+			string(ScopeSkillsImport),
+			string(ScopeSkillsList),
+			string(ScopeSkillsRead),
+			string(ScopeSkillsRefresh),
+			string(ScopeSkillsUpdate),
+			string(ScopeStatusesCreate),
+			string(ScopeStatusesDelete),
+			string(ScopeStatusesList),
+			string(ScopeStatusesReset),
+			string(ScopeStatusesUpdate),
+			string(ScopeTicketRepoScopesCreate),
+			string(ScopeTicketRepoScopesDelete),
+			string(ScopeTicketRepoScopesList),
+			string(ScopeTicketRepoScopesUpdate),
+			string(ScopeTicketsCreate),
+			string(ScopeTicketsList),
+			string(ScopeTicketsUpdate),
+			string(ScopeTicketsReportUsage),
+			string(ScopeWorkflowsCreate),
+			string(ScopeWorkflowsDelete),
+			string(ScopeWorkflowsHarnessHistoryRead),
+			string(ScopeWorkflowsHarnessRead),
+			string(ScopeWorkflowsHarnessUpdate),
+			string(ScopeWorkflowsHarnessValidate),
+			string(ScopeWorkflowsHarnessVariablesRead),
+			string(ScopeWorkflowsList),
+			string(ScopeWorkflowsRead),
+			string(ScopeWorkflowsUpdate),
 		}
-		if !slices.Contains(got, string(ScopeProjectsUpdate)) {
-			t.Fatalf("SupportedScopesForPrincipalKind(project conversation) missing %q", ScopeProjectsUpdate)
+		if !slices.Equal(got, want) {
+			t.Fatalf("SupportedScopesForPrincipalKind(project conversation) = %#v, want %#v", got, want)
 		}
 	})
 

--- a/internal/domain/ticket/contracts.go
+++ b/internal/domain/ticket/contracts.go
@@ -323,10 +323,11 @@ type RecordActivityEventInput struct {
 }
 
 type RecordUsageInput struct {
-	AgentID  uuid.UUID
-	TicketID uuid.UUID
-	RunID    *uuid.UUID
-	Usage    ticketing.RawUsageDelta
+	AgentID        uuid.UUID
+	ConversationID uuid.UUID
+	TicketID       uuid.UUID
+	RunID          *uuid.UUID
+	Usage          ticketing.RawUsageDelta
 }
 
 type AppliedUsage struct {

--- a/internal/httpapi/agent_platform_api.go
+++ b/internal/httpapi/agent_platform_api.go
@@ -26,7 +26,12 @@ func (s *Server) registerAgentPlatformRoutes(api *echo.Group) {
 	api.GET("/projects/:projectId/workflows", s.handleAgentListProjectWorkflows)
 	api.GET("/projects/:projectId/updates", s.handleAgentListProjectUpdates)
 	api.POST("/projects/:projectId/tickets", s.handleAgentCreateTicket)
+	api.GET("/projects/:projectId/tickets/:ticketId", s.handleAgentGetProjectTicket)
 	api.PATCH("/projects/:projectId/tickets/:ticketId", s.handleAgentUpdateProjectTicket)
+	api.GET("/projects/:projectId/tickets/:ticketId/comments", s.handleAgentListProjectTicketComments)
+	api.POST("/projects/:projectId/tickets/:ticketId/comments", s.handleAgentCreateProjectTicketComment)
+	api.PATCH("/projects/:projectId/tickets/:ticketId/comments/:commentId", s.handleAgentUpdateProjectTicketComment)
+	api.POST("/projects/:projectId/tickets/:ticketId/usage", s.handleAgentReportProjectTicketUsage)
 	api.POST("/projects/:projectId/updates", s.handleAgentCreateProjectUpdateThread)
 	api.GET("/tickets/:ticketId", s.handleAgentGetOwnTicket)
 	api.PATCH("/tickets/:ticketId", s.handleAgentUpdateOwnTicket)
@@ -217,6 +222,21 @@ func (s *Server) handleAgentGetOwnTicket(c echo.Context) error {
 	})
 }
 
+func (s *Server) handleAgentGetProjectTicket(c echo.Context) error {
+	if s.ticketService == nil {
+		return writeTicketError(c, ticketservice.ErrUnavailable)
+	}
+
+	_, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsList)
+	if !ok {
+		return nil
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"ticket": mapTicketResponse(current),
+	})
+}
+
 func (s *Server) handleAgentUpdateOwnTicket(c echo.Context) error {
 	if s.ticketService == nil {
 		return writeTicketError(c, ticketservice.ErrUnavailable)
@@ -238,29 +258,9 @@ func (s *Server) handleAgentUpdateProjectTicket(c echo.Context) error {
 		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	claims, ok := requireAgentScope(c, agentplatform.ScopeTicketsUpdate)
+	claims, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsUpdate)
 	if !ok {
 		return nil
-	}
-
-	projectID, err := parseProjectID(c)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_PROJECT_ID", err.Error())
-	}
-	if claims.ProjectID != projectID {
-		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
-	}
-
-	ticketID, err := parseTicketID(c)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_TICKET_ID", err.Error())
-	}
-	current, err := s.ticketService.Get(c.Request().Context(), ticketID)
-	if err != nil {
-		return writeTicketError(c, err)
-	}
-	if current.ProjectID != projectID {
-		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
 	return s.handleAgentTicketUpdate(c, claims, current)
@@ -326,28 +326,20 @@ func (s *Server) handleAgentReportUsage(c echo.Context) error {
 		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
-	var raw rawAgentReportUsageRequest
-	if err := decodeJSON(c, &raw); err != nil {
-		return err
+	return s.handleAgentTicketUsageResponse(c, claims, current)
+}
+
+func (s *Server) handleAgentReportProjectTicketUsage(c echo.Context) error {
+	if s.ticketService == nil {
+		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	result, err := s.ticketService.RecordUsage(c.Request().Context(), ticketservice.RecordUsageInput{
-		AgentID:  claims.AgentID,
-		TicketID: current.ID,
-		Usage:    parseAgentReportUsageRequest(raw),
-	}, s.metrics)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
-	}
-	if err := s.publishTicketEvent(c.Request().Context(), ticketUpdatedEventType, result.Ticket); err != nil {
-		return writeTicketError(c, err)
+	claims, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsReportUsage)
+	if !ok {
+		return nil
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
-		"ticket":          mapTicketResponse(result.Ticket),
-		"applied":         result.Applied,
-		"budget_exceeded": result.BudgetExceeded,
-	})
+	return s.handleAgentTicketUsageResponse(c, claims, current)
 }
 
 func (s *Server) handleAgentListOwnTicketComments(c echo.Context) error {
@@ -363,14 +355,20 @@ func (s *Server) handleAgentListOwnTicketComments(c echo.Context) error {
 		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
-	comments, err := s.ticketService.ListComments(c.Request().Context(), current.ID)
-	if err != nil {
-		return writeTicketError(c, err)
+	return s.handleAgentTicketCommentListResponse(c, current)
+}
+
+func (s *Server) handleAgentListProjectTicketComments(c echo.Context) error {
+	if s.ticketService == nil {
+		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
-		"comments": mapTicketCommentResponses(comments),
-	})
+	_, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsList)
+	if !ok {
+		return nil
+	}
+
+	return s.handleAgentTicketCommentListResponse(c, current)
 }
 
 func (s *Server) handleAgentCreateOwnTicketComment(c echo.Context) error {
@@ -386,37 +384,20 @@ func (s *Server) handleAgentCreateOwnTicketComment(c echo.Context) error {
 		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
-	var raw rawAgentTicketCommentRequest
-	if err := decodeJSON(c, &raw); err != nil {
-		return err
+	return s.handleAgentTicketCommentCreateResponse(c, claims, current)
+}
+
+func (s *Server) handleAgentCreateProjectTicketComment(c echo.Context) error {
+	if s.ticketService == nil {
+		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	input, err := parseAgentCreateTicketCommentRequest(current.ID, claims.CreatedBy(), raw)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	claims, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsUpdate)
+	if !ok {
+		return nil
 	}
 
-	comment, err := s.ticketService.AddComment(c.Request().Context(), input)
-	if err != nil {
-		return writeTicketError(c, err)
-	}
-	commentResponse := mapTicketCommentResponse(comment)
-	if err := s.emitActivity(c.Request().Context(), activitysvc.RecordInput{
-		ProjectID: current.ProjectID,
-		TicketID:  &current.ID,
-		EventType: activityevent.TypeTicketCommentCreated,
-		Message:   "Added comment to " + current.Identifier,
-		Metadata:  ticketCommentMetadata(commentResponse),
-	}); err != nil {
-		return writeTicketError(c, err)
-	}
-	if err := s.publishTicketUpdatedByID(c.Request().Context(), current.ID); err != nil {
-		return writeTicketError(c, err)
-	}
-
-	return c.JSON(http.StatusCreated, map[string]any{
-		"comment": commentResponse,
-	})
+	return s.handleAgentTicketCommentCreateResponse(c, claims, current)
 }
 
 func (s *Server) handleAgentUpdateOwnTicketComment(c echo.Context) error {
@@ -432,42 +413,20 @@ func (s *Server) handleAgentUpdateOwnTicketComment(c echo.Context) error {
 		return writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
 	}
 
-	commentID, err := parseCommentID(c)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_COMMENT_ID", err.Error())
+	return s.handleAgentTicketCommentUpdateResponse(c, claims, current)
+}
+
+func (s *Server) handleAgentUpdateProjectTicketComment(c echo.Context) error {
+	if s.ticketService == nil {
+		return writeTicketError(c, ticketservice.ErrUnavailable)
 	}
 
-	var raw rawAgentTicketCommentRequest
-	if err := decodeJSON(c, &raw); err != nil {
-		return err
+	claims, current, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsUpdate)
+	if !ok {
+		return nil
 	}
 
-	input, err := parseAgentUpdateTicketCommentRequest(current.ID, commentID, claims.CreatedBy(), raw)
-	if err != nil {
-		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
-	}
-
-	comment, err := s.ticketService.UpdateComment(c.Request().Context(), input)
-	if err != nil {
-		return writeTicketError(c, err)
-	}
-	commentResponse := mapTicketCommentResponse(comment)
-	if err := s.emitActivity(c.Request().Context(), activitysvc.RecordInput{
-		ProjectID: current.ProjectID,
-		TicketID:  &current.ID,
-		EventType: activityevent.TypeTicketCommentEdited,
-		Message:   "Edited comment on " + current.Identifier,
-		Metadata:  ticketCommentMetadata(commentResponse),
-	}); err != nil {
-		return writeTicketError(c, err)
-	}
-	if err := s.publishTicketUpdatedByID(c.Request().Context(), current.ID); err != nil {
-		return writeTicketError(c, err)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{
-		"comment": commentResponse,
-	})
+	return s.handleAgentTicketCommentUpdateResponse(c, claims, current)
 }
 
 func (s *Server) handleAgentUpdateProject(c echo.Context) error {
@@ -794,6 +753,40 @@ func (s *Server) handleAgentCreateProjectRepo(c echo.Context) error {
 	})
 }
 
+func (s *Server) requireAgentProjectTicket(c echo.Context, scope agentplatform.Scope) (agentplatform.Claims, ticketservice.Ticket, bool) {
+	claims, ok := requireAgentScope(c, scope)
+	if !ok {
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	projectID, err := parseProjectID(c)
+	if err != nil {
+		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_PROJECT_ID", err.Error())
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+	if claims.ProjectID != projectID {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	ticketID, err := parseTicketID(c)
+	if err != nil {
+		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_TICKET_ID", err.Error())
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+	current, err := s.ticketService.Get(c.Request().Context(), ticketID)
+	if err != nil {
+		_ = writeTicketError(c, err)
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+	if current.ProjectID != projectID {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
+		return agentplatform.Claims{}, ticketservice.Ticket{}, false
+	}
+
+	return claims, current, true
+}
+
 func (s *Server) requireAgentOwnTicket(c echo.Context, scope agentplatform.Scope) (agentplatform.Claims, ticketservice.Ticket, bool) {
 	claims, ok := requireAgentScope(c, scope)
 	if !ok {
@@ -821,6 +814,116 @@ func (s *Server) requireAgentOwnTicket(c echo.Context, scope agentplatform.Scope
 	}
 
 	return claims, current, true
+}
+
+func (s *Server) handleAgentTicketUsageResponse(c echo.Context, claims agentplatform.Claims, current ticketservice.Ticket) error {
+	var raw rawAgentReportUsageRequest
+	if err := decodeJSON(c, &raw); err != nil {
+		return err
+	}
+
+	result, err := s.ticketService.RecordUsage(c.Request().Context(), ticketservice.RecordUsageInput{
+		AgentID:        claims.AgentID,
+		ConversationID: claims.ConversationID,
+		TicketID:       current.ID,
+		Usage:          parseAgentReportUsageRequest(raw),
+	}, s.metrics)
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	}
+	if err := s.publishTicketEvent(c.Request().Context(), ticketUpdatedEventType, result.Ticket); err != nil {
+		return writeTicketError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"ticket":          mapTicketResponse(result.Ticket),
+		"applied":         result.Applied,
+		"budget_exceeded": result.BudgetExceeded,
+	})
+}
+
+func (s *Server) handleAgentTicketCommentListResponse(c echo.Context, current ticketservice.Ticket) error {
+	comments, err := s.ticketService.ListComments(c.Request().Context(), current.ID)
+	if err != nil {
+		return writeTicketError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"comments": mapTicketCommentResponses(comments),
+	})
+}
+
+func (s *Server) handleAgentTicketCommentCreateResponse(c echo.Context, claims agentplatform.Claims, current ticketservice.Ticket) error {
+	var raw rawAgentTicketCommentRequest
+	if err := decodeJSON(c, &raw); err != nil {
+		return err
+	}
+
+	input, err := parseAgentCreateTicketCommentRequest(current.ID, claims.CreatedBy(), raw)
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	}
+
+	comment, err := s.ticketService.AddComment(c.Request().Context(), input)
+	if err != nil {
+		return writeTicketError(c, err)
+	}
+	commentResponse := mapTicketCommentResponse(comment)
+	if err := s.emitActivity(c.Request().Context(), activitysvc.RecordInput{
+		ProjectID: current.ProjectID,
+		TicketID:  &current.ID,
+		EventType: activityevent.TypeTicketCommentCreated,
+		Message:   "Added comment to " + current.Identifier,
+		Metadata:  ticketCommentMetadata(commentResponse),
+	}); err != nil {
+		return writeTicketError(c, err)
+	}
+	if err := s.publishTicketUpdatedByID(c.Request().Context(), current.ID); err != nil {
+		return writeTicketError(c, err)
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{
+		"comment": commentResponse,
+	})
+}
+
+func (s *Server) handleAgentTicketCommentUpdateResponse(c echo.Context, claims agentplatform.Claims, current ticketservice.Ticket) error {
+	commentID, err := parseCommentID(c)
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_COMMENT_ID", err.Error())
+	}
+
+	var raw rawAgentTicketCommentRequest
+	if err := decodeJSON(c, &raw); err != nil {
+		return err
+	}
+
+	input, err := parseAgentUpdateTicketCommentRequest(current.ID, commentID, claims.CreatedBy(), raw)
+	if err != nil {
+		return writeAPIError(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	}
+
+	comment, err := s.ticketService.UpdateComment(c.Request().Context(), input)
+	if err != nil {
+		return writeTicketError(c, err)
+	}
+	commentResponse := mapTicketCommentResponse(comment)
+	if err := s.emitActivity(c.Request().Context(), activitysvc.RecordInput{
+		ProjectID: current.ProjectID,
+		TicketID:  &current.ID,
+		EventType: activityevent.TypeTicketCommentEdited,
+		Message:   "Edited comment on " + current.Identifier,
+		Metadata:  ticketCommentMetadata(commentResponse),
+	}); err != nil {
+		return writeTicketError(c, err)
+	}
+	if err := s.publishTicketUpdatedByID(c.Request().Context(), current.ID); err != nil {
+		return writeTicketError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"comment": commentResponse,
+	})
 }
 
 func requireAgentScope(c echo.Context, scope agentplatform.Scope) (agentplatform.Claims, bool) {

--- a/internal/httpapi/agent_platform_api_test.go
+++ b/internal/httpapi/agent_platform_api_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/BetterAndBetterII/openase/ent"
+	entactivityevent "github.com/BetterAndBetterII/openase/ent/activityevent"
 	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
 	activitysvc "github.com/BetterAndBetterII/openase/internal/activity"
 	"github.com/BetterAndBetterII/openase/internal/agentplatform"
@@ -1438,7 +1439,165 @@ func TestAgentPlatformExpandedTicketRepoScopeRoutesRequireExplicitScopes(t *test
 	}
 }
 
+func TestAgentPlatformExpandedTicketRoutesRequireExplicitScopes(t *testing.T) {
+	fixture := newAgentPlatformExpandedFixture(t)
+
+	assertPlatformScopeRoute(
+		t,
+		fixture,
+		agentplatform.ScopeTicketsList,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments", fixture.projectID, fixture.ticketID),
+		nil,
+		http.StatusOK,
+		`"comments":[`,
+	)
+
+	createToken := fixture.issueToken(t, agentplatform.ScopeTicketsUpdate)
+	createRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments", fixture.projectID, fixture.ticketID),
+		map[string]any{"body": "Project-scoped comment"},
+		createToken,
+	)
+	if createRec.Code != http.StatusCreated || !strings.Contains(createRec.Body.String(), `"body":"Project-scoped comment"`) {
+		t.Fatalf("expected project ticket comment create to return 201 with comment body, got %d: %s", createRec.Code, createRec.Body.String())
+	}
+	var createPayload struct {
+		Comment ticketCommentResponse `json:"comment"`
+	}
+	decodeResponse(t, createRec, &createPayload)
+
+	assertPlatformScopeRoute(
+		t,
+		fixture,
+		agentplatform.ScopeTicketsUpdate,
+		http.MethodPatch,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments/%s", fixture.projectID, fixture.ticketID, createPayload.Comment.ID),
+		map[string]any{"body": "Project-scoped comment updated"},
+		http.StatusOK,
+		`"body":"Project-scoped comment updated"`,
+	)
+
+	assertPlatformScopeRoute(
+		t,
+		fixture,
+		agentplatform.ScopeTicketsList,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/runs", fixture.projectID, fixture.ticketID),
+		nil,
+		http.StatusOK,
+		`"runs":[`,
+	)
+
+	assertPlatformScopeRoute(
+		t,
+		fixture,
+		agentplatform.ScopeTicketsReportUsage,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/usage", fixture.projectID, fixture.ticketID),
+		map[string]any{"input_tokens": 12, "output_tokens": 4},
+		http.StatusOK,
+		`"applied":{"input_tokens":12,"output_tokens":4`,
+	)
+}
+
+func TestAgentPlatformExpandedAgentInterruptRouteRequiresExplicitScope(t *testing.T) {
+	fixture := newAgentPlatformExpandedFixture(t)
+	runItem, err := fixture.client.AgentRun.Create().
+		SetAgentID(fixture.agentID).
+		SetWorkflowID(fixture.mainWorkflowID).
+		SetTicketID(fixture.ticketID).
+		SetProviderID(fixture.providerID).
+		SetStatus("executing").
+		Save(context.Background())
+	if err != nil {
+		t.Fatalf("create active run for interrupt route: %v", err)
+	}
+	if _, err := fixture.client.Ticket.UpdateOneID(fixture.ticketID).SetCurrentRunID(runItem.ID).Save(context.Background()); err != nil {
+		t.Fatalf("attach active run to ticket: %v", err)
+	}
+
+	assertPlatformScopeRoute(
+		t,
+		fixture,
+		agentplatform.ScopeAgentsInterrupt,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/agents/%s/interrupt", fixture.agentID),
+		nil,
+		http.StatusOK,
+		`"runtime_control_state":"interrupt_requested"`,
+	)
+}
+
 func TestAgentPlatformProjectConversationTokenCanListTicketRepoScopes(t *testing.T) {
+	fixture := newAgentPlatformExpandedFixture(t)
+	ctx := context.Background()
+	conversationID := uuid.New()
+
+	if _, err := fixture.client.ChatConversation.Create().
+		SetID(conversationID).
+		SetProjectID(fixture.projectID).
+		SetUserID("browser-user").
+		SetSource("project_sidebar").
+		SetProviderID(fixture.providerID).
+		SetStatus("active").
+		Save(ctx); err != nil {
+		t.Fatalf("create chat conversation: %v", err)
+	}
+	if _, err := fixture.client.ProjectConversationPrincipal.Create().
+		SetID(conversationID).
+		SetConversationID(conversationID).
+		SetProjectID(fixture.projectID).
+		SetProviderID(fixture.providerID).
+		SetName("project-conversation:" + conversationID.String()).
+		Save(ctx); err != nil {
+		t.Fatalf("create project conversation principal: %v", err)
+	}
+	runItem, err := fixture.client.AgentRun.Create().
+		SetAgentID(fixture.agentID).
+		SetWorkflowID(fixture.mainWorkflowID).
+		SetTicketID(fixture.ticketID).
+		SetProviderID(fixture.providerID).
+		SetStatus("executing").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create active run for project conversation interrupt: %v", err)
+	}
+	if _, err := fixture.client.Ticket.UpdateOneID(fixture.ticketID).SetCurrentRunID(runItem.ID).Save(ctx); err != nil {
+		t.Fatalf("attach active run to ticket for project conversation interrupt: %v", err)
+	}
+
+	issued, err := fixture.platformService.IssueToken(ctx, agentplatform.IssueInput{
+		PrincipalKind:  agentplatform.PrincipalKindProjectConversation,
+		PrincipalID:    conversationID,
+		ProjectID:      fixture.projectID,
+		ConversationID: conversationID,
+		Scopes:         []string{string(agentplatform.ScopeTicketRepoScopesList)},
+	})
+	if err != nil {
+		t.Fatalf("IssueToken(project conversation) returned error: %v", err)
+	}
+
+	rec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/repo-scopes", fixture.projectID, fixture.ticketID),
+		nil,
+		issued.Token,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected project conversation repo scope list to return 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"repo_scopes":[`) {
+		t.Fatalf("expected repo scope list response, got %s", rec.Body.String())
+	}
+}
+
+func TestAgentPlatformProjectConversationTokenCanUseProjectTicketRoutes(t *testing.T) {
 	fixture := newAgentPlatformExpandedFixture(t)
 	ctx := context.Background()
 	conversationID := uuid.New()
@@ -1468,25 +1627,121 @@ func TestAgentPlatformProjectConversationTokenCanListTicketRepoScopes(t *testing
 		PrincipalID:    conversationID,
 		ProjectID:      fixture.projectID,
 		ConversationID: conversationID,
-		Scopes:         []string{string(agentplatform.ScopeTicketRepoScopesList)},
+		Scopes: []string{
+			string(agentplatform.ScopeAgentsInterrupt),
+			string(agentplatform.ScopeTicketsList),
+			string(agentplatform.ScopeTicketsReportUsage),
+			string(agentplatform.ScopeTicketsUpdate),
+		},
 	})
 	if err != nil {
 		t.Fatalf("IssueToken(project conversation) returned error: %v", err)
 	}
 
-	rec := performPlatformRequest(
+	listCommentsRec := performPlatformRequest(
 		t,
 		fixture.server,
 		http.MethodGet,
-		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/repo-scopes", fixture.projectID, fixture.ticketID),
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments", fixture.projectID, fixture.ticketID),
 		nil,
 		issued.Token,
 	)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected project conversation repo scope list to return 200, got %d: %s", rec.Code, rec.Body.String())
+	if listCommentsRec.Code != http.StatusOK || !strings.Contains(listCommentsRec.Body.String(), `"comments":[`) {
+		t.Fatalf("expected project conversation comment list to return 200, got %d: %s", listCommentsRec.Code, listCommentsRec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `"repo_scopes":[`) {
-		t.Fatalf("expected repo scope list response, got %s", rec.Body.String())
+
+	createCommentRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments", fixture.projectID, fixture.ticketID),
+		map[string]any{"body": "Created by Project AI"},
+		issued.Token,
+	)
+	if createCommentRec.Code != http.StatusCreated {
+		t.Fatalf("expected project conversation comment create to return 201, got %d: %s", createCommentRec.Code, createCommentRec.Body.String())
+	}
+	var createCommentPayload struct {
+		Comment ticketCommentResponse `json:"comment"`
+	}
+	decodeResponse(t, createCommentRec, &createCommentPayload)
+	if createCommentPayload.Comment.CreatedBy != "project-conversation:"+conversationID.String() {
+		t.Fatalf("unexpected created_by for project conversation comment: %+v", createCommentPayload.Comment)
+	}
+
+	updateCommentRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodPatch,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/comments/%s", fixture.projectID, fixture.ticketID, createCommentPayload.Comment.ID),
+		map[string]any{"body": "Updated by Project AI"},
+		issued.Token,
+	)
+	if updateCommentRec.Code != http.StatusOK || !strings.Contains(updateCommentRec.Body.String(), `"body":"Updated by Project AI"`) {
+		t.Fatalf("expected project conversation comment update to return 200, got %d: %s", updateCommentRec.Code, updateCommentRec.Body.String())
+	}
+
+	listRunsRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/runs", fixture.projectID, fixture.ticketID),
+		nil,
+		issued.Token,
+	)
+	if listRunsRec.Code != http.StatusOK || !strings.Contains(listRunsRec.Body.String(), `"runs":[`) {
+		t.Fatalf("expected project conversation run list to return 200, got %d: %s", listRunsRec.Code, listRunsRec.Body.String())
+	}
+
+	reportUsageRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/projects/%s/tickets/%s/usage", fixture.projectID, fixture.ticketID),
+		map[string]any{"input_tokens": 9, "output_tokens": 3},
+		issued.Token,
+	)
+	if reportUsageRec.Code != http.StatusOK || !strings.Contains(reportUsageRec.Body.String(), `"applied":{"input_tokens":9,"output_tokens":3`) {
+		t.Fatalf("expected project conversation usage report to return 200, got %d: %s", reportUsageRec.Code, reportUsageRec.Body.String())
+	}
+
+	interruptRun, err := fixture.client.AgentRun.Create().
+		SetAgentID(fixture.agentID).
+		SetWorkflowID(fixture.mainWorkflowID).
+		SetTicketID(fixture.ticketID).
+		SetProviderID(fixture.providerID).
+		SetStatus("executing").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create fresh active run for project conversation interrupt: %v", err)
+	}
+	if _, err := fixture.client.Ticket.UpdateOneID(fixture.ticketID).SetCurrentRunID(interruptRun.ID).Save(ctx); err != nil {
+		t.Fatalf("attach fresh active run to ticket for project conversation interrupt: %v", err)
+	}
+
+	interruptRec := performPlatformRequest(
+		t,
+		fixture.server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/platform/agents/%s/interrupt", fixture.agentID),
+		nil,
+		issued.Token,
+	)
+	if interruptRec.Code != http.StatusOK || !strings.Contains(interruptRec.Body.String(), `"runtime_control_state":"interrupt_requested"`) {
+		t.Fatalf("expected project conversation interrupt to return 200, got %d: %s", interruptRec.Code, interruptRec.Body.String())
+	}
+
+	usageEvents, err := fixture.client.ActivityEvent.Query().
+		Where(entactivityevent.EventTypeEQ("ticket.cost_recorded")).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("list usage events: %v", err)
+	}
+	if len(usageEvents) == 0 {
+		t.Fatal("expected project conversation usage report to create a cost activity event")
+	}
+	if usageEvents[len(usageEvents)-1].AgentID != nil {
+		t.Fatalf("expected project conversation usage event to omit agent_id, got %+v", usageEvents[len(usageEvents)-1])
 	}
 }
 

--- a/internal/httpapi/agent_platform_expanded_api.go
+++ b/internal/httpapi/agent_platform_expanded_api.go
@@ -13,6 +13,7 @@ import (
 
 func (s *Server) registerExpandedAgentPlatformRoutes(api *echo.Group) {
 	api.GET("/projects/:projectId/activity", s.handleAgentListActivityEvents)
+	api.POST("/agents/:agentId/interrupt", s.handleAgentInterruptAgent)
 	api.POST("/projects/:projectId/agents/:agentId/interrupt", s.handleAgentInterruptProjectAgent)
 	api.GET("/projects/:projectId/statuses", s.handleAgentListTicketStatuses)
 	api.POST("/projects/:projectId/statuses", s.handleAgentCreateTicketStatus)
@@ -35,6 +36,8 @@ func (s *Server) registerExpandedAgentPlatformRoutes(api *echo.Group) {
 	api.POST("/projects/:projectId/tickets/:ticketId/repo-scopes", s.handleAgentCreateTicketRepoScope)
 	api.PATCH("/projects/:projectId/tickets/:ticketId/repo-scopes/:scopeId", s.handleAgentPatchTicketRepoScope)
 	api.DELETE("/projects/:projectId/tickets/:ticketId/repo-scopes/:scopeId", s.handleAgentDeleteTicketRepoScope)
+	api.GET("/projects/:projectId/tickets/:ticketId/runs", s.handleAgentListTicketRuns)
+	api.GET("/projects/:projectId/tickets/:ticketId/runs/:runId", s.handleAgentGetTicketRun)
 	api.GET("/projects/:projectId/scheduled-jobs", s.handleAgentListScheduledJobs)
 	api.POST("/projects/:projectId/scheduled-jobs", s.handleAgentCreateScheduledJob)
 	api.PATCH("/scheduled-jobs/:jobId", s.handleAgentUpdateScheduledJob)
@@ -111,6 +114,41 @@ func (s *Server) requireAgentProjectAgentAnyScope(c echo.Context, scopes ...agen
 		return domain.Agent{}, false
 	}
 	return item, true
+}
+
+func (s *Server) requireAgentAnyProjectAgentScope(c echo.Context, scopes ...agentplatform.Scope) (domain.Agent, bool) {
+	if s.catalog.AgentService == nil {
+		_ = writeAPIError(c, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "catalog service unavailable")
+		return domain.Agent{}, false
+	}
+
+	claims, ok := requireAgentAnyScope(c, scopes...)
+	if !ok {
+		return domain.Agent{}, false
+	}
+
+	agentID, err := parseUUIDPathParamValue(c, "agentId")
+	if err != nil {
+		_ = writeAPIError(c, http.StatusBadRequest, "INVALID_AGENT_ID", err.Error())
+		return domain.Agent{}, false
+	}
+	item, err := s.catalog.GetAgent(c.Request().Context(), agentID)
+	if err != nil {
+		_ = writeCatalogError(c, err)
+		return domain.Agent{}, false
+	}
+	if item.ProjectID != claims.ProjectID {
+		_ = writeAPIError(c, http.StatusForbidden, "AGENT_PROJECT_FORBIDDEN", "agent token cannot access another project")
+		return domain.Agent{}, false
+	}
+	return item, true
+}
+
+func (s *Server) handleAgentInterruptAgent(c echo.Context) error {
+	if _, ok := s.requireAgentAnyProjectAgentScope(c, agentplatform.ScopeAgentsInterrupt); !ok {
+		return nil
+	}
+	return s.interruptAgent(c)
 }
 
 func (s *Server) handleAgentInterruptProjectAgent(c echo.Context) error {
@@ -437,6 +475,20 @@ func (s *Server) handleAgentDeleteTicketRepoScope(c echo.Context) error {
 		return nil
 	}
 	return s.deleteTicketRepoScope(c)
+}
+
+func (s *Server) handleAgentListTicketRuns(c echo.Context) error {
+	if _, _, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsList); !ok {
+		return nil
+	}
+	return s.handleListTicketRuns(c)
+}
+
+func (s *Server) handleAgentGetTicketRun(c echo.Context) error {
+	if _, _, ok := s.requireAgentProjectTicket(c, agentplatform.ScopeTicketsList); !ok {
+		return nil
+	}
+	return s.handleGetTicketRun(c)
 }
 
 func (s *Server) handleAgentListScheduledJobs(c echo.Context) error {

--- a/internal/httpapi/machine_channel_api_test.go
+++ b/internal/httpapi/machine_channel_api_test.go
@@ -234,17 +234,13 @@ func TestMachineConnectWebsocketPublishesActivityAndMetrics(t *testing.T) {
 		t.Fatalf("expected registered envelope, got %+v", registeredEnvelope)
 	}
 
-	metricsBody := scrapeMetrics(t, server.Handler())
-	for _, expected := range []string{
+	expectedMetrics := []string{
 		`openase_machine_channel_active_sessions{transport_mode="ws_reverse"} 1`,
 		`openase_machine_channel_websocket_reconnect_total{transport_mode="ws_reverse"} 1`,
 		`openase_machine_channel_events_total{event="registered",transport_mode="ws_reverse"} 2`,
 		`openase_machine_channel_events_total{event="reconnected",transport_mode="ws_reverse"} 1`,
-	} {
-		if !strings.Contains(metricsBody, expected) {
-			t.Fatalf("expected metrics to contain %q, got %q", expected, metricsBody)
-		}
 	}
+	waitForMetricsContaining(t, server.Handler(), expectedMetrics...)
 
 	if err := writeMachineEnvelope(conn2, domain.MessageTypeGoodbye, "", domain.Goodbye{Reason: "test complete"}); err != nil {
 		t.Fatalf("write goodbye: %v", err)
@@ -458,6 +454,30 @@ func scrapeMetrics(t *testing.T, handler http.Handler) string {
 		t.Fatalf("expected metrics route to return 200, got %d", rec.Code)
 	}
 	return rec.Body.String()
+}
+
+func waitForMetricsContaining(t *testing.T, handler http.Handler, expected ...string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	var metricsBody string
+	for {
+		metricsBody = scrapeMetrics(t, handler)
+		missing := ""
+		for _, fragment := range expected {
+			if !strings.Contains(metricsBody, fragment) {
+				missing = fragment
+				break
+			}
+		}
+		if missing == "" {
+			return metricsBody
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected metrics to contain %q, got %q", missing, metricsBody)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func dialMachineWebsocket(t *testing.T, serverURL string) *websocket.Conn {

--- a/internal/repo/ticket/repo.go
+++ b/internal/repo/ticket/repo.go
@@ -26,6 +26,7 @@ import (
 	entticketstatus "github.com/BetterAndBetterII/openase/ent/ticketstatus"
 	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	"github.com/BetterAndBetterII/openase/internal/domain/pricing"
 	domain "github.com/BetterAndBetterII/openase/internal/domain/ticket"
 	"github.com/BetterAndBetterII/openase/internal/domain/ticketing"
 	workflowdomain "github.com/BetterAndBetterII/openase/internal/domain/workflow"
@@ -1956,30 +1957,76 @@ func (r *EntRepository) RecordUsage(
 		return PersistedUsageResult{}, mapTicketReadError("get ticket for usage", err)
 	}
 
-	agentItem, err := tx.Agent.Query().
-		Where(entagent.IDEQ(input.AgentID)).
-		WithProvider().
-		Only(ctx)
-	if err != nil {
-		if ent.IsNotFound(err) {
-			return PersistedUsageResult{}, fmt.Errorf("agent %s not found", input.AgentID)
-		}
-		return PersistedUsageResult{}, fmt.Errorf("get agent for usage: %w", err)
-	}
-	if agentItem.ProjectID != ticketItem.ProjectID {
-		return PersistedUsageResult{}, fmt.Errorf("agent %s does not belong to ticket project %s", agentItem.ID, ticketItem.ProjectID)
-	}
-	if agentItem.Edges.Provider == nil {
-		return PersistedUsageResult{}, fmt.Errorf("agent provider must be loaded for usage accounting")
-	}
-
-	pricingConfig := catalogdomain.ResolveAgentProviderPricingConfig(
-		catalogdomain.AgentProviderAdapterType(agentItem.Edges.Provider.AdapterType),
-		agentItem.Edges.Provider.ModelName,
-		agentItem.Edges.Provider.CostPerInputToken,
-		agentItem.Edges.Provider.CostPerOutputToken,
-		agentItem.Edges.Provider.PricingConfig,
+	var (
+		usageActorID    *uuid.UUID
+		metricsAgent    UsageMetricsAgent
+		pricingConfig   pricing.ProviderModelPricingConfig
+		belongsToTicket bool
 	)
+
+	if input.AgentID != uuid.Nil {
+		agentItem, err := tx.Agent.Query().
+			Where(entagent.IDEQ(input.AgentID)).
+			WithProvider().
+			Only(ctx)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return PersistedUsageResult{}, fmt.Errorf("agent %s not found", input.AgentID)
+			}
+			return PersistedUsageResult{}, fmt.Errorf("get agent for usage: %w", err)
+		}
+		if agentItem.ProjectID != ticketItem.ProjectID {
+			return PersistedUsageResult{}, fmt.Errorf("agent %s does not belong to ticket project %s", agentItem.ID, ticketItem.ProjectID)
+		}
+		if agentItem.Edges.Provider == nil {
+			return PersistedUsageResult{}, fmt.Errorf("agent provider must be loaded for usage accounting")
+		}
+
+		pricingConfig = catalogdomain.ResolveAgentProviderPricingConfig(
+			catalogdomain.AgentProviderAdapterType(agentItem.Edges.Provider.AdapterType),
+			agentItem.Edges.Provider.ModelName,
+			agentItem.Edges.Provider.CostPerInputToken,
+			agentItem.Edges.Provider.CostPerOutputToken,
+			agentItem.Edges.Provider.PricingConfig,
+		)
+		usageActorID = &agentItem.ID
+		metricsAgent = UsageMetricsAgent{
+			ProviderName: agentItem.Edges.Provider.Name,
+			ModelName:    agentItem.Edges.Provider.ModelName,
+		}
+		belongsToTicket = true
+	} else {
+		principalItem, err := tx.ProjectConversationPrincipal.Get(ctx, input.ConversationID)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return PersistedUsageResult{}, fmt.Errorf("project conversation principal %s not found", input.ConversationID)
+			}
+			return PersistedUsageResult{}, fmt.Errorf("get project conversation principal for usage: %w", err)
+		}
+		if principalItem.ProjectID != ticketItem.ProjectID {
+			return PersistedUsageResult{}, fmt.Errorf("project conversation principal %s does not belong to ticket project %s", principalItem.ID, ticketItem.ProjectID)
+		}
+
+		providerItem, err := tx.AgentProvider.Get(ctx, principalItem.ProviderID)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return PersistedUsageResult{}, fmt.Errorf("provider %s not found", principalItem.ProviderID)
+			}
+			return PersistedUsageResult{}, fmt.Errorf("get provider for project conversation usage: %w", err)
+		}
+
+		pricingConfig = catalogdomain.ResolveAgentProviderPricingConfig(
+			catalogdomain.AgentProviderAdapterType(providerItem.AdapterType),
+			providerItem.ModelName,
+			providerItem.CostPerInputToken,
+			providerItem.CostPerOutputToken,
+			providerItem.PricingConfig,
+		)
+		metricsAgent = UsageMetricsAgent{
+			ProviderName: providerItem.Name,
+			ModelName:    providerItem.ModelName,
+		}
+	}
 	resolvedCost, err := usageDelta.ResolveCost(pricingConfig)
 	if err != nil {
 		return PersistedUsageResult{}, err
@@ -2001,8 +2048,8 @@ func (r *EntRepository) RecordUsage(
 		return PersistedUsageResult{}, mapTicketWriteError("update ticket usage", err)
 	}
 
-	if usageDelta.TotalTokens() > 0 {
-		if _, err := tx.Agent.UpdateOneID(agentItem.ID).
+	if belongsToTicket && usageDelta.TotalTokens() > 0 {
+		if _, err := tx.Agent.UpdateOneID(*usageActorID).
 			AddTotalTokensUsed(usageDelta.TotalTokens()).
 			Save(ctx); err != nil {
 			return PersistedUsageResult{}, fmt.Errorf("update agent usage counters: %w", err)
@@ -2019,8 +2066,8 @@ func (r *EntRepository) RecordUsage(
 			}
 			return PersistedUsageResult{}, fmt.Errorf("get agent run for usage: %w", err)
 		}
-		if runItem.AgentID != agentItem.ID {
-			return PersistedUsageResult{}, fmt.Errorf("agent run %s does not belong to agent %s", runItem.ID, agentItem.ID)
+		if usageActorID == nil || runItem.AgentID != *usageActorID {
+			return PersistedUsageResult{}, fmt.Errorf("agent run %s does not belong to agent %s", runItem.ID, input.AgentID)
 		}
 		if runItem.TicketID != ticketItem.ID {
 			return PersistedUsageResult{}, fmt.Errorf("agent run %s does not belong to ticket %s", runItem.ID, ticketItem.ID)
@@ -2041,22 +2088,29 @@ func (r *EntRepository) RecordUsage(
 		}
 	}
 
-	if _, err := tx.ActivityEvent.Create().
+	metadata := map[string]any{
+		"input_tokens":  usageDelta.InputTokens,
+		"output_tokens": usageDelta.OutputTokens,
+		"total_tokens":  usageDelta.TotalTokens(),
+		"cost_usd":      resolvedCost.AmountUSD,
+		"cost_source":   resolvedCost.Source.String(),
+		"agent_run_id":  agentRunID,
+	}
+	if input.ConversationID != uuid.Nil {
+		metadata["conversation_id"] = input.ConversationID.String()
+	}
+
+	activityEvent := tx.ActivityEvent.Create().
 		SetProjectID(ticketItem.ProjectID).
 		SetTicketID(ticketItem.ID).
-		SetAgentID(agentItem.ID).
 		SetEventType(ticketing.CostRecordedEventType).
 		SetMessage("").
-		SetMetadata(map[string]any{
-			"input_tokens":  usageDelta.InputTokens,
-			"output_tokens": usageDelta.OutputTokens,
-			"total_tokens":  usageDelta.TotalTokens(),
-			"cost_usd":      resolvedCost.AmountUSD,
-			"cost_source":   resolvedCost.Source.String(),
-			"agent_run_id":  agentRunID,
-		}).
-		SetCreatedAt(timeNowUTC()).
-		Save(ctx); err != nil {
+		SetMetadata(metadata).
+		SetCreatedAt(timeNowUTC())
+	if usageActorID != nil {
+		activityEvent.SetAgentID(*usageActorID)
+	}
+	if _, err := activityEvent.Save(ctx); err != nil {
 		return PersistedUsageResult{}, fmt.Errorf("create ticket cost event: %w", err)
 	}
 
@@ -2080,11 +2134,8 @@ func (r *EntRepository) RecordUsage(
 			},
 			BudgetExceeded: ticketing.ShouldPauseForBudget(ticketAfter.CostAmount, ticketAfter.BudgetUSD),
 		},
-		MetricsAgent: UsageMetricsAgent{
-			ProviderName: agentItem.Edges.Provider.Name,
-			ModelName:    agentItem.Edges.Provider.ModelName,
-		},
-		ProjectID: ticketItem.ProjectID,
+		MetricsAgent: metricsAgent,
+		ProjectID:    ticketItem.ProjectID,
 	}, nil
 }
 

--- a/internal/ticket/cost_tracker.go
+++ b/internal/ticket/cost_tracker.go
@@ -17,14 +17,17 @@ func (s *Service) RecordUsage(
 	if s == nil || s.repo == nil {
 		return RecordUsageResult{}, ErrUnavailable
 	}
-	if input.AgentID == uuid.Nil {
-		return RecordUsageResult{}, fmt.Errorf("agent_id must be a valid UUID")
+	if input.AgentID == uuid.Nil && input.ConversationID == uuid.Nil {
+		return RecordUsageResult{}, fmt.Errorf("agent_id or conversation_id must be a valid UUID")
 	}
 	if input.TicketID == uuid.Nil {
 		return RecordUsageResult{}, fmt.Errorf("ticket_id must be a valid UUID")
 	}
 	if input.RunID != nil && *input.RunID == uuid.Nil {
 		return RecordUsageResult{}, fmt.Errorf("run_id must be a valid UUID")
+	}
+	if input.RunID != nil && input.AgentID == uuid.Nil {
+		return RecordUsageResult{}, fmt.Errorf("run_id requires agent_id")
 	}
 	if metrics == nil {
 		metrics = provider.NewNoopMetricsProvider()

--- a/internal/ticket/cost_tracker_test.go
+++ b/internal/ticket/cost_tracker_test.go
@@ -260,8 +260,8 @@ func TestServiceRecordUsageEdgeCases(t *testing.T) {
 	service := newTicketService(client)
 	if _, err := service.RecordUsage(ctx, RecordUsageInput{
 		AgentID: uuid.Nil,
-	}, nil); err == nil || err.Error() != "agent_id must be a valid UUID" {
-		t.Fatalf("RecordUsage(nil agent) error = %v", err)
+	}, nil); err == nil || err.Error() != "agent_id or conversation_id must be a valid UUID" {
+		t.Fatalf("RecordUsage(missing actor) error = %v", err)
 	}
 	if _, err := service.RecordUsage(ctx, RecordUsageInput{
 		AgentID:  projectAgent.ID,
@@ -333,6 +333,107 @@ func TestServiceRecordUsageEdgeCases(t *testing.T) {
 	}
 	if projectAgentAfter.TotalTokensUsed != 0 {
 		t.Fatalf("expected zero total tokens after explicit-cost-only update, got %d", projectAgentAfter.TotalTokensUsed)
+	}
+}
+
+func TestServiceRecordUsageSupportsProjectConversationPrincipal(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+
+	org, err := client.Organization.Create().
+		SetName("Better And Better").
+		SetSlug("better-and-better").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create organization: %v", err)
+	}
+	localMachine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local").
+		SetHost("local").
+		SetPort(22).
+		SetStatus("online").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create local machine: %v", err)
+	}
+	project, err := client.Project.Create().
+		SetOrganizationID(org.ID).
+		SetName("OpenASE").
+		SetSlug("openase").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	providerItem, err := client.AgentProvider.Create().
+		SetOrganizationID(org.ID).
+		SetMachineID(localMachine.ID).
+		SetName("Codex").
+		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
+		SetCliCommand("codex").
+		SetModelName("gpt-5.4").
+		SetCostPerInputToken(0.001).
+		SetCostPerOutputToken(0.002).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	statuses, err := newTicketStatusService(client).ResetToDefaultTemplate(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("reset statuses: %v", err)
+	}
+	todoID := findStatusIDByName(t, statuses, "Todo")
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(project.ID).
+		SetIdentifier("ASE-77").
+		SetTitle("Track Project AI costs").
+		SetStatusID(todoID).
+		SetCreatedBy("project-conversation:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	conversationID := uuid.New()
+	if _, err := client.ProjectConversationPrincipal.Create().
+		SetID(conversationID).
+		SetConversationID(conversationID).
+		SetProjectID(project.ID).
+		SetProviderID(providerItem.ID).
+		SetName("project-conversation:" + conversationID.String()).
+		Save(ctx); err != nil {
+		t.Fatalf("create project conversation principal: %v", err)
+	}
+
+	service := newTicketService(client)
+	inputTokens := int64(10)
+	outputTokens := int64(5)
+	result, err := service.RecordUsage(ctx, RecordUsageInput{
+		ConversationID: conversationID,
+		TicketID:       ticketItem.ID,
+		Usage: ticketing.RawUsageDelta{
+			InputTokens:  &inputTokens,
+			OutputTokens: &outputTokens,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordUsage(project conversation) returned error: %v", err)
+	}
+	if result.Applied.InputTokens != 10 || result.Applied.OutputTokens != 5 {
+		t.Fatalf("unexpected applied usage: %+v", result.Applied)
+	}
+	if math.Abs(result.Applied.CostUSD-0.02) > 0.0001 {
+		t.Fatalf("expected applied cost 0.02, got %.2f", result.Applied.CostUSD)
+	}
+
+	activityEvents, err := client.ActivityEvent.Query().Where(entactivityevent.EventTypeEQ(ticketing.CostRecordedEventType)).All(ctx)
+	if err != nil {
+		t.Fatalf("query usage activity events: %v", err)
+	}
+	if len(activityEvents) != 1 {
+		t.Fatalf("expected one cost activity event, got %+v", activityEvents)
+	}
+	if activityEvents[0].AgentID != nil {
+		t.Fatalf("expected project conversation cost event to omit agent_id, got %+v", activityEvents[0])
 	}
 }
 

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -33,4 +33,37 @@ else
   args+=("./...")
 fi
 
-go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${LINT_VERSION}" "${args[@]}"
+lint_cmd=(go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${LINT_VERSION}" "${args[@]}")
+retryable_patterns=(
+  "proxy.golang.org"
+  "Client.Timeout exceeded"
+  "TLS handshake timeout"
+  "connection reset by peer"
+  "EOF"
+)
+
+attempt=1
+max_attempts=3
+while (( attempt <= max_attempts )); do
+  output="$("${lint_cmd[@]}" 2>&1)" && {
+    printf '%s\n' "${output}"
+    exit 0
+  }
+
+  should_retry=0
+  for pattern in "${retryable_patterns[@]}"; do
+    if [[ "${output}" == *"${pattern}"* ]]; then
+      should_retry=1
+      break
+    fi
+  done
+
+  printf '%s\n' "${output}" >&2
+  if (( should_retry == 0 || attempt == max_attempts )); then
+    exit 1
+  fi
+
+  printf 'lint bootstrap failed with a transient network error; retrying (%d/%d)\n' "${attempt}" "${max_attempts}" >&2
+  sleep $(( attempt * 2 ))
+  ((attempt++))
+done

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -42,10 +42,14 @@ retryable_patterns=(
   "EOF"
 )
 
+lint_proxy_modes=("${GOPROXY:-https://proxy.golang.org,direct}" "direct")
 attempt=1
-max_attempts=3
+max_attempts=4
+mode_index=0
+
 while (( attempt <= max_attempts )); do
-  output="$("${lint_cmd[@]}" 2>&1)" && {
+  current_proxy="${lint_proxy_modes[mode_index]}"
+  output="$(GOPROXY="${current_proxy}" "${lint_cmd[@]}" 2>&1)" && {
     printf '%s\n' "${output}"
     exit 0
   }
@@ -63,7 +67,13 @@ while (( attempt <= max_attempts )); do
     exit 1
   fi
 
-  printf 'lint bootstrap failed with a transient network error; retrying (%d/%d)\n' "${attempt}" "${max_attempts}" >&2
+  if (( mode_index == 0 && ${#lint_proxy_modes[@]} > 1 )) && [[ "${output}" == *"proxy.golang.org"* ]]; then
+    mode_index=1
+    printf 'lint bootstrap failed via %s; retrying with GOPROXY=%s (%d/%d)\n' \
+      "${current_proxy}" "${lint_proxy_modes[mode_index]}" "${attempt}" "${max_attempts}" >&2
+  else
+    printf 'lint bootstrap failed with a transient network error; retrying (%d/%d)\n' "${attempt}" "${max_attempts}" >&2
+  fi
   sleep $(( attempt * 2 ))
   ((attempt++))
 done


### PR DESCRIPTION
## Summary
- add project-scoped platform ticket routes for Project AI conversation principals
- update CLI project-conversation ticket commands to use those project routes when the matching scopes are present
- support usage accounting for project conversations without an agent id and extend backend coverage around the new flows

## Validation
- `export PATH=$HOME/.local/go1.26.1/bin:$PATH`
- `export TMPDIR=/home/gary/openase/.tmp-go`
- `export OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest`
- `go test ./internal/cli ./internal/domain/agentplatform ./internal/httpapi ./internal/repo/ticket ./internal/ticket`

## Risks / Follow-up
- this is a stacked PR on top of `feat/ase-162-workspace-editor`
- local workspace still has an unrelated `internal/webui/static/.keep` deletion that was intentionally not included in this branch
