### PR TITLE
test(web): lock friendly Claude failure transcript copy

### DIFF
--- a/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
@@ -8,6 +8,9 @@ import {
 import { latestRun } from './run-transcript.test-fixtures'
 import type { TicketRunTranscriptBlock } from './types'
 
+const humanFriendlyClaudeExecutionFailure =
+  'Claude Code failed while executing the task. Try again or check the logs for more details.'
+
 describe('ticket run transcript reducer Claude traces', () => {
   it('renders Claude task traces as command output, tool calls, session status, and errors', () => {
     let state = setTicketRunList(createEmptyTicketRunTranscriptState(), [latestRun])
@@ -87,10 +90,10 @@ describe('ticket run transcript reducer Claude traces', () => {
           provider: 'claude',
           kind: 'error',
           stream: 'task',
-          output: 'Claude Code reported an empty error result.',
+          output: humanFriendlyClaudeExecutionFailure,
           payload: {
             type: 'result',
-            subtype: 'error',
+            subtype: 'error_during_execution',
           },
           created_at: '2026-04-01T10:06:13Z',
         },
@@ -120,7 +123,7 @@ describe('ticket run transcript reducer Claude traces', () => {
       kind: 'task_status',
       id: 'status:trace-session-state',
       statusType: 'session_state',
-      title: 'Claude session status',
+      title: 'Claude Session',
       detail: 'active · Running · running',
       raw: { status: 'active', detail: 'Running', active_flags: ['running'] },
       at: '2026-04-01T10:06:12Z',
@@ -130,8 +133,8 @@ describe('ticket run transcript reducer Claude traces', () => {
       id: 'status:trace-error',
       statusType: 'error',
       title: 'Turn failed',
-      detail: 'Claude Code reported an empty error result.',
-      raw: { type: 'result', subtype: 'error' },
+      detail: humanFriendlyClaudeExecutionFailure,
+      raw: { type: 'result', subtype: 'error_during_execution' },
       at: '2026-04-01T10:06:13Z',
     })
   })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -11,6 +11,7 @@ import {
 } from './run-transcript'
 import { mapTicketRunDetail } from './run-transcript-data'
 import type { TicketRunDetailPayload } from '$lib/api/contracts'
+import type { TicketRunTranscriptBlock } from './types'
 
 type ReplayFixture = {
   provider_name: string
@@ -19,9 +20,23 @@ type ReplayFixture = {
   supplement_frames: Array<{ event: string; payload: Record<string, unknown> }>
 }
 
+const legacyClaudeExecutionFailure =
+  'Claude Code reported an empty error_during_execution result.'
+const humanFriendlyClaudeExecutionFailure =
+  'Claude Code failed while executing the task. Try again or check the logs for more details.'
+
 function loadFixture(name: string): ReplayFixture {
   const fixturePath = resolve(process.cwd(), 'src/lib/features/ticket-detail/testdata', name)
   return JSON.parse(readFileSync(fixturePath, 'utf-8')) as ReplayFixture
+}
+
+function withFriendlyClaudeExecutionFailure(fixture: ReplayFixture): ReplayFixture {
+  return JSON.parse(
+    JSON.stringify(fixture).replaceAll(
+      legacyClaudeExecutionFailure,
+      humanFriendlyClaudeExecutionFailure,
+    ),
+  ) as ReplayFixture
 }
 
 function replayFrames(
@@ -103,5 +118,25 @@ describe('ticket run transcript real sample replay', () => {
       true,
     )
     expect(pagedState).toEqual(fullHydrationThenSupplement)
+  })
+
+  it('preserves user-facing Claude execution failure text through hydrate and replay', () => {
+    const fixture = withFriendlyClaudeExecutionFailure(loadFixture('claude-code-replay-fixture.json'))
+    const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
+
+    const errorBlock = state.blocks.find(
+      (
+        block,
+      ): block is Extract<
+        TicketRunTranscriptBlock,
+        { kind: 'task_status'; statusType: 'error' }
+      > =>
+        block.kind === 'task_status' &&
+        block.statusType === 'error' &&
+        block.raw?.subtype === 'error_during_execution',
+    )
+
+    expect(errorBlock?.detail).toBe(humanFriendlyClaudeExecutionFailure)
+    expect(errorBlock?.detail).not.toContain('error_during_execution')
   })
 })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -11,7 +11,6 @@ import {
 } from './run-transcript'
 import { mapTicketRunDetail } from './run-transcript-data'
 import type { TicketRunDetailPayload } from '$lib/api/contracts'
-import type { TicketRunTranscriptBlock } from './types'
 
 type ReplayFixture = {
   provider_name: string
@@ -126,15 +125,16 @@ describe('ticket run transcript real sample replay', () => {
     const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
 
     const errorBlock = state.blocks.find(
-      (
-        block,
-      ): block is Extract<TicketRunTranscriptBlock, { kind: 'task_status'; statusType: 'error' }> =>
+      (block) =>
         block.kind === 'task_status' &&
         block.statusType === 'error' &&
         block.raw?.subtype === 'error_during_execution',
     )
 
-    expect(errorBlock?.detail).toBe(humanFriendlyClaudeExecutionFailure)
-    expect(errorBlock?.detail).not.toContain('error_during_execution')
+    expect(errorBlock).toMatchObject({
+      detail: humanFriendlyClaudeExecutionFailure,
+      raw: { subtype: 'error_during_execution' },
+    })
+    expect(JSON.stringify(errorBlock)).not.toContain(legacyClaudeExecutionFailure)
   })
 })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -20,8 +20,7 @@ type ReplayFixture = {
   supplement_frames: Array<{ event: string; payload: Record<string, unknown> }>
 }
 
-const legacyClaudeExecutionFailure =
-  'Claude Code reported an empty error_during_execution result.'
+const legacyClaudeExecutionFailure = 'Claude Code reported an empty error_during_execution result.'
 const humanFriendlyClaudeExecutionFailure =
   'Claude Code failed while executing the task. Try again or check the logs for more details.'
 
@@ -121,16 +120,15 @@ describe('ticket run transcript real sample replay', () => {
   })
 
   it('preserves user-facing Claude execution failure text through hydrate and replay', () => {
-    const fixture = withFriendlyClaudeExecutionFailure(loadFixture('claude-code-replay-fixture.json'))
+    const fixture = withFriendlyClaudeExecutionFailure(
+      loadFixture('claude-code-replay-fixture.json'),
+    )
     const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
 
     const errorBlock = state.blocks.find(
       (
         block,
-      ): block is Extract<
-        TicketRunTranscriptBlock,
-        { kind: 'task_status'; statusType: 'error' }
-      > =>
+      ): block is Extract<TicketRunTranscriptBlock, { kind: 'task_status'; statusType: 'error' }> =>
         block.kind === 'task_status' &&
         block.statusType === 'error' &&
         block.raw?.subtype === 'error_during_execution',


### PR DESCRIPTION
## Summary
- update Claude transcript reducer expectations to use the new user-facing execution failure copy
- add replay coverage that keeps the friendly message stable through hydrate and stream replay
- keep the replay assertion type-safe under `svelte-check`

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH pnpm --dir web install --frozen-lockfile`
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH pnpm --dir web exec vitest run src/lib/features/ticket-detail/run-transcript-claude.test.ts src/lib/features/ticket-detail/run-transcript-real-samples.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh` *(passed through `vite build`; the bundled Playwright step hit the known fixed-port `127.0.0.1:4173` workspace conflict)*
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 pnpm --dir web exec playwright test --reporter=dot --quiet`

## Risks / Follow-up
- this PR only hardens frontend regression coverage; the backend copy mapping ships separately in #714
