### PR TITLE
ASE-187 formalize workspace browser budget categories

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -97,9 +97,13 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/components/layout/**/*.svelte` | 200        | 300                  |
 | `lib/components/ui/**/*.svelte`     | 150        | 250                  |
+| workspace browser panes             | 250        | 350                  |
+| workspace browser state modules     | 350        | 700                  |
+| workspace browser integration tests | 350        | 700                  |
 | single function                     | 40 target  | 60 warning threshold |
 
-There are no per-file budget waivers. If a recurring file shape needs a different limit, promote it into a named budget category instead of growing an allowlist.
+There are no per-file budget waivers. If a recurring file shape needs a different
+limit, promote it into a named budget category instead of growing an allowlist.
 
 ## Quality Gates
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -108,11 +108,40 @@ export default defineConfig(
     },
   },
   {
+    files: ['src/lib/features/chat/project-conversation-workspace-browser-*.test.{js,ts,mjs,cjs}'],
+    rules: {
+      'max-lines': [
+        'error',
+        {
+          max: fileBudgetLimits.workspaceBrowserIntegrationTest.hard,
+          skipBlankLines: true,
+          skipComments: true,
+        },
+      ],
+    },
+  },
+  {
     files: ['src/lib/features/**/*.svelte.{ts,js}'],
     rules: {
       'max-lines': [
         'error',
         { max: fileBudgetLimits.featureStateModule.hard, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  {
+    files: [
+      'src/lib/features/chat/project-conversation-workspace-browser-state.svelte.{ts,js}',
+      'src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.{ts,js}',
+    ],
+    rules: {
+      'max-lines': [
+        'error',
+        {
+          max: fileBudgetLimits.workspaceBrowserStateModule.hard,
+          skipBlankLines: true,
+          skipComments: true,
+        },
       ],
     },
   },

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -7,6 +7,9 @@ export const fileBudgetLimits = {
   featureModule: { soft: 200, hard: 325 },
   layoutComponent: { soft: 200, hard: 300 },
   uiPrimitive: { soft: 150, hard: 250 },
+  workspaceBrowserPane: { soft: 250, hard: 350 },
+  workspaceBrowserStateModule: { soft: 350, hard: 700 },
+  workspaceBrowserIntegrationTest: { soft: 350, hard: 700 },
 }
 
 function isRoutePage(filePath) {
@@ -41,42 +44,45 @@ function isUiPrimitive(filePath) {
   return /^src\/lib\/components\/ui\/.+\.svelte$/.test(filePath)
 }
 
+function isWorkspaceBrowserPane(filePath) {
+  return /^src\/lib\/features\/chat\/project-conversation-workspace-browser-(detail|pane|sidebar)\.svelte$/.test(
+    filePath,
+  )
+}
+
+function isWorkspaceBrowserStateModule(filePath) {
+  return /^src\/lib\/features\/chat\/project-conversation-workspace-(browser-state|file-editor-state)\.svelte\.(ts|js)$/.test(
+    filePath,
+  )
+}
+
+function isWorkspaceBrowserIntegrationTest(filePath) {
+  return /^src\/lib\/features\/chat\/project-conversation-workspace-browser-.*\.test\.(ts|js|mjs|cjs)$/.test(
+    filePath,
+  )
+}
+
 export const fileBudgetRules = [
+  // These workspace-browser files coordinate tree, editor, and diff state as one
+  // surface, so we give that recurring shape first-class budgets instead of
+  // piling up one-off waivers.
   {
-    name: 'Workspace editor V2 detail view',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-detail.svelte',
-    softLimit: 250,
-    hardLimit: 450,
+    name: 'Workspace browser panes',
+    match: isWorkspaceBrowserPane,
+    softLimit: fileBudgetLimits.workspaceBrowserPane.soft,
+    hardLimit: fileBudgetLimits.workspaceBrowserPane.hard,
   },
   {
-    name: 'Workspace editor V2 sidebar',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-sidebar.svelte',
-    softLimit: 250,
-    hardLimit: 400,
+    name: 'Workspace browser state modules',
+    match: isWorkspaceBrowserStateModule,
+    softLimit: fileBudgetLimits.workspaceBrowserStateModule.soft,
+    hardLimit: fileBudgetLimits.workspaceBrowserStateModule.hard,
   },
   {
-    name: 'Workspace editor V2 browser state',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts',
-    softLimit: 350,
-    hardLimit: 700,
-  },
-  {
-    name: 'Workspace editor V2 editor state',
-    match: (filePath) =>
-      filePath ===
-      'src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts',
-    softLimit: 350,
-    hardLimit: 650,
-  },
-  {
-    name: 'Workspace editor V2 refresh test',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts',
-    softLimit: 350,
-    hardLimit: 700,
+    name: 'Workspace browser integration tests',
+    match: isWorkspaceBrowserIntegrationTest,
+    softLimit: fileBudgetLimits.workspaceBrowserIntegrationTest.soft,
+    hardLimit: fileBudgetLimits.workspaceBrowserIntegrationTest.hard,
   },
   {
     name: 'Route pages',

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import {
   createProjectConversationWorkspaceFile,
   deleteProjectConversationWorkspaceFile,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { ApiError } from '$lib/api/client'
 import {
   saveProjectConversationWorkspaceFile,


### PR DESCRIPTION
## Summary
- replace the workspace browser's per-file budget waivers with named budget categories
- mirror the workspace browser state/test limits in ESLint and remove the inline `max-lines` bypasses
- document the named categories in the frontend README

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run format:check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run lint:structure`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run lint`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh` (passed through build; Playwright hit the known local port conflict on `localhost:4173`)
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 corepack pnpm --dir web exec playwright test --reporter=dot --quiet` (`98 passed`, `2 skipped`)

## Risks / Follow-up
- OpenASE repo-scope update routes currently require a human session in this runtime, so the ticket is linked back to the PR via an external link instead of a repo-scope mutation.
