### PR TITLE
fix: pin patched lodash-es for web runtime

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "api:generate": "openapi-typescript ../api/openapi.json -o src/lib/api/generated/openapi.d.ts && prettier --write src/lib/api/generated/openapi.d.ts",
     "api:check": "pnpm run api:generate && git diff --exit-code -- ../api/openapi.json src/lib/api/generated/openapi.d.ts",
+    "check:security-overrides": "node scripts/check-security-overrides.mjs",
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
@@ -27,7 +28,7 @@
     "sort:i18n-locales": "node scripts/sort-i18n-locales.mjs",
     "format": "pnpm run sort:i18n-locales && prettier --log-level warn --write .",
     "format:check": "pnpm run sort:i18n-locales -- --check && prettier --log-level warn --check .",
-    "ci": "pnpm run format:check && pnpm run lint && node scripts/check-file-budgets.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-mobile-route-gates.mjs && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --output machine --threshold error && vitest run --reporter=dot src/lib/i18n/index.test.ts src/lib/components/layout/top-bar.test.ts src/lib/components/layout/top-bar-user-menu.test.ts src/lib/components/layout/sidebar-nav.test.ts src/lib/components/layout/theme-root.test.ts src/lib/features/ticket-detail/run-transcript-real-samples.test.ts src/lib/features/ticket-detail/run-transcript-live-updates.test.ts src/lib/features/ticket-detail/run-transcript.test.ts && vite build --logLevel warn && playwright test --reporter=dot --quiet"
+    "ci": "pnpm run format:check && pnpm run lint && node scripts/check-file-budgets.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-mobile-route-gates.mjs && pnpm run check:security-overrides && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --output machine --threshold error && vitest run --reporter=dot src/lib/i18n/index.test.ts src/lib/components/layout/top-bar.test.ts src/lib/components/layout/top-bar-user-menu.test.ts src/lib/components/layout/sidebar-nav.test.ts src/lib/components/layout/theme-root.test.ts src/lib/features/ticket-detail/run-transcript-real-samples.test.ts src/lib/features/ticket-detail/run-transcript-live-updates.test.ts src/lib/features/ticket-detail/run-transcript.test.ts && vite build --logLevel warn && playwright test --reporter=dot --quiet"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -84,5 +85,10 @@
     "streamdown-svelte": "^3.0.6",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "4.18.1"
+    }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: 4.18.1
+
 importers:
   .:
     dependencies:
@@ -4178,10 +4181,10 @@ packages:
       }
     engines: { node: '>=10' }
 
-  lodash-es@4.17.23:
+  lodash-es@4.18.1:
     resolution:
       {
-        integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==,
+        integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==,
       }
 
   lodash.merge@4.6.2:
@@ -6206,12 +6209,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.1.2
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/gast@11.1.2':
     dependencies:
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/regexp-to-ast@11.1.2': {}
 
@@ -7523,7 +7526,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
       chevrotain: 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   chevrotain@11.1.2:
     dependencies:
@@ -7532,7 +7535,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.1.2
       '@chevrotain/types': 11.1.2
       '@chevrotain/utils': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   chokidar@4.0.3:
     dependencies:
@@ -7773,7 +7776,7 @@ snapshots:
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   data-urls@7.0.0:
     dependencies:
@@ -8717,7 +8720,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8882,7 +8885,7 @@ snapshots:
       dompurify: 3.3.3
       katex: 0.16.44
       khroma: 2.1.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+
+const expectedVersion = '4.18.1'
+const packageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+const lockfileText = fs.readFileSync(new URL('../pnpm-lock.yaml', import.meta.url), 'utf8')
+const issues = []
+
+const overrideVersion = packageJson.pnpm?.overrides?.['lodash-es']
+if (overrideVersion !== expectedVersion) {
+  issues.push(
+    `package.json must pin pnpm.overrides["lodash-es"] to ${expectedVersion}; found ${String(overrideVersion)}.`,
+  )
+}
+
+const resolvedVersions = [...lockfileText.matchAll(/^[ ]{2}lodash-es@([^:]+):/gm)].map(
+  (match) => match[1],
+)
+if (resolvedVersions.length === 0) {
+  issues.push('pnpm-lock.yaml no longer contains a resolved lodash-es package entry.')
+}
+
+const unexpectedResolvedVersions = resolvedVersions.filter((version) => version !== expectedVersion)
+if (unexpectedResolvedVersions.length > 0) {
+  issues.push(
+    `pnpm-lock.yaml resolves unexpected lodash-es versions: ${[...new Set(unexpectedResolvedVersions)].join(', ')}.`,
+  )
+}
+
+const dependencyVersions = [...lockfileText.matchAll(/^[ ]{6}lodash-es: ([^\n]+)$/gm)].map(
+  (match) => match[1],
+)
+if (dependencyVersions.length === 0) {
+  issues.push('pnpm-lock.yaml no longer contains any transitive lodash-es dependency references.')
+}
+
+const unexpectedDependencyVersions = dependencyVersions.filter(
+  (version) => version !== expectedVersion,
+)
+if (unexpectedDependencyVersions.length > 0) {
+  issues.push(
+    `pnpm-lock.yaml links lodash-es through unexpected versions: ${[...new Set(unexpectedDependencyVersions)].join(', ')}.`,
+  )
+}
+
+if (!lockfileText.includes(`overrides:\n  lodash-es: ${expectedVersion}`)) {
+  issues.push(`pnpm-lock.yaml must record the lodash-es override at version ${expectedVersion}.`)
+}
+
+if (issues.length > 0) {
+  console.error('Security override check failed:')
+  for (const issue of issues) {
+    console.error(`- ${issue}`)
+  }
+  process.exit(1)
+}
+
+console.log(
+  `Security override check passed: ${dependencyVersions.length} transitive lodash-es references resolve to ${expectedVersion}.`,
+)


### PR DESCRIPTION
## Summary
- pin the web workspace's transitive `lodash-es` resolution to `4.18.1` via `pnpm` override
- document the reachable runtime path (`streamdown-svelte -> mermaid -> lodash-es`) and guard it with a CI check
- keep the fix scoped to the affected frontend dependency chain without widening the parser/mermaid upgrade surface

## Validation
- `make openapi-check`
- `PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4273 .codex/skills/push/scripts/openase_ci_gate.sh`
  - passed through frontend API audit, install, formatting, lint, dependency checks, the new security override check, svelte-check, vitest, and build
  - Playwright hit one flaky failure in `tests/e2e/project-ai.spec.ts` (`Validate` button not visible) while 97 tests passed; isolated rerun passed
- `PLAYWRIGHT_WEB_PORT=4274 PLAYWRIGHT_PORT=4274 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4274 pnpm --dir web exec playwright test tests/e2e/project-ai.spec.ts --project=chromium --reporter=dot --quiet`
- `PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4273 pnpm --dir web exec playwright test --reporter=dot --quiet`

## Risks / Follow-up
- The project-ai Playwright test still looks flaky under the full CI chain; this change does not touch that flow.
