### PR TITLE
fix(security): enforce SSH host key verification by default

### DIFF
--- a/internal/infra/ssh/pool.go
+++ b/internal/infra/ssh/pool.go
@@ -19,9 +19,12 @@ import (
 	"github.com/BetterAndBetterII/openase/internal/infra/machineprobe"
 	"github.com/BetterAndBetterII/openase/internal/logging"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 var sshPoolComponent = logging.DeclareComponent("ssh-pool")
+
+const sshInsecureIgnoreHostKeyEnv = "OPENASE_SSH_INSECURE_IGNORE_HOST_KEY"
 
 type Session interface {
 	CombinedOutput(cmd string) ([]byte, error)
@@ -71,13 +74,32 @@ func (p *Pool) componentLogger() *slog.Logger {
 
 func NewPool(openASEHomeDir string, opts ...PoolOption) *Pool {
 	pool := &Pool{
-		conns:           map[string]Client{},
-		openASEHomeDir:  filepath.Clean(openASEHomeDir),
-		dialer:          realDialer{},
-		readFile:        os.ReadFile,
-		timeout:         10 * time.Second,
-		hostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec
-		logger:          logging.WithComponent(nil, sshPoolComponent),
+		conns:          map[string]Client{},
+		openASEHomeDir: filepath.Clean(openASEHomeDir),
+		dialer:         realDialer{},
+		readFile:       os.ReadFile,
+		timeout:        10 * time.Second,
+		logger:         logging.WithComponent(nil, sshPoolComponent),
+	}
+	if insecureIgnoreHostKeyEnabled() {
+		//nolint:gosec // This is an explicit compatibility escape hatch for environments that cannot verify host keys yet.
+		pool.hostKeyCallback = gossh.InsecureIgnoreHostKey()
+		pool.componentLogger().Warn(
+			"ssh host key verification is disabled by environment override",
+			"env", sshInsecureIgnoreHostKeyEnv,
+		)
+	} else {
+		callback, err := defaultHostKeyCallback(pool.openASEHomeDir)
+		if err != nil {
+			pool.hostKeyCallback = rejectingHostKeyCallback(err)
+			pool.componentLogger().Warn(
+				"ssh host key verification is required but no valid known_hosts file was found",
+				"error", err,
+				"checked_paths", knownHostsCandidatePaths(pool.openASEHomeDir),
+			)
+		} else {
+			pool.hostKeyCallback = callback
+		}
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -85,6 +107,70 @@ func NewPool(openASEHomeDir string, opts ...PoolOption) *Pool {
 		}
 	}
 	return pool
+}
+
+func insecureIgnoreHostKeyEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(sshInsecureIgnoreHostKeyEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultHostKeyCallback(openASEHomeDir string) (gossh.HostKeyCallback, error) {
+	paths := existingKnownHostsPaths(knownHostsCandidatePaths(openASEHomeDir))
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no known_hosts file found")
+	}
+	callback, err := knownhosts.New(paths...)
+	if err != nil {
+		return nil, fmt.Errorf("load known_hosts: %w", err)
+	}
+	return callback, nil
+}
+
+func knownHostsCandidatePaths(openASEHomeDir string) []string {
+	cleanRoot := filepath.Clean(strings.TrimSpace(openASEHomeDir))
+	if cleanRoot == "." || cleanRoot == "" {
+		return []string{filepath.Join(".ssh", "known_hosts")}
+	}
+	homeDir := filepath.Dir(cleanRoot)
+	return []string{
+		filepath.Join(cleanRoot, "known_hosts"),
+		filepath.Join(homeDir, ".ssh", "known_hosts"),
+	}
+}
+
+func existingKnownHostsPaths(candidates []string) []string {
+	result := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		clean := filepath.Clean(trimmed)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		info, err := os.Stat(clean)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		seen[clean] = struct{}{}
+		result = append(result, clean)
+	}
+	return result
+}
+
+func rejectingHostKeyCallback(cause error) gossh.HostKeyCallback {
+	return func(hostname string, _ net.Addr, _ gossh.PublicKey) error {
+		if cause == nil {
+			return fmt.Errorf("ssh host key verification unavailable for %s", hostname)
+		}
+		return fmt.Errorf("ssh host key verification unavailable for %s: %w", hostname, cause)
+	}
 }
 
 func WithDialer(dialer Dialer) PoolOption {

--- a/internal/infra/ssh/pool.go
+++ b/internal/infra/ssh/pool.go
@@ -19,9 +19,12 @@ import (
 	"github.com/BetterAndBetterII/openase/internal/infra/machineprobe"
 	"github.com/BetterAndBetterII/openase/internal/logging"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 var sshPoolComponent = logging.DeclareComponent("ssh-pool")
+
+const sshInsecureIgnoreHostKeyEnv = "OPENASE_SSH_INSECURE_IGNORE_HOST_KEY"
 
 type Session interface {
 	CombinedOutput(cmd string) ([]byte, error)
@@ -82,12 +85,96 @@ func NewPool(openASEHomeDir string, opts ...PoolOption) *Pool {
 		timeout:        10 * time.Second,
 		logger:         logging.WithComponent(nil, sshPoolComponent),
 	}
+	if insecureIgnoreHostKeyEnabled() {
+		//nolint:gosec // This is an explicit compatibility escape hatch for environments that cannot verify host keys yet.
+		pool.hostKeyCallback = gossh.InsecureIgnoreHostKey()
+		pool.componentLogger().Warn(
+			"ssh host key verification is disabled by environment override",
+			"env", sshInsecureIgnoreHostKeyEnv,
+		)
+	} else {
+		callback, err := defaultHostKeyCallback(pool.openASEHomeDir)
+		if err != nil {
+			pool.hostKeyCallback = rejectingHostKeyCallback(err)
+			pool.componentLogger().Warn(
+				"ssh host key verification is required but no valid known_hosts file was found",
+				"error", err,
+				"checked_paths", knownHostsCandidatePaths(pool.openASEHomeDir),
+			)
+		} else {
+			pool.hostKeyCallback = callback
+		}
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(pool)
 		}
 	}
 	return pool
+}
+
+func insecureIgnoreHostKeyEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(sshInsecureIgnoreHostKeyEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultHostKeyCallback(openASEHomeDir string) (gossh.HostKeyCallback, error) {
+	paths := existingKnownHostsPaths(knownHostsCandidatePaths(openASEHomeDir))
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no known_hosts file found")
+	}
+	callback, err := knownhosts.New(paths...)
+	if err != nil {
+		return nil, fmt.Errorf("load known_hosts: %w", err)
+	}
+	return callback, nil
+}
+
+func knownHostsCandidatePaths(openASEHomeDir string) []string {
+	cleanRoot := filepath.Clean(strings.TrimSpace(openASEHomeDir))
+	if cleanRoot == "." || cleanRoot == "" {
+		return []string{filepath.Join(".ssh", "known_hosts")}
+	}
+	homeDir := filepath.Dir(cleanRoot)
+	return []string{
+		filepath.Join(cleanRoot, "known_hosts"),
+		filepath.Join(homeDir, ".ssh", "known_hosts"),
+	}
+}
+
+func existingKnownHostsPaths(candidates []string) []string {
+	result := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		clean := filepath.Clean(trimmed)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		info, err := os.Stat(clean)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		seen[clean] = struct{}{}
+		result = append(result, clean)
+	}
+	return result
+}
+
+func rejectingHostKeyCallback(cause error) gossh.HostKeyCallback {
+	return func(hostname string, _ net.Addr, _ gossh.PublicKey) error {
+		if cause == nil {
+			return fmt.Errorf("ssh host key verification unavailable for %s", hostname)
+		}
+		return fmt.Errorf("ssh host key verification unavailable for %s: %w", hostname, cause)
+	}
 }
 
 func WithDialer(dialer Dialer) PoolOption {

--- a/internal/infra/ssh/pool_test.go
+++ b/internal/infra/ssh/pool_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +39,65 @@ func TestPoolReusesLiveConnection(t *testing.T) {
 	}
 	if first.keepaliveCalls != 1 {
 		t.Fatalf("expected one keepalive, got %d", first.keepaliveCalls)
+	}
+}
+
+func TestDefaultHostKeyCallbackMissingKnownHosts(t *testing.T) {
+	callback, err := defaultHostKeyCallback(filepath.Join(t.TempDir(), ".openase"))
+	if err == nil {
+		t.Fatalf("expected error when known_hosts is missing")
+	}
+	if callback != nil {
+		t.Fatalf("expected nil callback when known_hosts is missing")
+	}
+}
+
+func TestDefaultHostKeyCallbackLoadsOpenASEKnownHosts(t *testing.T) {
+	root := t.TempDir()
+	openaseHome := filepath.Join(root, ".openase")
+	if err := os.MkdirAll(openaseHome, 0o750); err != nil {
+		t.Fatalf("mkdir openase home: %v", err)
+	}
+	knownHostsPath := filepath.Join(openaseHome, "known_hosts")
+	if err := os.WriteFile(knownHostsPath, []byte("# managed by tests\n"), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+
+	callback, err := defaultHostKeyCallback(openaseHome)
+	if err != nil {
+		t.Fatalf("defaultHostKeyCallback returned error: %v", err)
+	}
+	if callback == nil {
+		t.Fatalf("expected non-nil callback")
+	}
+}
+
+func TestNewPoolRejectsUnknownHostWhenKnownHostsMissing(t *testing.T) {
+	t.Setenv(sshInsecureIgnoreHostKeyEnv, "")
+
+	pool := NewPool(filepath.Join(t.TempDir(), ".openase"))
+	if pool.hostKeyCallback == nil {
+		t.Fatalf("expected host key callback to be configured")
+	}
+
+	err := pool.hostKeyCallback("example.com:22", nil, nil)
+	if err == nil {
+		t.Fatalf("expected host key callback to reject without known_hosts")
+	}
+	if !strings.Contains(err.Error(), "verification unavailable") {
+		t.Fatalf("expected verification error, got %v", err)
+	}
+}
+
+func TestNewPoolAllowsExplicitInsecureHostKeyOverride(t *testing.T) {
+	t.Setenv(sshInsecureIgnoreHostKeyEnv, "true")
+
+	pool := NewPool(filepath.Join(t.TempDir(), ".openase"))
+	if pool.hostKeyCallback == nil {
+		t.Fatalf("expected host key callback to be configured")
+	}
+	if err := pool.hostKeyCallback("example.com:22", nil, nil); err != nil {
+		t.Fatalf("expected insecure override callback to allow host key, got %v", err)
 	}
 }
 

--- a/internal/infra/ssh/pool_test.go
+++ b/internal/infra/ssh/pool_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -45,6 +46,65 @@ func TestPoolReusesLiveConnection(t *testing.T) {
 	}
 	if first.keepaliveCalls != 1 {
 		t.Fatalf("expected one keepalive, got %d", first.keepaliveCalls)
+	}
+}
+
+func TestDefaultHostKeyCallbackMissingKnownHosts(t *testing.T) {
+	callback, err := defaultHostKeyCallback(filepath.Join(t.TempDir(), ".openase"))
+	if err == nil {
+		t.Fatalf("expected error when known_hosts is missing")
+	}
+	if callback != nil {
+		t.Fatalf("expected nil callback when known_hosts is missing")
+	}
+}
+
+func TestDefaultHostKeyCallbackLoadsOpenASEKnownHosts(t *testing.T) {
+	root := t.TempDir()
+	openaseHome := filepath.Join(root, ".openase")
+	if err := os.MkdirAll(openaseHome, 0o750); err != nil {
+		t.Fatalf("mkdir openase home: %v", err)
+	}
+	knownHostsPath := filepath.Join(openaseHome, "known_hosts")
+	if err := os.WriteFile(knownHostsPath, []byte("# managed by tests\n"), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+
+	callback, err := defaultHostKeyCallback(openaseHome)
+	if err != nil {
+		t.Fatalf("defaultHostKeyCallback returned error: %v", err)
+	}
+	if callback == nil {
+		t.Fatalf("expected non-nil callback")
+	}
+}
+
+func TestNewPoolRejectsUnknownHostWhenKnownHostsMissing(t *testing.T) {
+	t.Setenv(sshInsecureIgnoreHostKeyEnv, "")
+
+	pool := NewPool(filepath.Join(t.TempDir(), ".openase"))
+	if pool.hostKeyCallback == nil {
+		t.Fatalf("expected host key callback to be configured")
+	}
+
+	err := pool.hostKeyCallback("example.com:22", nil, nil)
+	if err == nil {
+		t.Fatalf("expected host key callback to reject without known_hosts")
+	}
+	if !strings.Contains(err.Error(), "verification unavailable") {
+		t.Fatalf("expected verification error, got %v", err)
+	}
+}
+
+func TestNewPoolAllowsExplicitInsecureHostKeyOverride(t *testing.T) {
+	t.Setenv(sshInsecureIgnoreHostKeyEnv, "true")
+
+	pool := NewPool(filepath.Join(t.TempDir(), ".openase"))
+	if pool.hostKeyCallback == nil {
+		t.Fatalf("expected host key callback to be configured")
+	}
+	if err := pool.hostKeyCallback("example.com:22", nil, nil); err != nil {
+		t.Fatalf("expected insecure override callback to allow host key, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a high-risk security issue in the SSH connection pool: host key verification was effectively disabled by default (`InsecureIgnoreHostKey`).

With this change, OpenASE now:
- verifies remote SSH host keys by default via `known_hosts`
- fails closed when no valid `known_hosts` file is available
- keeps an explicit, opt-in compatibility escape hatch for legacy environments

## Security impact
### Before
- SSH clients accepted any host key by default.
- A machine-in-the-middle could impersonate a remote machine and intercept/modify SSH traffic.

### After
- SSH host identity must match entries in `known_hosts`.
- Unknown or mismatched hosts are rejected by default.
- Operators can explicitly bypass verification only by setting:
  - `OPENASE_SSH_INSECURE_IGNORE_HOST_KEY=true`

## Implementation details
### `internal/infra/ssh/pool.go`
- Removed implicit default to `InsecureIgnoreHostKey()`.
- Added secure default callback loading from:
  1. `<openase_home>/known_hosts`
  2. `<home>/.ssh/known_hosts`
- Added strict fallback callback that rejects all host keys when no valid `known_hosts` is found.
- Added compatibility env switch:
  - `OPENASE_SSH_INSECURE_IGNORE_HOST_KEY` (`1/true/yes/on`)

### `internal/infra/ssh/pool_test.go`
Added focused tests for:
- missing `known_hosts` => secure callback setup fails as expected
- valid OpenASE-managed `known_hosts` => callback initializes successfully
- default behavior without `known_hosts` => reject unknown host key
- explicit insecure override => callback permits unknown host key

## Backward compatibility notes
- This is a secure-by-default behavior change.
- Existing environments that relied on implicit insecure SSH trust may need to:
  1. populate `known_hosts`, or
  2. temporarily set `OPENASE_SSH_INSECURE_IGNORE_HOST_KEY=true` (not recommended for production).

## Validation
- `go test ./internal/infra/ssh -count=1`
