### PR TITLE
feat: add one-click Linux/macOS release installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       desktop_changed: ${{ steps.detect.outputs.desktop_changed }}
       openapi_check_changed: ${{ steps.detect.outputs.openapi_check_changed }}
       frontend_api_audit_changed: ${{ steps.detect.outputs.frontend_api_audit_changed }}
+      release_install_script_changed: ${{ steps.detect.outputs.release_install_script_changed }}
 
     steps:
       - name: Check Out Repository
@@ -56,6 +57,7 @@ jobs:
           desktop_changed=false
           openapi_check_changed=false
           frontend_api_audit_changed=false
+          release_install_script_changed=false
 
           for file in "${changed_files[@]}"; do
             case "${file}" in
@@ -64,6 +66,7 @@ jobs:
                 web_changed=true
                 desktop_changed=true
                 openapi_check_changed=true
+                release_install_script_changed=true
                 ;;
               *.go|go.mod|go.sum|api/*)
                 go_changed=true
@@ -78,6 +81,9 @@ jobs:
               scripts/ci/*)
                 go_changed=true
                 desktop_changed=true
+                ;;
+              scripts/release/openase-install.sh)
+                release_install_script_changed=true
                 ;;
               web/*)
                 web_changed=true
@@ -101,6 +107,26 @@ jobs:
           printf 'desktop_changed=%s\n' "${desktop_changed}" >> "${GITHUB_OUTPUT}"
           printf 'openapi_check_changed=%s\n' "${openapi_check_changed}" >> "${GITHUB_OUTPUT}"
           printf 'frontend_api_audit_changed=%s\n' "${frontend_api_audit_changed}" >> "${GITHUB_OUTPUT}"
+          printf 'release_install_script_changed=%s\n' "${release_install_script_changed}" >> "${GITHUB_OUTPUT}"
+
+  release-install-script-check:
+    name: Release Install Script Check
+    runs-on: [self-hosted, Linux, X64]
+    needs: changes
+    if: needs.changes.outputs.release_install_script_changed == 'true'
+
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v5
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Validate Installer Script Syntax
+        run: bash -n scripts/release/openase-install.sh
+
+      - name: Run Installer Script Unit Tests
+        run: bash scripts/ci/test_release_install_script.sh
 
   openapi-check:
     name: OpenAPI Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,12 +346,20 @@ jobs:
       (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
 
     steps:
+      - name: Check Out Release Commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve-release.outputs.mode == 'tag' && needs.resolve-release.outputs.build_ref || needs.release-please.outputs.sha }}
+
       - name: Download Release Archives
         uses: actions/download-artifact@v7
         with:
           pattern: release-*
           merge-multiple: true
           path: release-artifacts
+
+      - name: Add One-Line Installer Script
+        run: cp scripts/release/openase-install.sh release-artifacts/openase-install.sh
 
       - name: Generate Checksums
         shell: bash
@@ -372,6 +380,14 @@ jobs:
           - Linux: `.AppImage`, `.deb`
 
           The desktop packages bundle the Electron host, the OpenASE binary, the desktop bundle manifest, and the starter config template. If macOS signing or notarization secrets are unavailable in CI, the workflow still publishes unsigned desktop assets and logs that downgrade explicitly.
+
+          ## One-line deploy
+
+          You can install the latest Linux/macOS release, auto-bootstrap the default local setup, and start OpenASE with:
+
+          ```bash
+          curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+          ```
           EOF
 
       - name: Upload Assets To GitHub Release

--- a/README.md
+++ b/README.md
@@ -440,6 +440,34 @@ These can also be installed later — setup will seed detected providers.
 
 ### Step 1: Clone & Build
 
+If you want the fastest Linux/macOS path from the latest GitHub Release instead of building from source, use:
+
+```bash
+curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+```
+
+By default the installer script:
+
+- downloads the latest release binary for the current Linux/macOS CPU architecture
+- verifies the archive against the published `checksums.txt`
+- installs `openase` into `~/.local/bin`
+- bootstraps a local config with Docker PostgreSQL
+- installs and starts the managed user service (`systemd --user` on Linux, `launchd` on macOS)
+
+If you already have PostgreSQL, switch the script to manual DB mode before piping it to `bash`:
+
+```bash
+OPENASE_INSTALL_SETUP_MODE=manual \
+OPENASE_DATABASE_HOST=127.0.0.1 \
+OPENASE_DATABASE_PORT=5432 \
+OPENASE_DATABASE_NAME=openase \
+OPENASE_DATABASE_USER=openase \
+OPENASE_DATABASE_PASSWORD=secret \
+curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+```
+
+If you prefer a source build or want to hack on OpenASE itself:
+
 ```bash
 git clone https://github.com/PacificStudio/openase.git
 cd openase

--- a/README.zh.md
+++ b/README.zh.md
@@ -440,6 +440,34 @@ OpenASE setup 会自动检测 `PATH` 上的这些工具：
 
 ### 第 1 步：克隆 & 构建
 
+如果你不想从源码编译，想直接在 Linux / macOS 上拉取最新 GitHub Release 并一键启动，可以直接执行：
+
+```bash
+curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+```
+
+默认情况下，这个安装脚本会：
+
+- 自动识别当前 Linux/macOS 架构并下载对应的最新 release 二进制
+- 使用发布产物里的 `checksums.txt` 校验下载内容
+- 把 `openase` 安装到 `~/.local/bin`
+- 用 Docker PostgreSQL 自动完成本地初始化
+- 安装并启动托管用户服务（Linux 用 `systemd --user`，macOS 用 `launchd`）
+
+如果你已经有现成的 PostgreSQL，也可以在执行脚本前切到手动数据库模式：
+
+```bash
+OPENASE_INSTALL_SETUP_MODE=manual \
+OPENASE_DATABASE_HOST=127.0.0.1 \
+OPENASE_DATABASE_PORT=5432 \
+OPENASE_DATABASE_NAME=openase \
+OPENASE_DATABASE_USER=openase \
+OPENASE_DATABASE_PASSWORD=secret \
+curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+```
+
+如果你想从源码构建，或者准备修改 OpenASE 本身，再走下面这条路径：
+
 ```bash
 git clone https://github.com/PacificStudio/openase.git
 cd openase

--- a/scripts/ci/test_release_install_script.sh
+++ b/scripts/ci/test_release_install_script.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/release/openase-install.sh"
+
+fail() {
+  return 1
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'assertion failed: %s\nexpected: %s\nactual:   %s\n' "$message" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_fails() {
+  local message="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf 'assertion failed: %s\n' "$message" >&2
+    exit 1
+  fi
+}
+
+run_with_uname() {
+  local sysname="$1"
+  local machine="$2"
+  local mode="$3"
+
+  uname() {
+    if [[ "${1:-}" == "-s" ]]; then
+      printf '%s\n' "$sysname"
+      return
+    fi
+    if [[ "${1:-}" == "-m" ]]; then
+      printf '%s\n' "$machine"
+      return
+    fi
+    printf '%s\n' "$sysname"
+  }
+
+  case "$mode" in
+    os) detect_os ;;
+    arch) detect_arch ;;
+    *) printf 'unsupported test mode %s\n' "$mode" >&2; return 1 ;;
+  esac
+}
+
+assert_eq "$(parse_release_tag_from_url 'https://github.com/pacificstudio/openase/releases/tag/v1.2.3')" "v1.2.3" "parse tag from release URL"
+assert_eq "$(json_escape $'line1\n"quoted"')" 'line1\n\"quoted\"' "escape JSON special characters"
+assert_eq "$(run_with_uname Linux x86_64 os)" "linux" "linux OS detection"
+assert_eq "$(run_with_uname Darwin arm64 os)" "darwin" "darwin OS detection"
+assert_eq "$(run_with_uname Linux x86_64 arch)" "amd64" "amd64 arch detection"
+assert_eq "$(run_with_uname Linux aarch64 arch)" "arm64" "arm64 arch detection"
+assert_fails "unsupported OS should fail" run_with_uname FreeBSD amd64 os
+assert_fails "unsupported arch should fail" run_with_uname Linux ppc64le arch
+
+printf 'release install script tests passed\n'

--- a/scripts/release/openase-install.sh
+++ b/scripts/release/openase-install.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENASE_RELEASE_REPO="${OPENASE_RELEASE_REPO:-pacificstudio/openase}"
+OPENASE_RELEASE_HOST="${OPENASE_RELEASE_HOST:-https://github.com}"
+OPENASE_INSTALL_VERSION="${OPENASE_INSTALL_VERSION:-latest}"
+OPENASE_INSTALL_DIR="${OPENASE_INSTALL_DIR:-$HOME/.local/bin}"
+OPENASE_HOME_DIR="${OPENASE_HOME_DIR:-$HOME/.openase}"
+OPENASE_CONFIG_PATH="${OPENASE_CONFIG_PATH:-$OPENASE_HOME_DIR/config.yaml}"
+OPENASE_INSTALL_SETUP_MODE="${OPENASE_INSTALL_SETUP_MODE:-docker}"
+OPENASE_INSTALL_START_MODE="${OPENASE_INSTALL_START_MODE:-service}"
+OPENASE_INSTALL_ALLOW_OVERWRITE="${OPENASE_INSTALL_ALLOW_OVERWRITE:-0}"
+OPENASE_CONTROL_PLANE_URL="${OPENASE_CONTROL_PLANE_URL:-http://127.0.0.1:19836}"
+
+log() {
+  printf '[openase-install] %s\n' "$*"
+}
+
+warn() {
+  printf '[openase-install] warning: %s\n' "$*" >&2
+}
+
+fail() {
+  printf '[openase-install] error: %s\n' "$*" >&2
+  exit 1
+}
+
+print_usage() {
+  cat <<'USAGE'
+Install the latest OpenASE release binary and optionally bootstrap/start it.
+
+Environment variables:
+  OPENASE_INSTALL_VERSION           Release tag to install, default: latest
+  OPENASE_INSTALL_DIR               Binary install dir, default: ~/.local/bin
+  OPENASE_HOME_DIR                  OpenASE state dir, default: ~/.openase
+  OPENASE_CONFIG_PATH               Config path, default: ~/.openase/config.yaml
+  OPENASE_INSTALL_SETUP_MODE        docker | manual | skip, default: docker
+  OPENASE_INSTALL_START_MODE        service | foreground | skip, default: service
+  OPENASE_INSTALL_ALLOW_OVERWRITE   1 to recreate config when it already exists
+  OPENASE_CONTROL_PLANE_URL         Health/bootstrap base URL, default: http://127.0.0.1:19836
+
+Manual database mode expects:
+  OPENASE_DATABASE_HOST
+  OPENASE_DATABASE_PORT
+  OPENASE_DATABASE_NAME
+  OPENASE_DATABASE_USER
+  OPENASE_DATABASE_PASSWORD         Optional
+  OPENASE_DATABASE_SSL_MODE         Optional, default: disable
+
+Docker mode optional overrides:
+  OPENASE_DOCKER_CONTAINER_NAME
+  OPENASE_DOCKER_DATABASE_NAME
+  OPENASE_DOCKER_DATABASE_USER
+  OPENASE_DOCKER_PORT
+  OPENASE_DOCKER_VOLUME_NAME
+  OPENASE_DOCKER_IMAGE
+
+Examples:
+  curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+  OPENASE_INSTALL_VERSION=v0.1.0 curl -fsSL https://github.com/pacificstudio/openase/releases/latest/download/openase-install.sh | bash
+  OPENASE_INSTALL_SETUP_MODE=skip OPENASE_INSTALL_START_MODE=skip bash ./openase-install.sh
+USAGE
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "required command not found: $1"
+  fi
+}
+
+normalize_bool() {
+  case "${1:-0}" in
+    1|true|TRUE|yes|YES|on|ON) printf '1\n' ;;
+    0|false|FALSE|no|NO|off|OFF|'') printf '0\n' ;;
+    *) fail "unsupported boolean value: $1" ;;
+  esac
+}
+
+json_escape() {
+  local value="${1-}"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+parse_release_tag_from_url() {
+  local url="${1%/}"
+  local tag="${url##*/}"
+  if [[ -z "$tag" || "$tag" == "latest" ]]; then
+    fail "could not resolve release tag from $1"
+  fi
+  printf '%s\n' "$tag"
+}
+
+curl_download() {
+  local token="${OPENASE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -n "$token" ]]; then
+    curl -fsSL -H "Authorization: Bearer $token" "$@"
+    return
+  fi
+  curl -fsSL "$@"
+}
+
+resolve_release_tag() {
+  if [[ "$OPENASE_INSTALL_VERSION" != "latest" ]]; then
+    printf '%s\n' "$OPENASE_INSTALL_VERSION"
+    return
+  fi
+
+  local latest_url
+  latest_url="$(curl_download -o /dev/null -w '%{url_effective}' -L "${OPENASE_RELEASE_HOST}/${OPENASE_RELEASE_REPO}/releases/latest")" || \
+    fail "failed to resolve the latest release tag from ${OPENASE_RELEASE_HOST}/${OPENASE_RELEASE_REPO}"
+  parse_release_tag_from_url "$latest_url"
+}
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux) printf 'linux\n' ;;
+    Darwin) printf 'darwin\n' ;;
+    *) fail "unsupported operating system: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) printf 'amd64\n' ;;
+    arm64|aarch64) printf 'arm64\n' ;;
+    *) fail "unsupported CPU architecture: $(uname -m)" ;;
+  esac
+}
+
+checksum_file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+    return
+  fi
+  fail "sha256sum or shasum is required to verify release checksums"
+}
+
+copy_executable() {
+  local source_path="$1"
+  local target_path="$2"
+
+  if command -v install >/dev/null 2>&1; then
+    install -m 0755 "$source_path" "$target_path"
+    return
+  fi
+
+  cp "$source_path" "$target_path"
+  chmod 0755 "$target_path"
+}
+
+ensure_install_dir() {
+  mkdir -p "$OPENASE_INSTALL_DIR"
+}
+
+verify_archive_checksum() {
+  local archive_path="$1"
+  local checksums_path="$2"
+  local archive_name="${archive_path##*/}"
+  local expected actual
+
+  expected="$(awk -v target="$archive_name" '$2 == target {print $1}' "$checksums_path")"
+  if [[ -z "$expected" ]]; then
+    fail "checksum entry missing for $archive_name"
+  fi
+
+  actual="$(checksum_file_sha256 "$archive_path")"
+  if [[ "$expected" != "$actual" ]]; then
+    fail "checksum mismatch for $archive_name"
+  fi
+}
+
+write_setup_request() {
+  local destination="$1"
+  local mode="$OPENASE_INSTALL_SETUP_MODE"
+  local overwrite
+  overwrite="$(normalize_bool "$OPENASE_INSTALL_ALLOW_OVERWRITE")"
+
+  case "$mode" in
+    docker)
+      cat > "$destination" <<JSON
+{
+  "database": {
+    "type": "docker",
+    "docker": {
+      "container_name": "$(json_escape "${OPENASE_DOCKER_CONTAINER_NAME:-openase-local-postgres}")",
+      "database_name": "$(json_escape "${OPENASE_DOCKER_DATABASE_NAME:-openase}")",
+      "user": "$(json_escape "${OPENASE_DOCKER_DATABASE_USER:-openase}")",
+      "port": ${OPENASE_DOCKER_PORT:-15432},
+      "volume_name": "$(json_escape "${OPENASE_DOCKER_VOLUME_NAME:-openase-local-postgres-data}")",
+      "image": "$(json_escape "${OPENASE_DOCKER_IMAGE:-postgres:16-alpine}")"
+    }
+  },
+  "allow_overwrite": ${overwrite}
+}
+JSON
+      ;;
+    manual)
+      : "${OPENASE_DATABASE_HOST:?OPENASE_DATABASE_HOST is required when OPENASE_INSTALL_SETUP_MODE=manual}"
+      : "${OPENASE_DATABASE_PORT:?OPENASE_DATABASE_PORT is required when OPENASE_INSTALL_SETUP_MODE=manual}"
+      : "${OPENASE_DATABASE_NAME:?OPENASE_DATABASE_NAME is required when OPENASE_INSTALL_SETUP_MODE=manual}"
+      : "${OPENASE_DATABASE_USER:?OPENASE_DATABASE_USER is required when OPENASE_INSTALL_SETUP_MODE=manual}"
+      cat > "$destination" <<JSON
+{
+  "database": {
+    "type": "manual",
+    "manual": {
+      "host": "$(json_escape "$OPENASE_DATABASE_HOST")",
+      "port": ${OPENASE_DATABASE_PORT},
+      "name": "$(json_escape "$OPENASE_DATABASE_NAME")",
+      "user": "$(json_escape "$OPENASE_DATABASE_USER")",
+      "password": "$(json_escape "${OPENASE_DATABASE_PASSWORD:-}")",
+      "ssl_mode": "$(json_escape "${OPENASE_DATABASE_SSL_MODE:-disable}")"
+    }
+  },
+  "allow_overwrite": ${overwrite}
+}
+JSON
+      ;;
+    skip)
+      return 0
+      ;;
+    *)
+      fail "unsupported OPENASE_INSTALL_SETUP_MODE: $mode"
+      ;;
+  esac
+}
+
+run_auto_setup() {
+  local binary_path="$1"
+  local request_path="$2"
+
+  case "$OPENASE_INSTALL_SETUP_MODE" in
+    docker)
+      need_cmd docker
+      ;;
+    manual)
+      :
+      ;;
+    skip)
+      log "skipping OpenASE config bootstrap"
+      return 0
+      ;;
+    *)
+      fail "unsupported OPENASE_INSTALL_SETUP_MODE: $OPENASE_INSTALL_SETUP_MODE"
+      ;;
+  esac
+
+  write_setup_request "$request_path"
+  log "bootstrapping OpenASE config via setup desktop apply"
+  "$binary_path" setup desktop apply --input "$request_path"
+}
+
+wait_for_health() {
+  local url="$1"
+  local attempt=0
+  local max_attempts=30
+
+  while (( attempt < max_attempts )); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  return 1
+}
+
+print_bootstrap_link() {
+  local binary_path="$1"
+  if ! "$binary_path" auth bootstrap create-link --config "$OPENASE_CONFIG_PATH" --return-to / --format text; then
+    warn "OpenASE started, but failed to generate a local bootstrap link"
+  fi
+}
+
+start_openase() {
+  local binary_path="$1"
+
+  case "$OPENASE_INSTALL_START_MODE" in
+    service)
+      log "installing or refreshing the managed OpenASE user service"
+      "$binary_path" up --config "$OPENASE_CONFIG_PATH"
+      if wait_for_health "${OPENASE_CONTROL_PLANE_URL}/healthz"; then
+        log "OpenASE is healthy at ${OPENASE_CONTROL_PLANE_URL}"
+      else
+        warn "service started but health check did not pass at ${OPENASE_CONTROL_PLANE_URL}/healthz yet"
+      fi
+      log "local bootstrap link:"
+      print_bootstrap_link "$binary_path"
+      ;;
+    foreground)
+      log "starting OpenASE in the foreground"
+      exec "$binary_path" all-in-one --config "$OPENASE_CONFIG_PATH"
+      ;;
+    skip)
+      log "skipping OpenASE start"
+      ;;
+    *)
+      fail "unsupported OPENASE_INSTALL_START_MODE: $OPENASE_INSTALL_START_MODE"
+      ;;
+  esac
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    print_usage
+    exit 0
+  fi
+
+  need_cmd curl
+  need_cmd tar
+  need_cmd mktemp
+  need_cmd uname
+  need_cmd awk
+
+  local os_name arch_name release_tag package_basename archive_name tmp_dir archive_path checksums_path
+  local download_base binary_path extracted_dir request_path
+
+  os_name="$(detect_os)"
+  arch_name="$(detect_arch)"
+  release_tag="$(resolve_release_tag)"
+  package_basename="openase_${release_tag}_${os_name}_${arch_name}"
+  archive_name="${package_basename}.tar.gz"
+  download_base="${OPENASE_RELEASE_HOST}/${OPENASE_RELEASE_REPO}/releases/download/${release_tag}"
+
+  log "resolved release ${release_tag} for ${os_name}/${arch_name}"
+
+  tmp_dir="$(mktemp -d)"
+  trap "rm -rf -- $(printf '%q' "$tmp_dir")" EXIT
+  archive_path="${tmp_dir}/${archive_name}"
+  checksums_path="${tmp_dir}/checksums.txt"
+  request_path="${tmp_dir}/setup-request.json"
+
+  curl_download -o "$archive_path" "${download_base}/${archive_name}"
+  curl_download -o "$checksums_path" "${download_base}/checksums.txt"
+  verify_archive_checksum "$archive_path" "$checksums_path"
+
+  tar -xzf "$archive_path" -C "$tmp_dir"
+  extracted_dir="${tmp_dir}/${package_basename}"
+  binary_path="${extracted_dir}/openase"
+  if [[ ! -x "$binary_path" ]]; then
+    fail "release archive did not contain an executable openase binary"
+  fi
+
+  ensure_install_dir
+  copy_executable "$binary_path" "${OPENASE_INSTALL_DIR}/openase"
+  binary_path="${OPENASE_INSTALL_DIR}/openase"
+
+  log "installed ${binary_path}"
+  "$binary_path" version
+
+  if [[ -f "$OPENASE_CONFIG_PATH" && "$(normalize_bool "$OPENASE_INSTALL_ALLOW_OVERWRITE")" != "1" ]]; then
+    log "existing config detected at ${OPENASE_CONFIG_PATH}; skipping setup"
+  else
+    run_auto_setup "$binary_path" "$request_path"
+  fi
+
+  if [[ "$OPENASE_INSTALL_START_MODE" != "skip" ]]; then
+    if [[ ! -f "$OPENASE_CONFIG_PATH" ]]; then
+      fail "missing config at ${OPENASE_CONFIG_PATH}; rerun with OPENASE_INSTALL_SETUP_MODE=docker or configure manual database settings"
+    fi
+  fi
+
+  start_openase "$binary_path"
+
+  if [[ ":${PATH}:" != *":${OPENASE_INSTALL_DIR}:"* ]]; then
+    warn "${OPENASE_INSTALL_DIR} is not on PATH yet; add it if you want to run 'openase' directly in new shells"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary
- add a Linux/macOS one-click installer script that downloads the latest OpenASE release, verifies checksums, and can bootstrap/start the managed service
- publish the installer script as a release asset and advertise the one-line deploy command in the release notes
- add CI coverage and lightweight script tests for the release installer path

## Validation
- `bash -n scripts/release/openase-install.sh`
- `bash scripts/ci/test_release_install_script.sh`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH PLAYWRIGHT_HOST=127.0.0.1 PLAYWRIGHT_PORT=4273 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4273 PLAYWRIGHT_SERVER_MODE=preview corepack pnpm --dir web run ci`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH env OPENASE_BACKEND_TEST_GROUP_SIZE=8 make check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH make build`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH make LINT_BASE_REV=$(git merge-base origin/main HEAD) lint`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH make lint-depguard`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH make lint-architecture`
- local fixture smoke test for installer download + checksum verification

## Risks / Follow-up
- the current latest public release (`v0.4.0`, published 2026-04-11) has no release assets yet, so the one-line install flow becomes externally usable after the next release publishes with this workflow
- local frontend validation needed a non-default Playwright port because `127.0.0.1:4173` was already occupied in this workspace
