### PR TITLE
fix(claude): show user-facing failure copy

### DIFF
--- a/internal/chat/runtime_semantics_test.go
+++ b/internal/chat/runtime_semantics_test.go
@@ -624,8 +624,9 @@ func TestMapClaudeEventPromotesClaudeResultErrorsIntoErrorEvents(t *testing.T) {
 	if events[0].Event != "error" || !ok {
 		t.Fatalf("event = %+v, want error payload", events[0])
 	}
-	if !strings.Contains(payload.Message, "error_during_execution") {
-		t.Fatalf("error payload = %#v, want subtype summary", payload)
+	expected := "Claude Code failed while executing the task. Try again or check the logs for more details."
+	if payload.Message != expected {
+		t.Fatalf("error payload = %#v, want %q", payload, expected)
 	}
 }
 

--- a/internal/orchestrator/agent_adapter_test.go
+++ b/internal/orchestrator/agent_adapter_test.go
@@ -258,7 +258,7 @@ func TestClaudeCodeAgentAdapterPreservesTaskAndSessionEventsAndFallbackFailureDe
 	if sixth.Type != agentEventTypeTurnFailed || sixth.Turn == nil || sixth.Turn.Error == nil {
 		t.Fatalf("unexpected sixth event: %+v", sixth)
 	}
-	if !strings.Contains(sixth.Turn.Error.Message, "empty error result") {
+	if sixth.Turn.Error.Message != "Claude Code failed before it returned a result. Try again or check the logs for more details." {
 		t.Fatalf("unexpected turn failure message: %+v", sixth.Turn.Error)
 	}
 	if !strings.Contains(sixth.Turn.Error.AdditionalDetails, `"subtype":"error"`) {

--- a/internal/orchestrator/claude_protocol.go
+++ b/internal/orchestrator/claude_protocol.go
@@ -2,7 +2,6 @@ package orchestrator
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/BetterAndBetterII/openase/internal/provider"
@@ -646,28 +645,5 @@ func cloneClaudeMap(value map[string]any) map[string]any {
 }
 
 func claudeTurnFailure(event provider.ClaudeCodeEvent) (string, string) {
-	message := strings.TrimSpace(event.Result)
-	rawPayload := decodeClaudeRaw(event.Raw)
-	additionalDetails := ""
-	if rawPayload != nil {
-		if encoded, err := json.Marshal(rawPayload); err == nil {
-			additionalDetails = string(encoded)
-		}
-	}
-	if message != "" {
-		return message, additionalDetails
-	}
-
-	subtype := strings.TrimSpace(event.Subtype)
-	if subtype != "" {
-		summary := fmt.Sprintf("Claude Code reported an empty %s result.", subtype)
-		if subtype == "error" {
-			summary = "Claude Code reported an empty error result."
-		}
-		return summary, additionalDetails
-	}
-	if additionalDetails != "" {
-		return "Claude Code reported an empty result error.", additionalDetails
-	}
-	return "Claude Code reported an empty result error.", ""
+	return provider.ClaudeCodeTurnFailure(event)
 }

--- a/internal/orchestrator/coverage_test.go
+++ b/internal/orchestrator/coverage_test.go
@@ -1211,7 +1211,7 @@ func TestRuntimeLifecycleEventAndStateCoverage(t *testing.T) {
 	if err := launcher.recordAgentTaskStatus(ctx, fixture.projectID, agentItem.ID, ticketItem.ID, currentRun.ID, entagentprovider.AdapterTypeClaudeCodeCli, &agentTaskStatusEvent{
 		ThreadID:   "claude-session-1",
 		StatusType: catalogdomain.AgentTraceKindError,
-		Text:       "Claude Code reported an empty error result.",
+		Text:       "Claude Code failed before it returned a result. Try again or check the logs for more details.",
 		Payload: map[string]any{
 			"type":     "result",
 			"subtype":  "error",
@@ -1314,7 +1314,7 @@ func TestRuntimeLifecycleEventAndStateCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query error trace event: %v", err)
 	}
-	if errorTrace.Payload["subtype"] != "error" || errorTrace.Text != "Claude Code reported an empty error result." {
+	if errorTrace.Payload["subtype"] != "error" || errorTrace.Text != "Claude Code failed before it returned a result. Try again or check the logs for more details." {
 		t.Fatalf("error trace = %+v", errorTrace)
 	}
 

--- a/internal/provider/claudecode_protocol.go
+++ b/internal/provider/claudecode_protocol.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -172,16 +171,27 @@ func ClaudeCodeTurnFailure(event ClaudeCodeEvent) (string, string) {
 
 	subtype := strings.TrimSpace(event.Subtype)
 	if subtype != "" {
-		summary := fmt.Sprintf("Claude Code reported an empty %s result.", subtype)
-		if subtype == "error" {
-			summary = "Claude Code reported an empty error result."
-		}
-		return summary, additionalDetails
+		return claudeCodeFailureMessageForSubtype(subtype), additionalDetails
 	}
 	if additionalDetails != "" {
-		return "Claude Code reported an empty result error.", additionalDetails
+		return claudeCodeGenericFailureMessage(), additionalDetails
 	}
-	return "Claude Code reported an empty result error.", ""
+	return claudeCodeGenericFailureMessage(), ""
+}
+
+func claudeCodeFailureMessageForSubtype(subtype string) string {
+	switch strings.TrimSpace(subtype) {
+	case "error_during_execution":
+		return "Claude Code failed while executing the task. Try again or check the logs for more details."
+	case "error":
+		return "Claude Code failed before it returned a result. Try again or check the logs for more details."
+	default:
+		return claudeCodeGenericFailureMessage()
+	}
+}
+
+func claudeCodeGenericFailureMessage() string {
+	return "Claude Code failed before it returned a result. Try again or check the logs for more details."
 }
 
 func ClaudeCodeAssistantSnapshotContinues(previous string, next string) bool {

--- a/internal/provider/claudecode_protocol_test.go
+++ b/internal/provider/claudecode_protocol_test.go
@@ -39,16 +39,50 @@ func TestExtractClaudeCodeToolResultTextJoinsStructuredTextContent(t *testing.T)
 	}
 }
 
-func TestClaudeCodeTurnFailureFallsBackToSubtypeSummary(t *testing.T) {
-	message, details := ClaudeCodeTurnFailure(ClaudeCodeEvent{
-		Kind:    ClaudeCodeEventKindResult,
-		Subtype: "error_during_execution",
-		Raw:     json.RawMessage(`{"type":"result","subtype":"error_during_execution"}`),
-	})
-	if !strings.Contains(message, "error_during_execution") {
-		t.Fatalf("message = %q, want subtype summary", message)
+func TestClaudeCodeTurnFailureUsesUserFacingSubtypeMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		subtype  string
+		expected string
+	}{
+		{
+			name:     "execution failure",
+			subtype:  "error_during_execution",
+			expected: "Claude Code failed while executing the task. Try again or check the logs for more details.",
+		},
+		{
+			name:     "generic error",
+			subtype:  "error",
+			expected: "Claude Code failed before it returned a result. Try again or check the logs for more details.",
+		},
+		{
+			name:     "unknown subtype falls back to generic guidance",
+			subtype:  "backend_unreachable",
+			expected: "Claude Code failed before it returned a result. Try again or check the logs for more details.",
+		},
 	}
-	if !strings.Contains(details, `"subtype":"error_during_execution"`) {
-		t.Fatalf("details = %q, want encoded raw payload", details)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			message, details := ClaudeCodeTurnFailure(ClaudeCodeEvent{
+				Kind:    ClaudeCodeEventKindResult,
+				Subtype: tc.subtype,
+				Raw:     json.RawMessage(`{"type":"result","subtype":"` + tc.subtype + `"}`),
+			})
+			if message != tc.expected {
+				t.Fatalf("message = %q, want %q", message, tc.expected)
+			}
+			if strings.Contains(message, tc.subtype) {
+				t.Fatalf("message = %q, should hide internal subtype %q", message, tc.subtype)
+			}
+			if !strings.Contains(details, `"subtype":"`+tc.subtype+`"`) {
+				t.Fatalf("details = %q, want encoded raw payload", details)
+			}
+		})
 	}
 }

--- a/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
@@ -8,6 +8,9 @@ import {
 import { latestRun } from './run-transcript.test-fixtures'
 import type { TicketRunTranscriptBlock } from './types'
 
+const humanFriendlyClaudeExecutionFailure =
+  'Claude Code failed while executing the task. Try again or check the logs for more details.'
+
 describe('ticket run transcript reducer Claude traces', () => {
   it('renders Claude task traces as command output, tool calls, session status, and errors', () => {
     let state = setTicketRunList(createEmptyTicketRunTranscriptState(), [latestRun])
@@ -87,10 +90,10 @@ describe('ticket run transcript reducer Claude traces', () => {
           provider: 'claude',
           kind: 'error',
           stream: 'task',
-          output: 'Claude Code reported an empty error result.',
+          output: humanFriendlyClaudeExecutionFailure,
           payload: {
             type: 'result',
-            subtype: 'error',
+            subtype: 'error_during_execution',
           },
           created_at: '2026-04-01T10:06:13Z',
         },
@@ -120,7 +123,7 @@ describe('ticket run transcript reducer Claude traces', () => {
       kind: 'task_status',
       id: 'status:trace-session-state',
       statusType: 'session_state',
-      title: 'Claude session status',
+      title: 'Claude Session',
       detail: 'active · Running · running',
       raw: { status: 'active', detail: 'Running', active_flags: ['running'] },
       at: '2026-04-01T10:06:12Z',
@@ -130,8 +133,8 @@ describe('ticket run transcript reducer Claude traces', () => {
       id: 'status:trace-error',
       statusType: 'error',
       title: 'Turn failed',
-      detail: 'Claude Code reported an empty error result.',
-      raw: { type: 'result', subtype: 'error' },
+      detail: humanFriendlyClaudeExecutionFailure,
+      raw: { type: 'result', subtype: 'error_during_execution' },
       at: '2026-04-01T10:06:13Z',
     })
   })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -11,6 +11,7 @@ import {
 } from './run-transcript'
 import { mapTicketRunDetail } from './run-transcript-data'
 import type { TicketRunDetailPayload } from '$lib/api/contracts'
+import type { TicketRunTranscriptBlock } from './types'
 
 type ReplayFixture = {
   provider_name: string
@@ -19,9 +20,23 @@ type ReplayFixture = {
   supplement_frames: Array<{ event: string; payload: Record<string, unknown> }>
 }
 
+const legacyClaudeExecutionFailure =
+  'Claude Code reported an empty error_during_execution result.'
+const humanFriendlyClaudeExecutionFailure =
+  'Claude Code failed while executing the task. Try again or check the logs for more details.'
+
 function loadFixture(name: string): ReplayFixture {
   const fixturePath = resolve(process.cwd(), 'src/lib/features/ticket-detail/testdata', name)
   return JSON.parse(readFileSync(fixturePath, 'utf-8')) as ReplayFixture
+}
+
+function withFriendlyClaudeExecutionFailure(fixture: ReplayFixture): ReplayFixture {
+  return JSON.parse(
+    JSON.stringify(fixture).replaceAll(
+      legacyClaudeExecutionFailure,
+      humanFriendlyClaudeExecutionFailure,
+    ),
+  ) as ReplayFixture
 }
 
 function replayFrames(
@@ -103,5 +118,25 @@ describe('ticket run transcript real sample replay', () => {
       true,
     )
     expect(pagedState).toEqual(fullHydrationThenSupplement)
+  })
+
+  it('preserves user-facing Claude execution failure text through hydrate and replay', () => {
+    const fixture = withFriendlyClaudeExecutionFailure(loadFixture('claude-code-replay-fixture.json'))
+    const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
+
+    const errorBlock = state.blocks.find(
+      (
+        block,
+      ): block is Extract<
+        TicketRunTranscriptBlock,
+        { kind: 'task_status'; statusType: 'error' }
+      > =>
+        block.kind === 'task_status' &&
+        block.statusType === 'error' &&
+        block.raw?.subtype === 'error_during_execution',
+    )
+
+    expect(errorBlock?.detail).toBe(humanFriendlyClaudeExecutionFailure)
+    expect(errorBlock?.detail).not.toContain('error_during_execution')
   })
 })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -11,7 +11,6 @@ import {
 } from './run-transcript'
 import { mapTicketRunDetail } from './run-transcript-data'
 import type { TicketRunDetailPayload } from '$lib/api/contracts'
-import type { TicketRunTranscriptBlock } from './types'
 
 type ReplayFixture = {
   provider_name: string
@@ -126,15 +125,16 @@ describe('ticket run transcript real sample replay', () => {
     const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
 
     const errorBlock = state.blocks.find(
-      (
-        block,
-      ): block is Extract<TicketRunTranscriptBlock, { kind: 'task_status'; statusType: 'error' }> =>
+      (block) =>
         block.kind === 'task_status' &&
         block.statusType === 'error' &&
         block.raw?.subtype === 'error_during_execution',
     )
 
-    expect(errorBlock?.detail).toBe(humanFriendlyClaudeExecutionFailure)
-    expect(errorBlock?.detail).not.toContain('error_during_execution')
+    expect(errorBlock).toMatchObject({
+      detail: humanFriendlyClaudeExecutionFailure,
+      raw: { subtype: 'error_during_execution' },
+    })
+    expect(JSON.stringify(errorBlock)).not.toContain(legacyClaudeExecutionFailure)
   })
 })

--- a/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-real-samples.test.ts
@@ -20,8 +20,7 @@ type ReplayFixture = {
   supplement_frames: Array<{ event: string; payload: Record<string, unknown> }>
 }
 
-const legacyClaudeExecutionFailure =
-  'Claude Code reported an empty error_during_execution result.'
+const legacyClaudeExecutionFailure = 'Claude Code reported an empty error_during_execution result.'
 const humanFriendlyClaudeExecutionFailure =
   'Claude Code failed while executing the task. Try again or check the logs for more details.'
 
@@ -121,16 +120,15 @@ describe('ticket run transcript real sample replay', () => {
   })
 
   it('preserves user-facing Claude execution failure text through hydrate and replay', () => {
-    const fixture = withFriendlyClaudeExecutionFailure(loadFixture('claude-code-replay-fixture.json'))
+    const fixture = withFriendlyClaudeExecutionFailure(
+      loadFixture('claude-code-replay-fixture.json'),
+    )
     const state = replayFrames(fixture.supplement_frames, fixture.detail, true)
 
     const errorBlock = state.blocks.find(
       (
         block,
-      ): block is Extract<
-        TicketRunTranscriptBlock,
-        { kind: 'task_status'; statusType: 'error' }
-      > =>
+      ): block is Extract<TicketRunTranscriptBlock, { kind: 'task_status'; statusType: 'error' }> =>
         block.kind === 'task_status' &&
         block.statusType === 'error' &&
         block.raw?.subtype === 'error_during_execution',


### PR DESCRIPTION
## Summary
- map Claude Code result subtypes to user-facing failure copy instead of exposing raw internal subtype names
- reuse the provider failure mapping in the orchestrator path so runtime layers stay aligned
- add backend and frontend regression coverage for transcript error handling

## Validation
- `PATH=$PWD/.tooling/go/bin:$PATH go test ./internal/provider ./internal/chat -run 'TestClaudeCodeTurnFailureUsesUserFacingSubtypeMessages|TestMapClaudeEventPromotesClaudeResultErrorsIntoErrorEvents' -count=1 -v`
- `PATH=$PWD/.tooling/go/bin:$PATH go test ./internal/orchestrator -run 'TestClaudeCodeAgentAdapterPreservesTaskAndSessionEventsAndFallbackFailureDetails|TestOrchestratorHelperCoverage' -count=1 -v`
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH pnpm --dir web install --frozen-lockfile`
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PATH pnpm --dir web exec vitest run src/lib/features/ticket-detail/run-transcript-claude.test.ts src/lib/features/ticket-detail/run-transcript-real-samples.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.0/bin:$PWD/.tooling/go/bin:$PATH PLAYWRIGHT_WEB_PORT=4273 PLAYWRIGHT_PORT=4273 .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- this still relies on copy-level mapping rather than a normalized backend/frontend failure enum, so a future hardening pass could promote that contract explicitly
