### PR TITLE
refactor(web): replace workspace budget bypass rules

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -99,7 +99,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `lib/components/ui/**/*.svelte`     | 150        | 250                  |
 | single function                     | 40 target  | 60 warning threshold |
 
-There are no per-file budget waivers. If a recurring file shape needs a different limit, promote it into a named budget category instead of growing an allowlist.
+There are no per-file budget waivers. If a recurring file shape needs a different limit, promote it into a named budget category for that feature family or UI layer instead of growing an allowlist.
 
 ## Quality Gates
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -5,8 +5,12 @@ import sonarjs from 'eslint-plugin-sonarjs'
 import svelte from 'eslint-plugin-svelte'
 import globals from 'globals'
 import ts from 'typescript-eslint'
-import { fileBudgetLimits } from './file-budgets.config.mjs'
+import { eslintFileBudgetOverrides, fileBudgetLimits } from './file-budgets.config.mjs'
 import svelteConfig from './svelte.config.js'
+
+function maxLinesRule(max) {
+  return ['error', { max, skipBlankLines: true, skipComments: true }]
+}
 
 export default defineConfig(
   {
@@ -74,95 +78,58 @@ export default defineConfig(
   {
     files: ['src/routes/**/+page.svelte'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.routePage.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.routePage.hard),
     },
   },
   {
     files: ['src/routes/**/+layout.svelte'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.routeLayout.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.routeLayout.hard),
     },
   },
   {
     files: ['src/lib/features/**/*.svelte'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.featureComponent.hard, skipBlankLines: true, skipComments: true },
-      ],
-    },
-  },
-  {
-    files: [
-      'src/lib/features/chat/project-conversation-workspace-browser-branch-picker.svelte',
-      'src/lib/features/chat/project-conversation-workspace-browser-sidebar.svelte',
-      'src/lib/features/chat/project-conversation-workspace-browser.svelte',
-    ],
-    rules: {
-      'max-lines': ['error', { max: 700, skipBlankLines: true, skipComments: true }],
+      'max-lines': maxLinesRule(fileBudgetLimits.featureComponent.hard),
     },
   },
   {
     files: ['src/lib/features/**/*.test.{js,ts,mjs,cjs}'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.featureTest.hard, skipBlankLines: true, skipComments: true },
-      ],
-    },
-  },
-  {
-    files: [
-      'src/lib/features/chat/project-conversation-workspace-browser-git-checkout.test.ts',
-      'src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts',
-    ],
-    rules: {
-      'max-lines': ['error', { max: 900, skipBlankLines: true, skipComments: true }],
+      'max-lines': maxLinesRule(fileBudgetLimits.featureTest.hard),
     },
   },
   {
     files: ['src/lib/features/**/*.svelte.{ts,js}'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.featureStateModule.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.featureStateModule.hard),
     },
   },
   {
     files: ['src/lib/features/**/*.{js,ts,mjs,cjs}'],
     ignores: ['src/lib/features/**/*.test.{js,ts,mjs,cjs}', 'src/lib/features/**/*.svelte.{ts,js}'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.featureModule.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.featureModule.hard),
     },
   },
   {
     files: ['src/lib/components/layout/**/*.svelte'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.layoutComponent.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.layoutComponent.hard),
     },
   },
   {
     files: ['src/lib/components/ui/**/*.svelte'],
     rules: {
-      'max-lines': [
-        'error',
-        { max: fileBudgetLimits.uiPrimitive.hard, skipBlankLines: true, skipComments: true },
-      ],
+      'max-lines': maxLinesRule(fileBudgetLimits.uiPrimitive.hard),
     },
   },
+  ...eslintFileBudgetOverrides.map(({ files, hardLimit }) => ({
+    files,
+    rules: {
+      'max-lines': maxLinesRule(hardLimit),
+    },
+  })),
   {
     files: ['**/*.{js,cjs,mjs,ts}'],
     rules: {

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -7,7 +7,57 @@ export const fileBudgetLimits = {
   featureModule: { soft: 200, hard: 325 },
   layoutComponent: { soft: 200, hard: 300 },
   uiPrimitive: { soft: 150, hard: 250 },
+  workspaceBrowserComponent: { soft: 300, hard: 700 },
+  workspaceBrowserTest: { soft: 450, hard: 900 },
+  workspaceStateModule: { soft: 350, hard: 750 },
 }
+
+function buildBudgetRule({ name, match, softLimit, hardLimit, eslintFiles }) {
+  return { name, match, softLimit, hardLimit, eslintFiles }
+}
+
+export const namedFileBudgetCategories = [
+  buildBudgetRule({
+    name: 'Workspace browser components',
+    match: (filePath) =>
+      /^src\/lib\/features\/chat\/project-conversation-workspace-browser(?:-.+)?\.svelte$/.test(
+        filePath,
+      ),
+    softLimit: fileBudgetLimits.workspaceBrowserComponent.soft,
+    hardLimit: fileBudgetLimits.workspaceBrowserComponent.hard,
+    eslintFiles: ['src/lib/features/chat/project-conversation-workspace-browser*.svelte'],
+  }),
+  buildBudgetRule({
+    name: 'Workspace browser tests',
+    match: (filePath) =>
+      /^src\/lib\/features\/chat\/project-conversation-workspace-browser(?:-.+)?\.test\.(ts|js|mjs|cjs)$/.test(
+        filePath,
+      ),
+    softLimit: fileBudgetLimits.workspaceBrowserTest.soft,
+    hardLimit: fileBudgetLimits.workspaceBrowserTest.hard,
+    eslintFiles: [
+      'src/lib/features/chat/project-conversation-workspace-browser*.test.{js,ts,mjs,cjs}',
+    ],
+  }),
+  buildBudgetRule({
+    name: 'Workspace state modules',
+    match: (filePath) =>
+      /^src\/lib\/features\/chat\/project-conversation-workspace(?:-.+)?\.svelte\.(ts|js)$/.test(
+        filePath,
+      ),
+    softLimit: fileBudgetLimits.workspaceStateModule.soft,
+    hardLimit: fileBudgetLimits.workspaceStateModule.hard,
+    eslintFiles: ['src/lib/features/chat/project-conversation-workspace-*.svelte.{ts,js}'],
+  }),
+]
+
+export const eslintFileBudgetOverrides = namedFileBudgetCategories.map(
+  ({ name, eslintFiles, hardLimit }) => ({
+    name,
+    files: eslintFiles,
+    hardLimit,
+  }),
+)
 
 function isRoutePage(filePath) {
   return /^src\/routes\/.+\/\+page\.svelte$|^src\/routes\/\+page\.svelte$/.test(filePath)
@@ -42,73 +92,7 @@ function isUiPrimitive(filePath) {
 }
 
 export const fileBudgetRules = [
-  {
-    name: 'Workspace editor V2 detail view',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-detail.svelte',
-    softLimit: 250,
-    hardLimit: 450,
-  },
-  {
-    name: 'Workspace editor V2 sidebar',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-sidebar.svelte',
-    softLimit: 250,
-    hardLimit: 400,
-  },
-  {
-    name: 'Workspace editor V2 branch picker',
-    match: (filePath) =>
-      filePath ===
-      'src/lib/features/chat/project-conversation-workspace-browser-branch-picker.svelte',
-    softLimit: 400,
-    hardLimit: 700,
-  },
-  {
-    name: 'Workspace editor V2 browser shell',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser.svelte',
-    softLimit: 300,
-    hardLimit: 500,
-  },
-  {
-    name: 'Workspace editor V2 browser state',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts',
-    softLimit: 350,
-    hardLimit: 750,
-  },
-  {
-    name: 'Workspace editor V2 editor state',
-    match: (filePath) =>
-      filePath ===
-      'src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts',
-    softLimit: 350,
-    hardLimit: 650,
-  },
-  {
-    name: 'Workspace editor V2 refresh test',
-    match: (filePath) =>
-      filePath === 'src/lib/features/chat/project-conversation-workspace-browser-refresh.test.ts',
-    softLimit: 350,
-    hardLimit: 700,
-  },
-  {
-    name: 'Workspace editor V2 checkout test',
-    match: (filePath) =>
-      filePath ===
-      'src/lib/features/chat/project-conversation-workspace-browser-git-checkout.test.ts',
-    softLimit: 450,
-    hardLimit: 900,
-  },
-  {
-    name: 'Workspace editor V2 navigation test',
-    match: (filePath) =>
-      filePath ===
-      'src/lib/features/chat/project-conversation-workspace-browser-navigation.test.ts',
-    softLimit: 450,
-    hardLimit: 900,
-  },
+  ...namedFileBudgetCategories,
   {
     name: 'Route pages',
     match: isRoutePage,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import {
   getProjectConversationWorkspaceDiff,
   type ChatDiffPayload,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { ApiError } from '$lib/api/client'
 import {
   saveProjectConversationWorkspaceFile,


### PR DESCRIPTION
## Summary
- replace workspace-browser file-by-file budget exceptions with named budget categories in `web/file-budgets.config.mjs`
- reuse the same category overrides in `web/eslint.config.js` and remove the inline `max-lines` bypass comments from the workspace state modules
- tighten the frontend budget policy wording in `web/README.md` around feature-family categories instead of per-file waivers

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run format:check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:eslint`
- `make openapi-check-ci`
- `make frontend-api-audit-check`
- `make web-install`
- `PLAYWRIGHT_WEB_HOST=127.0.0.1 PLAYWRIGHT_WEB_PORT=4175 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4175 .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- `lint:structure` still reports the repo's existing soft-budget warning backlog; ASE-211 removes the temporary workspace-browser bypasses but does not attempt a broader file-splitting refactor.
- OpenASE ticket: `ASE-211`
