### PR TITLE
refactor(chat): remove lingering frontend budget suppressions

### DIFF
--- a/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-detail.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
   import { Button } from '$ui/button'
   import * as Dialog from '$ui/dialog'
   import { cn } from '$lib/utils'

--- a/web/src/lib/features/chat/terminal-manager-connection.ts
+++ b/web/src/lib/features/chat/terminal-manager-connection.ts
@@ -1,0 +1,212 @@
+import {
+  buildExitMessage,
+  buildTerminalWebSocketURL,
+  parseTerminalServerFrame,
+} from './project-conversation-terminal-panel-helpers'
+import type { TerminalInstance, TerminalInstanceRuntime } from './terminal-manager-types'
+import { createProjectConversationTerminalSession } from '$lib/api/chat'
+
+export function createTerminalConnectionHelpers(input: {
+  getConversationId: () => string
+  hasInstance: (id: string) => boolean
+  listInstances: () => TerminalInstance[]
+  runtimeMap: Map<string, TerminalInstanceRuntime>
+  socketMap: Map<string, WebSocket>
+  scheduleReconnect: (id: string, label: string) => void
+  updateInstance: (id: string, updates: Partial<TerminalInstance>) => void
+}) {
+  function matchesConnectionState(id: string, conversationId: string, connectRevision: number) {
+    return (
+      input.hasInstance(id) &&
+      input.getConversationId() === conversationId &&
+      input.runtimeMap.get(id)?.connectRevision === connectRevision
+    )
+  }
+
+  function matchesSocketEvent(id: string, socket: WebSocket, connectRevision: number) {
+    return (
+      input.socketMap.get(id) === socket &&
+      input.runtimeMap.get(id)?.connectRevision === connectRevision &&
+      input.hasInstance(id)
+    )
+  }
+
+  function setConnectingStatus(id: string, label: string, isReconnect: boolean) {
+    input.updateInstance(id, {
+      status: 'connecting',
+      statusMessage: isReconnect
+        ? `Reconnecting shell in ${label}...`
+        : `Starting shell in ${label}...`,
+    })
+  }
+
+  async function resolveTerminalSession(inputState: {
+    id: string
+    conversationId: string
+    connectRevision: number
+    runtime: TerminalInstanceRuntime
+    terminal: import('@xterm/xterm').Terminal
+  }) {
+    if (inputState.runtime.session) {
+      return inputState.runtime.session
+    }
+
+    inputState.terminal.reset()
+    try {
+      const payload = await createProjectConversationTerminalSession(inputState.conversationId, {
+        mode: 'shell',
+        cols: inputState.terminal.cols > 0 ? inputState.terminal.cols : 120,
+        rows: inputState.terminal.rows > 0 ? inputState.terminal.rows : 32,
+      })
+      inputState.runtime.session = payload.terminalSession
+      return payload.terminalSession
+    } catch (error) {
+      if (
+        !matchesConnectionState(
+          inputState.id,
+          inputState.conversationId,
+          inputState.connectRevision,
+        )
+      ) {
+        return null
+      }
+      input.updateInstance(inputState.id, {
+        status: 'error',
+        statusMessage:
+          error instanceof Error ? error.message : 'Failed to create terminal session.',
+      })
+      return null
+    }
+  }
+
+  function handleSocketMessage(inputState: {
+    id: string
+    socket: WebSocket
+    connectRevision: number
+    terminal: import('@xterm/xterm').Terminal
+    event: MessageEvent
+    runtime: TerminalInstanceRuntime
+  }) {
+    if (!matchesSocketEvent(inputState.id, inputState.socket, inputState.connectRevision)) {
+      return
+    }
+    try {
+      const frame = parseTerminalServerFrame(inputState.event.data)
+      const inst = input.listInstances().find((instance) => instance.id === inputState.id)
+      switch (frame.type) {
+        case 'ready':
+          inputState.runtime.reconnectAttempts = 0
+          input.updateInstance(inputState.id, {
+            status: 'open',
+            statusMessage: `Shell attached to ${inst?.label}.`,
+          })
+          inputState.terminal.focus()
+          return
+        case 'output':
+          inputState.terminal.write(frame.data)
+          return
+        case 'exit':
+          inputState.runtime.reconnectEnabled = false
+          inputState.runtime.session = null
+          input.updateInstance(inputState.id, {
+            status: 'closed',
+            statusMessage: buildExitMessage(frame.exitCode, frame.signal),
+            sessionID: '',
+          })
+          inputState.socket.close()
+          return
+        case 'error':
+          inputState.runtime.reconnectEnabled = false
+          inputState.runtime.session = null
+          input.updateInstance(inputState.id, {
+            status: 'error',
+            statusMessage: frame.message,
+            sessionID: '',
+          })
+          inputState.socket.close()
+      }
+    } catch (error) {
+      inputState.runtime.reconnectEnabled = false
+      inputState.runtime.session = null
+      input.updateInstance(inputState.id, {
+        status: 'error',
+        statusMessage: error instanceof Error ? error.message : 'Failed to parse terminal output.',
+      })
+      inputState.socket.close()
+    }
+  }
+
+  function handleSocketError(
+    id: string,
+    socket: WebSocket,
+    connectRevision: number,
+    label: string,
+  ) {
+    if (!matchesSocketEvent(id, socket, connectRevision)) {
+      return
+    }
+    input.updateInstance(id, {
+      status: 'connecting',
+      statusMessage: `Reconnecting shell in ${label}...`,
+    })
+  }
+
+  function handleSocketClose(
+    id: string,
+    socket: WebSocket,
+    connectRevision: number,
+    runtime: TerminalInstanceRuntime,
+  ) {
+    if (!matchesSocketEvent(id, socket, connectRevision)) {
+      return
+    }
+    input.socketMap.delete(id)
+    const inst = input.listInstances().find((instance) => instance.id === id)
+    if (!inst) {
+      return
+    }
+    if (runtime.reconnectEnabled && (inst.status === 'connecting' || inst.status === 'open')) {
+      input.scheduleReconnect(id, inst.label)
+      return
+    }
+    if (inst.status === 'connecting' || inst.status === 'open') {
+      input.updateInstance(id, {
+        status: 'closed',
+        statusMessage: 'Terminal disconnected.',
+        sessionID: '',
+      })
+    }
+  }
+
+  function attachSocket(inputState: {
+    id: string
+    session: import('$lib/api/chat').ProjectConversationTerminalSession
+    connectRevision: number
+    terminal: import('@xterm/xterm').Terminal
+    runtime: TerminalInstanceRuntime
+    label: string
+  }) {
+    const socket = new WebSocket(buildTerminalWebSocketURL(inputState.session))
+    input.socketMap.set(inputState.id, socket)
+    socket.onmessage = (event) =>
+      handleSocketMessage({
+        id: inputState.id,
+        socket,
+        connectRevision: inputState.connectRevision,
+        terminal: inputState.terminal,
+        event,
+        runtime: inputState.runtime,
+      })
+    socket.onerror = () =>
+      handleSocketError(inputState.id, socket, inputState.connectRevision, inputState.label)
+    socket.onclose = () =>
+      handleSocketClose(inputState.id, socket, inputState.connectRevision, inputState.runtime)
+  }
+
+  return {
+    attachSocket,
+    matchesConnectionState,
+    resolveTerminalSession,
+    setConnectingStatus,
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager-types.ts
+++ b/web/src/lib/features/chat/terminal-manager-types.ts
@@ -1,0 +1,25 @@
+import type { ProjectConversationTerminalSession } from '$lib/api/chat'
+import type { TerminalPanelStatus } from './project-conversation-terminal-panel-helpers'
+
+export interface TerminalInstance {
+  id: string
+  label: string
+  status: TerminalPanelStatus
+  statusMessage: string
+  sessionID: string
+}
+
+export type TerminalInstanceRuntime = {
+  mountRevision: number
+  connectRevision: number
+  reconnectAttempts: number
+  reconnectEnabled: boolean
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  session: ProjectConversationTerminalSession | null
+}
+
+export type MountedTerminal = {
+  terminal: import('@xterm/xterm').Terminal
+  fitAddon: import('@xterm/addon-fit').FitAddon
+  dispose: () => void
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -1,34 +1,13 @@
-/* eslint-disable max-lines, max-lines-per-function, complexity */
 import {
-  createProjectConversationTerminalSession,
-  type ProjectConversationTerminalSession,
-} from '$lib/api/chat'
-import {
-  buildExitMessage,
-  buildTerminalWebSocketURL,
   encodeTerminalPayload,
   mountProjectConversationTerminal,
-  parseTerminalServerFrame,
-  type TerminalPanelStatus,
-  type TerminalServerFrame,
 } from './project-conversation-terminal-panel-helpers'
-
-export interface TerminalInstance {
-  id: string
-  label: string
-  status: TerminalPanelStatus
-  statusMessage: string
-  sessionID: string
-}
-
-type TerminalInstanceRuntime = {
-  mountRevision: number
-  connectRevision: number
-  reconnectAttempts: number
-  reconnectEnabled: boolean
-  reconnectTimer: ReturnType<typeof setTimeout> | null
-  session: ProjectConversationTerminalSession | null
-}
+import { createTerminalConnectionHelpers } from './terminal-manager-connection'
+import type {
+  MountedTerminal,
+  TerminalInstance,
+  TerminalInstanceRuntime,
+} from './terminal-manager-types'
 
 let nextId = 1
 const reconnectDelaysMs = [750, 1_500, 3_000, 5_000] as const
@@ -46,14 +25,7 @@ export function createTerminalManager(input: {
   let panelOpen = $state(false)
 
   // Internal state per instance (not reactive, keyed by id)
-  const xtermMap = new Map<
-    string,
-    {
-      terminal: import('@xterm/xterm').Terminal
-      fitAddon: import('@xterm/addon-fit').FitAddon
-      dispose: () => void
-    }
-  >()
+  const xtermMap = new Map<string, MountedTerminal>()
   const socketMap = new Map<string, WebSocket>()
   const elementMap = new Map<string, HTMLDivElement>()
   const resizeObserverMap = new Map<string, ResizeObserver>()
@@ -104,6 +76,17 @@ export function createTerminalManager(input: {
   function nextReconnectDelay(attempt: number) {
     return reconnectDelaysMs[Math.min(attempt - 1, reconnectDelaysMs.length - 1)]
   }
+
+  const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
+    createTerminalConnectionHelpers({
+      getConversationId: input.getConversationId,
+      hasInstance,
+      listInstances: () => instances,
+      runtimeMap,
+      socketMap,
+      scheduleReconnect,
+      updateInstance,
+    })
 
   async function mountTerminal(id: string, element: HTMLDivElement) {
     // Prevent double-mount
@@ -252,154 +235,35 @@ export function createTerminalManager(input: {
     entry.fitAddon.fit()
 
     const label = workspacePath || 'workspace root'
-    updateInstance(id, {
-      status: 'connecting',
-      statusMessage: isReconnect
-        ? `Reconnecting shell in ${label}...`
-        : `Starting shell in ${label}...`,
-      label,
-    })
+    updateInstance(id, { label })
+    setConnectingStatus(id, label, isReconnect)
 
-    let session = runtime.session
+    const session = await resolveTerminalSession({
+      id,
+      conversationId,
+      connectRevision,
+      runtime,
+      terminal: entry.terminal,
+    })
     if (!session) {
-      entry.terminal.reset()
-      try {
-        const payload = await createProjectConversationTerminalSession(conversationId, {
-          mode: 'shell',
-          cols: entry.terminal.cols > 0 ? entry.terminal.cols : 120,
-          rows: entry.terminal.rows > 0 ? entry.terminal.rows : 32,
-        })
-        session = payload.terminalSession
-        runtime.session = session
-      } catch (error) {
-        if (
-          !hasInstance(id) ||
-          input.getConversationId() !== conversationId ||
-          runtimeMap.get(id)?.connectRevision !== connectRevision
-        ) {
-          return
-        }
-        updateInstance(id, {
-          status: 'error',
-          statusMessage:
-            error instanceof Error ? error.message : 'Failed to create terminal session.',
-        })
-        return
-      }
+      return
     }
 
     const currentEntry = xtermMap.get(id)
-    if (
-      !hasInstance(id) ||
-      input.getConversationId() !== conversationId ||
-      runtimeMap.get(id)?.connectRevision !== connectRevision ||
-      !currentEntry
-    ) {
+    if (!currentEntry || !matchesConnectionState(id, conversationId, connectRevision)) {
       return
     }
 
     runtime.session = session
     updateInstance(id, { sessionID: session.id })
-    const socket = new WebSocket(buildTerminalWebSocketURL(session))
-    socketMap.set(id, socket)
-
-    socket.onmessage = (event) => {
-      if (
-        socketMap.get(id) !== socket ||
-        runtimeMap.get(id)?.connectRevision !== connectRevision ||
-        !hasInstance(id)
-      ) {
-        return
-      }
-      try {
-        handleFrame(id, parseTerminalServerFrame(event.data), socket, currentEntry.terminal)
-      } catch (error) {
-        runtime.reconnectEnabled = false
-        updateInstance(id, {
-          status: 'error',
-          statusMessage:
-            error instanceof Error ? error.message : 'Failed to parse terminal output.',
-        })
-        runtime.session = null
-        socket.close()
-      }
-    }
-
-    socket.onerror = () => {
-      if (
-        socketMap.get(id) !== socket ||
-        runtimeMap.get(id)?.connectRevision !== connectRevision ||
-        !hasInstance(id)
-      ) {
-        return
-      }
-      updateInstance(id, {
-        status: 'connecting',
-        statusMessage: `Reconnecting shell in ${label}...`,
-      })
-    }
-
-    socket.onclose = () => {
-      if (
-        socketMap.get(id) !== socket ||
-        runtimeMap.get(id)?.connectRevision !== connectRevision ||
-        !hasInstance(id)
-      ) {
-        return
-      }
-      socketMap.delete(id)
-      const inst = instances.find((i) => i.id === id)
-      if (!inst) {
-        return
-      }
-      if (runtime.reconnectEnabled && (inst.status === 'connecting' || inst.status === 'open')) {
-        scheduleReconnect(id, inst.label)
-        return
-      }
-      if (inst.status === 'connecting' || inst.status === 'open') {
-        updateInstance(id, {
-          status: 'closed',
-          statusMessage: 'Terminal disconnected.',
-          sessionID: '',
-        })
-      }
-    }
-  }
-
-  function handleFrame(
-    id: string,
-    frame: TerminalServerFrame,
-    socket: WebSocket,
-    xterm: import('@xterm/xterm').Terminal,
-  ) {
-    const inst = instances.find((i) => i.id === id)
-    const runtime = ensureRuntime(id)
-    switch (frame.type) {
-      case 'ready':
-        runtime.reconnectAttempts = 0
-        updateInstance(id, { status: 'open', statusMessage: `Shell attached to ${inst?.label}.` })
-        xterm.focus()
-        return
-      case 'output':
-        xterm.write(frame.data)
-        return
-      case 'exit':
-        runtime.reconnectEnabled = false
-        runtime.session = null
-        updateInstance(id, {
-          status: 'closed',
-          statusMessage: buildExitMessage(frame.exitCode, frame.signal),
-          sessionID: '',
-        })
-        socket.close()
-        return
-      case 'error':
-        runtime.reconnectEnabled = false
-        runtime.session = null
-        updateInstance(id, { status: 'error', statusMessage: frame.message, sessionID: '' })
-        socket.close()
-        return
-    }
+    attachSocket({
+      id,
+      session,
+      connectRevision,
+      terminal: currentEntry.terminal,
+      runtime,
+      label,
+    })
   }
 
   function createInstance(): string {

--- a/web/src/lib/features/chat/terminal-manager.test.ts
+++ b/web/src/lib/features/chat/terminal-manager.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable max-lines-per-function */
 import { waitFor } from '@testing-library/svelte'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest'
 
 const { createProjectConversationTerminalSession } = vi.hoisted(() => ({
   createProjectConversationTerminalSession: vi.fn(),
@@ -95,76 +94,28 @@ vi.mock('@xterm/addon-fit', () => ({
 
 import { createTerminalManager } from './terminal-manager.svelte'
 
-describe('terminal manager', () => {
-  beforeAll(() => {
-    globalThis.ResizeObserver ??= class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
-  })
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+})
 
-  beforeEach(() => {
-    vi.useRealTimers()
-  })
+beforeEach(() => {
+  vi.useRealTimers()
+})
 
-  afterEach(() => {
-    vi.clearAllMocks()
-    MockWebSocket.instances.length = 0
-    MockTerminal.instances.length = 0
-  })
+afterEach(() => {
+  vi.clearAllMocks()
+  MockWebSocket.instances.length = 0
+  MockTerminal.instances.length = 0
+})
 
-  it('keeps existing terminal tabs connected when another tab opens and closes', async () => {
-    createProjectConversationTerminalSession
-      .mockResolvedValueOnce({
-        terminalSession: {
-          id: 'terminal-1',
-          mode: 'shell',
-          cwd: '/tmp/conversation-1',
-          wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-1/attach',
-          attachToken: 'attach-token-1',
-        },
-      })
-      .mockResolvedValueOnce({
-        terminalSession: {
-          id: 'terminal-2',
-          mode: 'shell',
-          cwd: '/tmp/conversation-1',
-          wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-2/attach',
-          attachToken: 'attach-token-2',
-        },
-      })
-
-    const manager = createTerminalManager({
-      getConversationId: () => 'conversation-1',
-      getWorkspacePath: () => '/tmp/conversation-1',
-    })
-
-    const firstId = manager.createInstance()
-    await manager.mountTerminal(firstId, document.createElement('div'))
-    await manager.connectTerminal(firstId)
-    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
-    MockWebSocket.instances[0].emitMessage({ type: 'ready' })
-    await waitFor(() => expect(manager.instances[0]?.status).toBe('open'))
-
-    const secondId = manager.createInstance()
-    await manager.mountTerminal(secondId, document.createElement('div'))
-    await manager.connectTerminal(secondId)
-    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2))
-    MockWebSocket.instances[1].emitMessage({ type: 'ready' })
-    await waitFor(() => expect(manager.getActiveInstance()?.id).toBe(secondId))
-
-    manager.removeInstance(secondId)
-
-    expect(manager.activeId).toBe(firstId)
-    expect(MockWebSocket.instances[1]?.sent).toContain(JSON.stringify({ type: 'close' }))
-    expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN)
-  })
-
-  it('reconnects a terminal after an unexpected socket close', async () => {
-    vi.useFakeTimers()
-    createProjectConversationTerminalSession.mockResolvedValue({
+it('keeps existing terminal tabs connected when another tab opens and closes', async () => {
+  createProjectConversationTerminalSession
+    .mockResolvedValueOnce({
       terminalSession: {
         id: 'terminal-1',
         mode: 'shell',
@@ -173,71 +124,117 @@ describe('terminal manager', () => {
         attachToken: 'attach-token-1',
       },
     })
-
-    const manager = createTerminalManager({
-      getConversationId: () => 'conversation-1',
-      getWorkspacePath: () => '/tmp/conversation-1',
-    })
-
-    const id = manager.createInstance()
-    await manager.mountTerminal(id, document.createElement('div'))
-    await manager.connectTerminal(id)
-    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
-    MockWebSocket.instances[0].emitMessage({ type: 'ready' })
-    await waitFor(() => expect(manager.instances[0]?.status).toBe('open'))
-    MockWebSocket.instances[0].emitMessage({ type: 'output', data: 'YmVmb3Jl' })
-    expect(MockTerminal.instances[0]?.output).toContain('before')
-
-    MockWebSocket.instances[0].close()
-    await waitFor(() => expect(manager.instances[0]?.status).toBe('connecting'))
-
-    await vi.advanceTimersByTimeAsync(750)
-    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2))
-
-    MockWebSocket.instances[1].emitMessage({ type: 'ready' })
-    MockWebSocket.instances[1].emitMessage({ type: 'output', data: 'YWZ0ZXI=' })
-    await waitFor(() => {
-      expect(manager.instances[0]?.status).toBe('open')
-      expect(manager.instances[0]?.sessionID).toBe('terminal-1')
-    })
-    expect(createProjectConversationTerminalSession).toHaveBeenCalledTimes(1)
-    expect(MockWebSocket.instances[1]?.url).toContain('/terminal-1/attach')
-    expect(MockTerminal.instances[0]?.output).toContain('beforeafter')
-  })
-
-  it('does not leak a websocket when a tab is removed during session creation', async () => {
-    let resolveSession: ((value: unknown) => void) | undefined
-    createProjectConversationTerminalSession.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveSession = resolve
-        }),
-    )
-
-    const manager = createTerminalManager({
-      getConversationId: () => 'conversation-1',
-      getWorkspacePath: () => '/tmp/conversation-1',
-    })
-
-    const id = manager.createInstance()
-    await manager.mountTerminal(id, document.createElement('div'))
-    const connectPromise = manager.connectTerminal(id)
-
-    manager.removeInstance(id)
-    resolveSession?.({
+    .mockResolvedValueOnce({
       terminalSession: {
-        id: 'terminal-1',
+        id: 'terminal-2',
         mode: 'shell',
         cwd: '/tmp/conversation-1',
-        wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-1/attach',
-        attachToken: 'attach-token-1',
+        wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-2/attach',
+        attachToken: 'attach-token-2',
       },
     })
 
-    await connectPromise
-    await Promise.resolve()
-
-    expect(manager.instances).toHaveLength(0)
-    expect(MockWebSocket.instances).toHaveLength(0)
+  const manager = createTerminalManager({
+    getConversationId: () => 'conversation-1',
+    getWorkspacePath: () => '/tmp/conversation-1',
   })
+
+  const firstId = manager.createInstance()
+  await manager.mountTerminal(firstId, document.createElement('div'))
+  await manager.connectTerminal(firstId)
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+  MockWebSocket.instances[0].emitMessage({ type: 'ready' })
+  await waitFor(() => expect(manager.instances[0]?.status).toBe('open'))
+
+  const secondId = manager.createInstance()
+  await manager.mountTerminal(secondId, document.createElement('div'))
+  await manager.connectTerminal(secondId)
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2))
+  MockWebSocket.instances[1].emitMessage({ type: 'ready' })
+  await waitFor(() => expect(manager.getActiveInstance()?.id).toBe(secondId))
+
+  manager.removeInstance(secondId)
+
+  expect(manager.activeId).toBe(firstId)
+  expect(MockWebSocket.instances[1]?.sent).toContain(JSON.stringify({ type: 'close' }))
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN)
+})
+
+it('reconnects a terminal after an unexpected socket close', async () => {
+  vi.useFakeTimers()
+  createProjectConversationTerminalSession.mockResolvedValue({
+    terminalSession: {
+      id: 'terminal-1',
+      mode: 'shell',
+      cwd: '/tmp/conversation-1',
+      wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-1/attach',
+      attachToken: 'attach-token-1',
+    },
+  })
+
+  const manager = createTerminalManager({
+    getConversationId: () => 'conversation-1',
+    getWorkspacePath: () => '/tmp/conversation-1',
+  })
+
+  const id = manager.createInstance()
+  await manager.mountTerminal(id, document.createElement('div'))
+  await manager.connectTerminal(id)
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+  MockWebSocket.instances[0].emitMessage({ type: 'ready' })
+  await waitFor(() => expect(manager.instances[0]?.status).toBe('open'))
+  MockWebSocket.instances[0].emitMessage({ type: 'output', data: 'YmVmb3Jl' })
+  expect(MockTerminal.instances[0]?.output).toContain('before')
+
+  MockWebSocket.instances[0].close()
+  await waitFor(() => expect(manager.instances[0]?.status).toBe('connecting'))
+
+  await vi.advanceTimersByTimeAsync(750)
+  await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2))
+
+  MockWebSocket.instances[1].emitMessage({ type: 'ready' })
+  MockWebSocket.instances[1].emitMessage({ type: 'output', data: 'YWZ0ZXI=' })
+  await waitFor(() => {
+    expect(manager.instances[0]?.status).toBe('open')
+    expect(manager.instances[0]?.sessionID).toBe('terminal-1')
+  })
+  expect(createProjectConversationTerminalSession).toHaveBeenCalledTimes(1)
+  expect(MockWebSocket.instances[1]?.url).toContain('/terminal-1/attach')
+  expect(MockTerminal.instances[0]?.output).toContain('beforeafter')
+})
+
+it('does not leak a websocket when a tab is removed during session creation', async () => {
+  let resolveSession: ((value: unknown) => void) | undefined
+  createProjectConversationTerminalSession.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveSession = resolve
+      }),
+  )
+
+  const manager = createTerminalManager({
+    getConversationId: () => 'conversation-1',
+    getWorkspacePath: () => '/tmp/conversation-1',
+  })
+
+  const id = manager.createInstance()
+  await manager.mountTerminal(id, document.createElement('div'))
+  const connectPromise = manager.connectTerminal(id)
+
+  manager.removeInstance(id)
+  resolveSession?.({
+    terminalSession: {
+      id: 'terminal-1',
+      mode: 'shell',
+      cwd: '/tmp/conversation-1',
+      wsPath: '/api/v1/chat/conversations/conversation-1/terminal-sessions/terminal-1/attach',
+      attachToken: 'attach-token-1',
+    },
+  })
+
+  await connectPromise
+  await Promise.resolve()
+
+  expect(manager.instances).toHaveLength(0)
+  expect(MockWebSocket.instances).toHaveLength(0)
 })

--- a/web/src/lib/features/settings/components/agent-settings.test.ts
+++ b/web/src/lib/features/settings/components/agent-settings.test.ts
@@ -70,97 +70,94 @@ describe('Agent settings add provider entry', () => {
   })
 })
 
-// eslint-disable-next-line max-lines-per-function
-describe('Agent settings provider creation', () => {
-  it('creates a provider from project settings', async () => {
-    seedAppContext()
-    listProviders.mockResolvedValue({ providers: [] })
-    listAgents.mockResolvedValue({ agents: [] })
-    listMachines.mockResolvedValue({ machines: [machineFixture()] })
-    listProviderModelOptions.mockResolvedValue({ adapter_model_options: [] })
-    createProvider.mockResolvedValue({
-      provider: providerFixture({ id: 'provider-2', name: 'Project Provider' }),
-    })
+it('creates a provider from project settings', async () => {
+  seedAppContext()
+  listProviders.mockResolvedValue({ providers: [] })
+  listAgents.mockResolvedValue({ agents: [] })
+  listMachines.mockResolvedValue({ machines: [machineFixture()] })
+  listProviderModelOptions.mockResolvedValue({ adapter_model_options: [] })
+  createProvider.mockResolvedValue({
+    provider: providerFixture({ id: 'provider-2', name: 'Project Provider' }),
+  })
 
-    const { findByRole, findByLabelText, findByText, getByRole } = render(AgentSettings)
+  const { findByRole, findByLabelText, findByText, getByRole } = render(AgentSettings)
 
-    await fireEvent.click(await findByRole('button', { name: 'Add provider' }))
-    await waitFor(() => expect(listProviderModelOptions).toHaveBeenCalledTimes(1))
+  await fireEvent.click(await findByRole('button', { name: 'Add provider' }))
+  await waitFor(() => expect(listProviderModelOptions).toHaveBeenCalledTimes(1))
 
-    await fireEvent.input(await findByLabelText('Provider name'), {
-      target: { value: 'Project Provider' },
-    })
-    await fireEvent.input(await findByLabelText('Model name'), {
-      target: { value: 'gpt-5.4' },
-    })
-    await fireEvent.click(getByRole('button', { name: 'Create provider' }))
+  await fireEvent.input(await findByLabelText('Provider name'), {
+    target: { value: 'Project Provider' },
+  })
+  await fireEvent.input(await findByLabelText('Model name'), {
+    target: { value: 'gpt-5.4' },
+  })
+  await fireEvent.click(getByRole('button', { name: 'Create provider' }))
 
-    await waitFor(() =>
-      expect(createProvider).toHaveBeenCalledWith('org-1', {
-        machine_id: 'machine-1',
-        name: 'Project Provider',
-        adapter_type: 'custom',
-        permission_profile: 'unrestricted',
-        cli_command: '',
-        cli_args: [],
-        auth_config: {},
-        secret_bindings: [],
-        model_name: 'gpt-5.4',
-        model_temperature: 0,
-        model_max_tokens: 1,
-        max_parallel_runs: 0,
-        cost_per_input_token: 0,
-        cost_per_output_token: 0,
-        pricing_config: {
-          source_kind: 'custom',
-          pricing_mode: 'flat',
-          rates: {
-            input_per_token: 0,
-            output_per_token: 0,
-          },
+  await waitFor(() =>
+    expect(createProvider).toHaveBeenCalledWith('org-1', {
+      machine_id: 'machine-1',
+      name: 'Project Provider',
+      adapter_type: 'custom',
+      permission_profile: 'unrestricted',
+      cli_command: '',
+      cli_args: [],
+      auth_config: {},
+      secret_bindings: [],
+      model_name: 'gpt-5.4',
+      model_temperature: 0,
+      model_max_tokens: 1,
+      max_parallel_runs: 0,
+      cost_per_input_token: 0,
+      cost_per_output_token: 0,
+      pricing_config: {
+        source_kind: 'custom',
+        pricing_mode: 'flat',
+        rates: {
+          input_per_token: 0,
+          output_per_token: 0,
         },
-      }),
-    )
+      },
+    }),
+  )
 
-    expect(await findByText('Project Provider')).toBeTruthy()
+  expect(await findByText('Project Provider')).toBeTruthy()
+})
+
+it('refreshes provider state so the new provider can be selected immediately', async () => {
+  seedAppContext()
+  listProviders.mockResolvedValue({ providers: [] })
+  listAgents.mockResolvedValue({ agents: [] })
+  listMachines.mockResolvedValue({ machines: [machineFixture()] })
+  listProviderModelOptions.mockResolvedValue({ adapter_model_options: [] })
+  createProvider.mockResolvedValue({
+    provider: providerFixture({ id: 'provider-2', name: 'Project Provider' }),
+  })
+  updateProject.mockResolvedValue({
+    project: currentProject({ default_agent_provider_id: 'provider-2' }),
   })
 
-  it('refreshes provider state so the new provider can be selected immediately', async () => {
-    seedAppContext()
-    listProviders.mockResolvedValue({ providers: [] })
-    listAgents.mockResolvedValue({ agents: [] })
-    listMachines.mockResolvedValue({ machines: [machineFixture()] })
-    listProviderModelOptions.mockResolvedValue({ adapter_model_options: [] })
-    createProvider.mockResolvedValue({
-      provider: providerFixture({ id: 'provider-2', name: 'Project Provider' }),
-    })
-    updateProject.mockResolvedValue({
-      project: currentProject({ default_agent_provider_id: 'provider-2' }),
-    })
+  const { findByRole, findByLabelText, findByText, getByRole, getByTitle } = render(AgentSettings)
 
-    const { findByRole, findByLabelText, findByText, getByRole, getByTitle } = render(AgentSettings)
+  await fireEvent.click(await findByRole('button', { name: 'Add provider' }))
+  await waitFor(() => expect(listProviderModelOptions).toHaveBeenCalledTimes(1))
 
-    await fireEvent.click(await findByRole('button', { name: 'Add provider' }))
-    await waitFor(() => expect(listProviderModelOptions).toHaveBeenCalledTimes(1))
-
-    await fireEvent.input(await findByLabelText('Provider name'), {
-      target: { value: 'Project Provider' },
-    })
-    await fireEvent.input(await findByLabelText('Model name'), {
-      target: { value: 'gpt-5.4' },
-    })
-    await fireEvent.click(getByRole('button', { name: 'Create provider' }))
-    await findByText('Project Provider')
-
-    await fireEvent.click(getByTitle('Set Project Provider as project default'))
-    await fireEvent.click(getByRole('button', { name: 'Save default' }))
-
-    await waitFor(() =>
-      expect(updateProject).toHaveBeenCalledWith('project-1', {
-        default_agent_provider_id: 'provider-2',
-      }),
-    )
+  await fireEvent.input(await findByLabelText('Provider name'), {
+    target: { value: 'Project Provider' },
   })
+  await fireEvent.input(await findByLabelText('Model name'), {
+    target: { value: 'gpt-5.4' },
+  })
+  await fireEvent.click(getByRole('button', { name: 'Create provider' }))
+  await findByText('Project Provider')
+
+  await fireEvent.click(getByTitle('Set Project Provider as project default'))
+  await fireEvent.click(getByRole('button', { name: 'Save default' }))
+
+  await waitFor(() =>
+    expect(updateProject).toHaveBeenCalledWith('project-1', {
+      default_agent_provider_id: 'provider-2',
+    }),
+  )
 })
 
 function seedAppContext() {


### PR DESCRIPTION
## Summary
- extract Project AI terminal connection/session handling into dedicated chat helper modules so the terminal manager no longer relies on inline budget suppressions
- remove a stale `max-lines` suppression from the workspace browser detail panel and flatten test wrappers that only existed to hide function-length warnings
- keep the cleanup scoped to frontend debt in the chat workspace and provider settings tests without changing user-facing behavior

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm exec vitest run src/lib/features/chat/terminal-manager.test.ts src/lib/features/chat/project-conversation-workspace-browser-detail.test.ts src/lib/features/settings/components/agent-settings.test.ts`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm run check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm run build`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make frontend-api-audit-check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- the terminal manager and connection helper still exceed soft file-budget warnings; this ticket removes the inline bypasses so future cleanup can happen against visible warnings instead of hidden suppressions
- the broader frontend tree still has many soft-budget warnings outside ASE-172 scope
