### PR TITLE
Fix queued auto-send sending state in Project AI

### DIFF
--- a/web/src/lib/features/chat/project-conversation-controller-runtime-tab-ops.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-runtime-tab-ops.ts
@@ -1,3 +1,4 @@
+import { tick } from 'svelte'
 import {
   createProjectConversation,
   startProjectConversationTurn,
@@ -197,6 +198,8 @@ export function createProjectConversationRuntimeTabOps(
       activeTab.unread = false
       activeTab.phase = 'submitting_turn'
       input.touch()
+      await tick()
+      if (!isCurrentProjectConversationOperation(activeTab, currentOperationId)) return false
       const turnResponse = await startProjectConversationTurn(activeTab.conversationId, {
         message: trimmed,
         focus: focus ?? undefined,

--- a/web/src/lib/features/chat/project-conversation-panel-tabs.test.ts
+++ b/web/src/lib/features/chat/project-conversation-panel-tabs.test.ts
@@ -204,18 +204,25 @@ describe('ProjectConversationPanel tab behavior', () => {
       },
     })
     getProjectConversationWorkspaceDiff.mockResolvedValue(createWorkspaceDiff('conversation-1'))
-    startProjectConversationTurn.mockResolvedValue({
-      turn: { id: 'turn-1', turn_index: 1, status: 'started' },
-    })
+    startProjectConversationTurn
+      .mockResolvedValueOnce({
+        turn: { id: 'turn-1', turn_index: 1, status: 'started' },
+      })
+      .mockResolvedValueOnce({
+        turn: { id: 'turn-2', turn_index: 2, status: 'started' },
+      })
 
-    const { findByText, getByPlaceholderText, getByRole } = render(ProjectConversationPanel, {
-      props: {
-        context: { projectId: 'project-1' },
-        providers: providerFixtures,
-        defaultProviderId: 'provider-1',
-        placeholder: 'Ask anything about this project…',
+    const { findByText, getByPlaceholderText, getByRole, queryByText } = render(
+      ProjectConversationPanel,
+      {
+        props: {
+          context: { projectId: 'project-1' },
+          providers: providerFixtures,
+          defaultProviderId: 'provider-1',
+          placeholder: 'Ask anything about this project…',
+        },
       },
-    })
+    )
 
     await waitForComposerReady(getByPlaceholderText)
 
@@ -257,10 +264,26 @@ describe('ProjectConversationPanel tab behavior', () => {
     })
 
     await waitFor(() => {
+      expect(queryByText('Queued')).toBeNull()
+      expect(queryByText('Sending your message…')).toBeTruthy()
+    })
+    await waitFor(() => {
       expect(startProjectConversationTurn).toHaveBeenNthCalledWith(2, 'conversation-1', {
         message: 'Draft the next request',
         focus: undefined,
       })
+    })
+    mux.emit('conversation-1', {
+      kind: 'session',
+      payload: {
+        conversationId: 'conversation-1',
+        runtimeState: 'executing',
+        providerStatus: 'active',
+        providerActiveFlags: ['running'],
+      },
+    })
+    await waitFor(() => {
+      expect(queryByText('Waiting for the assistant reply…')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
## Summary
- flush the shared project conversation send path after entering `submitting_turn` so queued auto-dispatch renders `Sending your message…` before the next reply wait state
- add a panel regression test that covers queuing while waiting, auto-dispatch after `turn_done`, and the visible `Queued -> Sending your message… -> Waiting for the assistant reply…` progression

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/chat/project-conversation-panel-tabs.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/chat/project-conversation-controller-queued-turns.test.ts src/lib/features/chat/project-conversation-controller-turns.test.ts src/lib/features/chat/project-conversation-controller-actions.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec svelte-check --tsconfig ./tsconfig.json --output machine --threshold error`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vite build --logLevel warn`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH PNPM=pnpm .codex/skills/push/scripts/openase_ci_gate.sh` *(passes until the known local Playwright port-4173 conflict)*
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4273 pnpm exec playwright test --reporter=dot --quiet`

## Risks / Follow-up
- `web` CI currently assumes Playwright can bind `127.0.0.1:4173`; this workspace needed the documented alternate-port workaround because another local server already held that port.
