### PR TITLE
fix: scope ticket run listing to the current ticket

### DIFF
--- a/internal/httpapi/agent_catalog_test.go
+++ b/internal/httpapi/agent_catalog_test.go
@@ -1222,12 +1222,47 @@ func (f *fakeCatalogService) ListAgents(_ context.Context, projectID uuid.UUID) 
 }
 
 func (f *fakeCatalogService) ListAgentRuns(_ context.Context, projectID uuid.UUID) ([]domain.AgentRun, error) {
+	if f.listAgentRunsErr != nil {
+		return nil, f.listAgentRunsErr
+	}
 	if _, ok := f.projects[projectID]; !ok {
 		return nil, catalogservice.ErrNotFound
 	}
 
 	items := make([]domain.AgentRun, 0)
 	for _, item := range f.agentRuns {
+		agentItem, ok := f.agents[item.AgentID]
+		if ok && agentItem.ProjectID == projectID {
+			items = append(items, item)
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID.String() > items[j].ID.String()
+		}
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+
+	return items, nil
+}
+
+func (f *fakeCatalogService) ListTicketRuns(_ context.Context, projectID uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error) {
+	if f.listTicketRunsErr != nil {
+		return nil, f.listTicketRunsErr
+	}
+	if _, ok := f.projects[projectID]; !ok {
+		return nil, catalogservice.ErrNotFound
+	}
+	ticketItem, ok := f.tickets[ticketID]
+	if !ok || ticketItem.ProjectID != projectID {
+		return nil, catalogservice.ErrNotFound
+	}
+
+	items := make([]domain.AgentRun, 0)
+	for _, item := range f.agentRuns {
+		if item.TicketID != ticketID {
+			continue
+		}
 		agentItem, ok := f.agents[item.AgentID]
 		if ok && agentItem.ProjectID == projectID {
 			items = append(items, item)

--- a/internal/httpapi/catalog_test.go
+++ b/internal/httpapi/catalog_test.go
@@ -51,6 +51,8 @@ type fakeCatalogService struct {
 	rawEvents            []domain.AgentRawEventEntry
 	activityInstances    []domain.AgentActivityInstance
 	transcriptEntries    []domain.AgentTranscriptEntry
+	listAgentRunsErr     error
+	listTicketRunsErr    error
 }
 
 type fakeCatalogTicket struct {

--- a/internal/httpapi/ticket_runs.go
+++ b/internal/httpapi/ticket_runs.go
@@ -639,22 +639,16 @@ func (s *Server) ensureTicketBelongsToProject(ctx context.Context, projectID uui
 }
 
 func (s *Server) loadTicketRunCatalog(ctx context.Context, projectID uuid.UUID, ticketID uuid.UUID) (ticketRunCatalog, error) {
-	runs, err := s.catalog.ListAgentRuns(ctx, projectID)
+	runs, err := s.catalog.ListTicketRuns(ctx, projectID, ticketID)
 	if err != nil {
 		return ticketRunCatalog{}, err
 	}
 
-	filteredRuns := make([]domain.AgentRun, 0)
-	for _, item := range runs {
-		if item.TicketID == ticketID {
-			filteredRuns = append(filteredRuns, item)
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i].CreatedAt.Equal(runs[j].CreatedAt) {
+			return runs[i].ID.String() < runs[j].ID.String()
 		}
-	}
-	sort.Slice(filteredRuns, func(i, j int) bool {
-		if filteredRuns[i].CreatedAt.Equal(filteredRuns[j].CreatedAt) {
-			return filteredRuns[i].ID.String() < filteredRuns[j].ID.String()
-		}
-		return filteredRuns[i].CreatedAt.Before(filteredRuns[j].CreatedAt)
+		return runs[i].CreatedAt.Before(runs[j].CreatedAt)
 	})
 
 	agents, err := s.catalog.ListAgents(ctx, projectID)
@@ -667,7 +661,7 @@ func (s *Server) loadTicketRunCatalog(ctx context.Context, projectID uuid.UUID, 
 	}
 
 	providerIndex := map[uuid.UUID]domain.AgentProvider{}
-	for _, item := range filteredRuns {
+	for _, item := range runs {
 		if _, ok := providerIndex[item.ProviderID]; ok {
 			continue
 		}
@@ -678,13 +672,13 @@ func (s *Server) loadTicketRunCatalog(ctx context.Context, projectID uuid.UUID, 
 		providerIndex[item.ProviderID] = providerItem
 	}
 
-	attempts := make(map[uuid.UUID]int, len(filteredRuns))
-	for idx, item := range filteredRuns {
+	attempts := make(map[uuid.UUID]int, len(runs))
+	for idx, item := range runs {
 		attempts[item.ID] = idx + 1
 	}
 
 	return ticketRunCatalog{
-		runs:      filteredRuns,
+		runs:      runs,
 		attempts:  attempts,
 		agents:    agentIndex,
 		providers: providerIndex,

--- a/internal/httpapi/ticket_runs_test.go
+++ b/internal/httpapi/ticket_runs_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -378,6 +379,124 @@ func TestTicketRunRoutesExposeRunNativeTranscriptData(t *testing.T) {
 	}
 	if len(detailPayload.StepEntries) != 2 || detailPayload.StepEntries[1].StepStatus != "running_tests" {
 		t.Fatalf("expected run-scoped step entries, got %+v", detailPayload.StepEntries)
+	}
+}
+
+func TestTicketRunRoutesUseTicketScopedRunQuery(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+
+	org, err := client.Organization.Create().
+		SetName("Acme").
+		SetSlug("acme-scoped").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create organization: %v", err)
+	}
+	project, err := client.Project.Create().
+		SetOrganizationID(org.ID).
+		SetName("OpenASE").
+		SetSlug("openase-scoped").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	statuses, err := newTicketStatusService(client).ResetToDefaultTemplate(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("reset statuses: %v", err)
+	}
+	backlogID := findStatusIDByName(t, statuses, "Backlog")
+
+	targetTicket, err := client.Ticket.Create().
+		SetProjectID(project.ID).
+		SetStatusID(backlogID).
+		SetIdentifier("ASE-243").
+		SetTitle("Fix ticket runs overfetch").
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create target ticket: %v", err)
+	}
+	otherTicket, err := client.Ticket.Create().
+		SetProjectID(project.ID).
+		SetStatusID(backlogID).
+		SetIdentifier("ASE-244").
+		SetTitle("Another ticket").
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create other ticket: %v", err)
+	}
+
+	catalog := newFakeCatalogService()
+	catalog.organizations[org.ID] = domain.Organization{ID: org.ID, Name: org.Name, Slug: org.Slug}
+	catalog.projects[project.ID] = domain.Project{ID: project.ID, OrganizationID: org.ID, Name: project.Name, Slug: project.Slug}
+	catalog.tickets[targetTicket.ID] = fakeCatalogTicket{ID: targetTicket.ID, ProjectID: project.ID}
+	catalog.tickets[otherTicket.ID] = fakeCatalogTicket{ID: otherTicket.ID, ProjectID: project.ID}
+	catalog.listAgentRunsErr = errors.New("unexpected project-wide run query")
+
+	providerID := uuid.New()
+	agentID := uuid.New()
+	targetRunID := uuid.New()
+	otherRunID := uuid.New()
+	catalog.providers[providerID] = domain.AgentProvider{
+		ID:             providerID,
+		OrganizationID: org.ID,
+		Name:           "Codex",
+		AdapterType:    domain.AgentProviderAdapterTypeCodexAppServer,
+		ModelName:      "gpt-5.4",
+	}
+	catalog.agents[agentID] = domain.Agent{ID: agentID, ProjectID: project.ID, ProviderID: providerID, Name: "Ticket Runner"}
+
+	now := time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC)
+	catalog.agentRuns[targetRunID] = domain.AgentRun{
+		ID:         targetRunID,
+		AgentID:    agentID,
+		TicketID:   targetTicket.ID,
+		ProviderID: providerID,
+		WorkflowID: uuid.New(),
+		Status:     domain.AgentRunStatusCompleted,
+		CreatedAt:  now,
+	}
+	catalog.agentRuns[otherRunID] = domain.AgentRun{
+		ID:         otherRunID,
+		AgentID:    agentID,
+		TicketID:   otherTicket.ID,
+		ProviderID: providerID,
+		WorkflowID: uuid.New(),
+		Status:     domain.AgentRunStatusCompleted,
+		CreatedAt:  now.Add(time.Minute),
+	}
+
+	server := NewServer(
+		config.ServerConfig{Port: 40023},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		newTicketService(client),
+		newTicketStatusService(client),
+		nil,
+		catalog,
+		nil,
+	)
+
+	rec := performJSONRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/api/v1/projects/"+project.ID.String()+"/tickets/"+targetTicket.ID.String()+"/runs",
+		"",
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected ticket runs 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Runs []ticketRunResponse `json:"runs"`
+	}
+	decodeResponse(t, rec, &payload)
+	if len(payload.Runs) != 1 || payload.Runs[0].ID != targetRunID.String() {
+		t.Fatalf("expected only target ticket runs, got %+v", payload.Runs)
 	}
 }
 

--- a/internal/repo/catalog/agent_catalog.go
+++ b/internal/repo/catalog/agent_catalog.go
@@ -182,6 +182,34 @@ func (r *EntRepository) ListAgentRuns(ctx context.Context, projectID uuid.UUID) 
 	return mapAgentRuns(items), nil
 }
 
+func (r *EntRepository) ListTicketRuns(ctx context.Context, projectID uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error) {
+	exists, err := r.client.Ticket.Query().
+		Where(
+			entticket.ID(ticketID),
+			entticket.ProjectIDEQ(projectID),
+		).
+		Exist(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("check ticket before listing agent runs: %w", err)
+	}
+	if !exists {
+		return nil, ErrNotFound
+	}
+
+	items, err := r.client.AgentRun.Query().
+		Where(
+			entagentrun.TicketIDEQ(ticketID),
+			entagentrun.HasTicketWith(entticket.ProjectIDEQ(projectID)),
+		).
+		Order(ent.Desc(entagentrun.FieldCreatedAt)).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list ticket agent runs: %w", err)
+	}
+
+	return mapAgentRuns(items), nil
+}
+
 func (r *EntRepository) CreateAgent(ctx context.Context, input domain.CreateAgent) (domain.Agent, error) {
 	project, err := r.client.Project.Get(ctx, input.ProjectID)
 	if err != nil {

--- a/internal/repo/catalog/agent_machine_activity_integration_test.go
+++ b/internal/repo/catalog/agent_machine_activity_integration_test.go
@@ -267,6 +267,9 @@ func TestEntRepositoryMachineAgentProviderAndActivityLifecycle(t *testing.T) {
 	if _, err := repo.ListAgentRuns(ctx, uuid.New()); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("ListAgentRuns(missing project) error = %v, want %v", err, ErrNotFound)
 	}
+	if _, err := repo.ListTicketRuns(ctx, uuid.New(), uuid.New()); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ListTicketRuns(missing ticket) error = %v, want %v", err, ErrNotFound)
+	}
 
 	orgB, err := repo.CreateOrganization(ctx, domain.CreateOrganization{
 		Name: "GrandCX",
@@ -397,6 +400,20 @@ func TestEntRepositoryMachineAgentProviderAndActivityLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create agent run: %v", err)
 	}
+	otherRunCreatedAt := runCreatedAt.Add(10 * time.Minute)
+	otherAgentRun, err := client.AgentRun.Create().
+		SetAgentID(createdAgent.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(otherTicketItem.ID).
+		SetProviderID(agentProvider.ID).
+		SetStatus(entagentrun.StatusCompleted).
+		SetSessionID("session-279").
+		SetTerminalAt(otherRunCreatedAt.Add(2 * time.Minute)).
+		SetCreatedAt(otherRunCreatedAt).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create secondary agent run: %v", err)
+	}
 	if _, err := client.Ticket.UpdateOneID(ticketItem.ID).SetCurrentRunID(agentRun.ID).Save(ctx); err != nil {
 		t.Fatalf("bind current run: %v", err)
 	}
@@ -441,8 +458,15 @@ func TestEntRepositoryMachineAgentProviderAndActivityLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAgentRuns() error = %v", err)
 	}
-	if len(agentRuns) != 1 || agentRuns[0].ID != agentRun.ID {
+	if len(agentRuns) != 2 || agentRuns[0].ID != otherAgentRun.ID || agentRuns[1].ID != agentRun.ID {
 		t.Fatalf("ListAgentRuns() = %+v", agentRuns)
+	}
+	ticketRuns, err := repo.ListTicketRuns(ctx, project.ID, ticketItem.ID)
+	if err != nil {
+		t.Fatalf("ListTicketRuns() error = %v", err)
+	}
+	if len(ticketRuns) != 1 || ticketRuns[0].ID != agentRun.ID {
+		t.Fatalf("ListTicketRuns() = %+v", ticketRuns)
 	}
 
 	gotRun, err := repo.GetAgentRun(ctx, agentRun.ID)
@@ -637,6 +661,9 @@ func TestEntRepositoryMachineAgentProviderAndActivityLifecycle(t *testing.T) {
 	}
 	if err := client.AgentRun.DeleteOneID(agentRun.ID).Exec(ctx); err != nil {
 		t.Fatalf("delete agent run: %v", err)
+	}
+	if err := client.AgentRun.DeleteOneID(otherAgentRun.ID).Exec(ctx); err != nil {
+		t.Fatalf("delete secondary agent run: %v", err)
 	}
 
 	deletedAgent, err := repo.DeleteAgent(ctx, createdAgent.ID)

--- a/internal/service/catalog/agent_catalog.go
+++ b/internal/service/catalog/agent_catalog.go
@@ -85,6 +85,15 @@ func (s *service) ListAgentRuns(ctx context.Context, projectID uuid.UUID) ([]dom
 	return s.repo.ListAgentRuns(ctx, projectID)
 }
 
+func (s *service) ListTicketRuns(ctx context.Context, projectID uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error) {
+	if allowed, err := s.allowsProjectScope(ctx, projectID); err != nil {
+		return nil, err
+	} else if !allowed {
+		return []domain.AgentRun{}, nil
+	}
+	return s.repo.ListTicketRuns(ctx, projectID, ticketID)
+}
+
 func (s *service) CreateAgent(ctx context.Context, input domain.CreateAgent) (domain.Agent, error) {
 	return s.repo.CreateAgent(ctx, input)
 }

--- a/internal/service/catalog/agent_catalog_test.go
+++ b/internal/service/catalog/agent_catalog_test.go
@@ -1196,6 +1196,16 @@ func (r *stubRepository) ListAgentRuns(context.Context, uuid.UUID) ([]domain.Age
 	return append([]domain.AgentRun(nil), r.agentRuns...), nil
 }
 
+func (r *stubRepository) ListTicketRuns(_ context.Context, _ uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error) {
+	items := make([]domain.AgentRun, 0)
+	for _, item := range r.agentRuns {
+		if item.TicketID == ticketID {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
 func (r *stubRepository) ListActivityEvents(context.Context, domain.ListActivityEvents) (domain.ActivityEventPage, error) {
 	return domain.ActivityEventPage{}, nil
 }

--- a/internal/service/catalog/coverage_test.go
+++ b/internal/service/catalog/coverage_test.go
@@ -106,6 +106,9 @@ func TestServiceDelegatesRepositoryWrappers(t *testing.T) {
 	if _, err := svc.ListAgentRuns(ctx, projectID); err != nil {
 		t.Fatalf("ListAgentRuns error = %v", err)
 	}
+	if _, err := svc.ListTicketRuns(ctx, projectID, ticketID); err != nil {
+		t.Fatalf("ListTicketRuns error = %v", err)
+	}
 	if _, err := svc.CreateAgent(ctx, domain.CreateAgent{ProjectID: projectID}); err != nil {
 		t.Fatalf("CreateAgent error = %v", err)
 	}

--- a/internal/service/catalog/interfaces.go
+++ b/internal/service/catalog/interfaces.go
@@ -77,6 +77,7 @@ type AgentService interface {
 
 type AgentRunQueryService interface {
 	ListAgentRuns(ctx context.Context, projectID uuid.UUID) ([]domain.AgentRun, error)
+	ListTicketRuns(ctx context.Context, projectID uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error)
 	GetAgentRun(ctx context.Context, id uuid.UUID) (domain.AgentRun, error)
 	ListAgentOutput(ctx context.Context, input domain.ListAgentOutput) ([]domain.AgentOutputEntry, error)
 	ListAgentSteps(ctx context.Context, input domain.ListAgentSteps) ([]domain.AgentStepEntry, error)
@@ -221,6 +222,7 @@ type AgentRepository interface {
 
 type AgentRunQueryRepository interface {
 	ListAgentRuns(ctx context.Context, projectID uuid.UUID) ([]domain.AgentRun, error)
+	ListTicketRuns(ctx context.Context, projectID uuid.UUID, ticketID uuid.UUID) ([]domain.AgentRun, error)
 	GetAgentRun(ctx context.Context, id uuid.UUID) (domain.AgentRun, error)
 	ListAgentOutput(ctx context.Context, input domain.ListAgentOutput) ([]domain.AgentOutputEntry, error)
 	ListAgentSteps(ctx context.Context, input domain.ListAgentSteps) ([]domain.AgentStepEntry, error)


### PR DESCRIPTION
## What
- add a ticket-scoped catalog/service/repository path for ticket run listing
- switch the ticket runs API to use the ticket-scoped query instead of loading project-wide runs and filtering in Go
- add regression coverage for the new route/service/repository behavior

## Why
`GET /api/v1/projects/:projectId/tickets/:ticketId/runs` was loading every run in the project before filtering to one ticket, so latency scaled with total project history instead of the ticket's own runs.

## Validation
- `go test ./internal/service/catalog ./internal/repo/catalog ./internal/httpapi`
