### PR TITLE
Prevent Claude raw-event projection from failing on NUL dedup keys

### DIFF
--- a/internal/orchestrator/agent_adapter_claudecode.go
+++ b/internal/orchestrator/agent_adapter_claudecode.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -741,21 +743,18 @@ func rawClaudeProviderEvent(event provider.ClaudeCodeEvent) *agentRawProviderEve
 	threadID := claudeEventSessionID(event, payload)
 	turnID := claudeReadString(payload, "turn_id", "turnId")
 	activityHintID := firstClaudeNonEmptyString(claudeReadString(payload, "tool_use_id"), claudeReadString(payload, "parent_tool_use_id"), claudeReadString(payload, "task_id"))
-	dedupKey := strings.Join(
-		[]string{
-			providerKind,
-			subtype,
-			threadID,
-			turnID,
-			eventID,
-			activityHintID,
-			claudeReadString(payload, "text"),
-			claudeReadString(payload, "summary"),
-			claudeReadString(payload, "message"),
-		},
-		"\x00",
+	dedupKey := claudeRawEventDedupKey(
+		providerKind,
+		subtype,
+		threadID,
+		turnID,
+		eventID,
+		activityHintID,
+		claudeReadString(payload, "text"),
+		claudeReadString(payload, "summary"),
+		claudeReadString(payload, "message"),
 	)
-	if strings.TrimSpace(strings.ReplaceAll(dedupKey, "\x00", "")) == "" {
+	if dedupKey == "" {
 		return nil
 	}
 	return &agentRawProviderEvent{
@@ -769,6 +768,23 @@ func rawClaudeProviderEvent(event provider.ClaudeCodeEvent) *agentRawProviderEve
 		Payload:              payload,
 		TextExcerpt:          claudeProtocolTaskStatusText(payload),
 	}
+}
+
+func claudeRawEventDedupKey(parts ...string) string {
+	normalized := make([]string, 0, len(parts))
+	hasContent := false
+	for _, part := range parts {
+		cleaned := strings.ReplaceAll(strings.ToValidUTF8(part, ""), "\x00", "")
+		if strings.TrimSpace(cleaned) != "" {
+			hasContent = true
+		}
+		normalized = append(normalized, cleaned)
+	}
+	if !hasContent {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.Join(normalized, "\x00")))
+	return "claude:" + hex.EncodeToString(sum[:])
 }
 
 func extractClaudeToolResultText(content any) string {

--- a/internal/orchestrator/runtime_event_projection.go
+++ b/internal/orchestrator/runtime_event_projection.go
@@ -125,7 +125,7 @@ func (l *RuntimeLauncher) appendAgentRawEvent(
 	if raw == nil {
 		return nil
 	}
-	dedupKey := strings.TrimSpace(raw.DedupKey)
+	dedupKey := sanitizeRawEventDBText(raw.DedupKey)
 	if dedupKey == "" {
 		return nil
 	}
@@ -148,28 +148,32 @@ func (l *RuntimeLauncher) appendAgentRawEvent(
 		SetAgentID(input.AgentID).
 		SetAgentRunID(input.RunID).
 		SetDedupKey(dedupKey).
-		SetProvider(strings.TrimSpace(input.Provider)).
-		SetProviderEventKind(strings.TrimSpace(raw.ProviderEventKind)).
-		SetProviderEventSubtype(strings.TrimSpace(raw.ProviderEventSubtype)).
+		SetProvider(sanitizeRawEventDBText(input.Provider)).
+		SetProviderEventKind(sanitizeRawEventDBText(raw.ProviderEventKind)).
+		SetProviderEventSubtype(sanitizeRawEventDBText(raw.ProviderEventSubtype)).
 		SetOccurredAt(input.ObservedAt.UTC()).
 		SetPayload(cloneProjectionMap(raw.Payload)).
-		SetTextExcerpt(strings.TrimSpace(raw.TextExcerpt))
-	if trimmed := strings.TrimSpace(raw.ProviderEventID); trimmed != "" {
+		SetTextExcerpt(sanitizeRawEventDBText(raw.TextExcerpt))
+	if trimmed := sanitizeRawEventDBText(raw.ProviderEventID); trimmed != "" {
 		create.SetProviderEventID(trimmed)
 	}
-	if trimmed := strings.TrimSpace(raw.ThreadID); trimmed != "" {
+	if trimmed := sanitizeRawEventDBText(raw.ThreadID); trimmed != "" {
 		create.SetThreadID(trimmed)
 	}
-	if trimmed := strings.TrimSpace(raw.TurnID); trimmed != "" {
+	if trimmed := sanitizeRawEventDBText(raw.TurnID); trimmed != "" {
 		create.SetTurnID(trimmed)
 	}
-	if trimmed := strings.TrimSpace(raw.ActivityHintID); trimmed != "" {
+	if trimmed := sanitizeRawEventDBText(raw.ActivityHintID); trimmed != "" {
 		create.SetActivityHintID(trimmed)
 	}
 	if _, err := create.Save(ctx); err != nil {
 		return fmt.Errorf("append raw event for run %s: %w", input.RunID, err)
 	}
 	return nil
+}
+
+func sanitizeRawEventDBText(raw string) string {
+	return strings.TrimSpace(strings.ReplaceAll(strings.ToValidUTF8(raw, ""), "\x00", ""))
 }
 
 func (l *RuntimeLauncher) projectItemStartedEvent(ctx context.Context, input runtimeEventProjectionInput) error {

--- a/internal/orchestrator/runtime_event_projection_test.go
+++ b/internal/orchestrator/runtime_event_projection_test.go
@@ -1,0 +1,102 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	entagentrawevent "github.com/BetterAndBetterII/openase/ent/agentrawevent"
+	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
+	entticket "github.com/BetterAndBetterII/openase/ent/ticket"
+	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
+	"github.com/BetterAndBetterII/openase/internal/provider"
+)
+
+func TestProjectRuntimeEventPersistsClaudeRawEventWithoutNULDedupKey(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	fixture := seedProjectFixture(ctx, t, client)
+	now := time.Date(2026, time.April, 15, 10, 30, 0, 0, time.UTC)
+
+	workflowItem, err := client.Workflow.Create().
+		SetProjectID(fixture.projectID).
+		SetName("Claude raw events").
+		SetType(entworkflow.TypeCoding).
+		SetHarnessPath(".openase/harnesses/coding.md").
+		AddPickupStatusIDs(fixture.statusIDs["Todo"]).
+		AddFinishStatusIDs(fixture.statusIDs["Done"]).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(fixture.projectID).
+		SetIdentifier("ASE-RAW-CLAUDE").
+		SetTitle("Persist Claude raw events safely").
+		SetStatusID(fixture.statusIDs["Todo"]).
+		SetWorkflowID(workflowItem.ID).
+		SetPriority(entticket.PriorityHigh).
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	agentItem := fixture.createAgent(ctx, t, "claude-raw-01", 0)
+	runItem := mustCreateCurrentRun(ctx, t, client, agentItem, workflowItem.ID, ticketItem.ID, entagentrun.StatusExecuting, now)
+
+	rawPayload, err := json.Marshal(map[string]any{
+		"type":        "task_progress",
+		"session_id":  "claude-session-raw-1",
+		"turn_id":     "turn-raw-1",
+		"tool_use_id": "toolu-raw-1",
+		"stream":      "command",
+		"command":     "pwd",
+		"text":        "/repo\n",
+		"snapshot":    true,
+	})
+	if err != nil {
+		t.Fatalf("marshal raw payload: %v", err)
+	}
+
+	raw := rawClaudeProviderEvent(provider.ClaudeCodeEvent{
+		Kind:      provider.ClaudeCodeEventKindTaskProgress,
+		SessionID: "claude-session-raw-1",
+		UUID:      "event-raw-1",
+		Raw:       rawPayload,
+	})
+	if raw == nil {
+		t.Fatal("expected raw Claude provider event")
+	}
+
+	launcher := NewRuntimeLauncher(client, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, nil)
+	if err := launcher.projectRuntimeEvent(ctx, runtimeEventProjectionInput{
+		ProjectID:  fixture.projectID,
+		AgentID:    agentItem.ID,
+		TicketID:   ticketItem.ID,
+		RunID:      runItem.ID,
+		Provider:   "claude",
+		ObservedAt: now,
+		Event: agentEvent{
+			Raw: raw,
+		},
+	}); err != nil {
+		t.Fatalf("projectRuntimeEvent() error = %v", err)
+	}
+
+	rawEvent, err := client.AgentRawEvent.Query().
+		Where(entagentrawevent.AgentRunIDEQ(runItem.ID)).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query raw event: %v", err)
+	}
+	if strings.Contains(rawEvent.DedupKey, "\x00") {
+		t.Fatalf("dedup key must not contain NUL bytes: %q", rawEvent.DedupKey)
+	}
+	if rawEvent.Provider != "claude" {
+		t.Fatalf("provider = %q, want claude", rawEvent.Provider)
+	}
+}


### PR DESCRIPTION
## Summary
- replace Claude raw-event dedup keys with a stable SHA-256 hash so Postgres never receives embedded NUL bytes during raw-event existence checks
- sanitize raw-event text fields at the Ent/Postgres boundary to strip NUL bytes and invalid UTF-8 before querying or persisting
- add a Postgres-backed regression test that reproduces the exact `pq: invalid byte sequence for encoding "UTF8": 0x00` failure path and proves the fix

## Validation
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator -run TestProjectRuntimeEventPersistsClaudeRawEventWithoutNULDedupKey -count=1`
- `OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator -count=1`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH make build`
- `OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/go1.26.1/bin:$PATH .codex/skills/push/scripts/openase_ci_gate.sh`

## Risks / Follow-up
- raw-event payload JSON is still stored as-is; this fix hardens text columns and the dedup key path that was crashing production projection
