### PR TITLE
fix(web): recover stale project views after reconnect

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "pnpm run lint:eslint && pnpm run lint:i18n",
-    "lint:eslint": "eslint . --quiet",
+    "lint:eslint": "node scripts/run-eslint-with-heartbeat.mjs . --quiet",
     "lint:i18n": "node scripts/check-i18n-registry.mjs && node scripts/check-i18n.mjs",
     "lint:structure": "node scripts/check-file-budgets.mjs",
     "lint:deps": "node scripts/check-dependency-boundaries.mjs && node scripts/check-lockfile-security.mjs",

--- a/web/scripts/run-eslint-with-heartbeat.mjs
+++ b/web/scripts/run-eslint-with-heartbeat.mjs
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process'
+
+const heartbeatMs = Math.max(1_000, Number(process.env.ESLINT_HEARTBEAT_MS ?? 15_000))
+const eslintArgs = process.argv.slice(2)
+
+const child = spawn('pnpm', ['exec', 'eslint', ...eslintArgs], {
+  stdio: 'inherit',
+  env: process.env,
+})
+
+const heartbeat = setInterval(() => {
+  console.log(`[eslint-heartbeat] ${new Date().toISOString()} eslint still running`)
+}, heartbeatMs)
+
+child.on('exit', (code, signal) => {
+  clearInterval(heartbeat)
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 1)
+})
+
+child.on('error', (error) => {
+  clearInterval(heartbeat)
+  console.error('[eslint-heartbeat] failed to start eslint:', error)
+  process.exit(1)
+})

--- a/web/src/lib/features/agents/components/agents-page-streams.ts
+++ b/web/src/lib/features/agents/components/agents-page-streams.ts
@@ -1,5 +1,6 @@
 import { connectEventStream } from '$lib/api/sse'
 import {
+  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   readProjectDashboardRefreshSections,
   subscribeProjectEvents,
@@ -11,6 +12,9 @@ export function connectAgentsPageStreams(
   orgId: string,
   onEvent: () => void,
 ): () => void {
+  const recoverAfterReconnect = createProjectReconnectRecoveryTask(() => {
+    onEvent()
+  })
   const disconnectAgents = subscribeProjectEvents(
     projectId,
     (event) => {
@@ -29,7 +33,7 @@ export function connectAgentsPageStreams(
       }
     },
     {
-      onReconnect: onEvent,
+      onReconnectRecovery: recoverAfterReconnect,
     },
   )
   const disconnectProviders = connectEventStream(`/api/v1/orgs/${orgId}/providers/stream`, {

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
@@ -270,15 +270,26 @@ export function createOrgDashboardController() {
       true,
     )
 
-    const unsubscribeDashboard = subscribeProjectEvents(projectId, (event) => {
-      if (!isProjectDashboardRefreshEvent(event)) return
-      const sections = readProjectDashboardRefreshSections(event)
-      if (sections.length > 0) queueLoad(sections)
-    }, {
-      onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
-        queueLoad(['agents', 'tickets', 'activity', 'memory', 'hr_advisor', 'organization_summary'])
-      }),
-    })
+    const unsubscribeDashboard = subscribeProjectEvents(
+      projectId,
+      (event) => {
+        if (!isProjectDashboardRefreshEvent(event)) return
+        const sections = readProjectDashboardRefreshSections(event)
+        if (sections.length > 0) queueLoad(sections)
+      },
+      {
+        onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
+          queueLoad([
+            'agents',
+            'tickets',
+            'activity',
+            'memory',
+            'hr_advisor',
+            'organization_summary',
+          ])
+        }),
+      },
+    )
 
     const memoryInterval = window.setInterval(() => {
       queueLoad(['memory'])

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
@@ -8,6 +8,7 @@ import {
   updateProject,
 } from '$lib/api/openase'
 import {
+  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   readProjectDashboardRefreshSections,
   subscribeProjectEvents,
@@ -273,6 +274,10 @@ export function createOrgDashboardController() {
       if (!isProjectDashboardRefreshEvent(event)) return
       const sections = readProjectDashboardRefreshSections(event)
       if (sections.length > 0) queueLoad(sections)
+    }, {
+      onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
+        queueLoad(['agents', 'tickets', 'activity', 'memory', 'hr_advisor', 'organization_summary'])
+      }),
     })
 
     const memoryInterval = window.setInterval(() => {

--- a/web/src/lib/features/dashboard/components/org-dashboard.test.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard.test.ts
@@ -16,6 +16,7 @@ import {
 const projectEventListeners = new Set<(event: ProjectEventEnvelope) => void>()
 
 const {
+  subscribeProjectEvents,
   createProjectUpdateComment,
   createProjectUpdateThread,
   deleteProjectUpdateComment,
@@ -31,6 +32,7 @@ const {
   updateProjectUpdateComment,
   updateProjectUpdateThread,
 } = vi.hoisted(() => ({
+  subscribeProjectEvents: vi.fn(),
   createProjectUpdateComment: vi.fn(),
   createProjectUpdateThread: vi.fn(),
   deleteProjectUpdateComment: vi.fn(),
@@ -99,12 +101,14 @@ vi.mock('$lib/features/project-events', async () => {
   )
   return {
     ...actual,
-    subscribeProjectEvents: vi.fn((_: string, listener: (event: ProjectEventEnvelope) => void) => {
-      projectEventListeners.add(listener)
-      return () => {
-        projectEventListeners.delete(listener)
-      }
-    }),
+    subscribeProjectEvents: subscribeProjectEvents.mockImplementation(
+      (_: string, listener: (event: ProjectEventEnvelope) => void) => {
+        projectEventListeners.add(listener)
+        return () => {
+          projectEventListeners.delete(listener)
+        }
+      },
+    ),
   }
 })
 
@@ -224,6 +228,33 @@ describe('OrgDashboard', () => {
     expect(getHRAdvisor).toHaveBeenCalledTimes(1)
     expect(getProjectTokenUsage).toHaveBeenCalledTimes(1)
     expect(loadOrganizationDashboardSummary).toHaveBeenCalledTimes(1)
+  })
+
+  it('revalidates dashboard sections after reconnect even when no new post-reconnect event arrives', async () => {
+    render(OrgDashboard)
+
+    await waitFor(() => {
+      expect(listAgents).toHaveBeenCalledTimes(1)
+      expect(listTickets).toHaveBeenCalledTimes(1)
+      expect(listActivity).toHaveBeenCalledTimes(1)
+      expect(getSystemDashboard).toHaveBeenCalledTimes(1)
+      expect(getHRAdvisor).toHaveBeenCalledTimes(1)
+      expect(loadOrganizationDashboardSummary).toHaveBeenCalledTimes(1)
+    })
+
+    for (const [, , options] of subscribeProjectEvents.mock.calls) {
+      ;(options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined)
+        ?.onReconnectRecovery?.({ sequence: 1 })
+    }
+
+    await waitFor(() => {
+      expect(listAgents).toHaveBeenCalledTimes(2)
+      expect(listTickets).toHaveBeenCalledTimes(2)
+      expect(listActivity).toHaveBeenCalledTimes(2)
+      expect(getSystemDashboard).toHaveBeenCalledTimes(2)
+      expect(getHRAdvisor).toHaveBeenCalledTimes(2)
+      expect(loadOrganizationDashboardSummary).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('loads project token usage on the dashboard and refreshes the selected window', async () => {

--- a/web/src/lib/features/dashboard/components/org-dashboard.test.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard.test.ts
@@ -243,8 +243,9 @@ describe('OrgDashboard', () => {
     })
 
     for (const [, , options] of subscribeProjectEvents.mock.calls) {
-      ;(options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined)
-        ?.onReconnectRecovery?.({ sequence: 1 })
+      ;(
+        options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined
+      )?.onReconnectRecovery?.({ sequence: 1 })
     }
 
     await waitFor(() => {

--- a/web/src/lib/features/project-events/index.ts
+++ b/web/src/lib/features/project-events/index.ts
@@ -1,5 +1,4 @@
 export {
-  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   isProjectUpdateEvent,
   isTicketRunProjectEvent,
@@ -14,5 +13,8 @@ export {
   toProjectEventFrame,
   type ProjectDashboardRefreshSection,
   type ProjectEventEnvelope,
-  type ProjectReconnectRecovery,
 } from './project-event-bus'
+export {
+  createProjectReconnectRecoveryTask,
+  type ProjectReconnectRecovery,
+} from './project-reconnect-recovery'

--- a/web/src/lib/features/project-events/index.ts
+++ b/web/src/lib/features/project-events/index.ts
@@ -1,4 +1,5 @@
 export {
+  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   isProjectUpdateEvent,
   isTicketRunProjectEvent,
@@ -13,4 +14,5 @@ export {
   toProjectEventFrame,
   type ProjectDashboardRefreshSection,
   type ProjectEventEnvelope,
+  type ProjectReconnectRecovery,
 } from './project-event-bus'

--- a/web/src/lib/features/project-events/project-event-bus.test.ts
+++ b/web/src/lib/features/project-events/project-event-bus.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SSEFrame } from '$lib/api/sse'
 import {
+  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   projectEventAffectsTicketDetailReferences,
   projectEventReferencesTicket,
@@ -230,5 +231,60 @@ describe('projectEventBus', () => {
 
     unsubscribe()
     releaseShell()
+  })
+
+  it('emits ordered reconnect recovery sequences for each retry to live transition', () => {
+    const disconnect = vi.fn()
+    connectEventStream.mockReturnValue(disconnect)
+
+    const releaseShell = retainProjectEventBus('project-1')
+    const onReconnectRecovery = vi.fn()
+    const unsubscribe = subscribeProjectEvents('project-1', vi.fn(), { onReconnectRecovery })
+
+    const options = connectEventStream.mock.calls[0]?.[1] as {
+      onStateChange: (state: 'live' | 'idle' | 'connecting' | 'retrying') => void
+    }
+
+    options.onStateChange('connecting')
+    options.onStateChange('live')
+    expect(onReconnectRecovery).not.toHaveBeenCalled()
+
+    options.onStateChange('retrying')
+    options.onStateChange('live')
+    options.onStateChange('retrying')
+    options.onStateChange('live')
+
+    expect(onReconnectRecovery.mock.calls).toEqual([[{ sequence: 1 }], [{ sequence: 2 }]])
+
+    unsubscribe()
+    releaseShell()
+  })
+
+  it('coalesces quick reconnect recoveries into a single latest rerun while work is in flight', async () => {
+    const completions: Array<() => void> = []
+    const recover = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completions.push(resolve)
+        }),
+    )
+    const runRecovery = createProjectReconnectRecoveryTask(recover)
+
+    runRecovery({ sequence: 1 })
+    await Promise.resolve()
+    expect(recover).toHaveBeenCalledTimes(1)
+    expect(recover).toHaveBeenNthCalledWith(1, { sequence: 1 })
+
+    runRecovery({ sequence: 2 })
+    runRecovery({ sequence: 3 })
+    await Promise.resolve()
+    expect(recover).toHaveBeenCalledTimes(1)
+
+    completions.shift()?.()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(recover).toHaveBeenCalledTimes(2)
+    expect(recover).toHaveBeenNthCalledWith(2, { sequence: 3 })
   })
 })

--- a/web/src/lib/features/project-events/project-event-bus.test.ts
+++ b/web/src/lib/features/project-events/project-event-bus.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SSEFrame } from '$lib/api/sse'
 import {
-  createProjectReconnectRecoveryTask,
   isProjectDashboardRefreshEvent,
   projectEventAffectsTicketDetailReferences,
   projectEventReferencesTicket,
@@ -12,6 +11,7 @@ import {
   subscribeProjectEvents,
   toProjectEventFrame,
 } from './project-event-bus'
+import { createProjectReconnectRecoveryTask } from './project-reconnect-recovery'
 
 const { connectEventStream } = vi.hoisted(() => ({
   connectEventStream: vi.fn(),

--- a/web/src/lib/features/project-events/project-event-bus.ts
+++ b/web/src/lib/features/project-events/project-event-bus.ts
@@ -21,9 +21,14 @@ export type ProjectDashboardRefreshSection =
 type ProjectEventListener = (event: ProjectEventEnvelope) => void
 type ProjectEventStateListener = (state: StreamConnectionState) => void
 type ProjectEventReconnectListener = () => void
+export type ProjectReconnectRecovery = {
+  sequence: number
+}
+type ProjectEventReconnectRecoveryListener = (recovery: ProjectReconnectRecovery) => void
 
 type ProjectEventSubscriptionOptions = {
   onReconnect?: ProjectEventReconnectListener
+  onReconnectRecovery?: ProjectEventReconnectRecoveryListener
 }
 
 type Runtime = {
@@ -31,9 +36,11 @@ type Runtime = {
   retainers: number
   state: StreamConnectionState
   hasConnected: boolean
+  reconnectSequence: number
   disconnect: (() => void) | null
   eventListeners: Set<ProjectEventListener>
   reconnectListeners: Set<ProjectEventReconnectListener>
+  reconnectRecoveryListeners: Set<ProjectEventReconnectRecoveryListener>
   stateListeners: Set<ProjectEventStateListener>
 }
 
@@ -77,13 +84,53 @@ export function subscribeProjectEvents(
   if (options.onReconnect) {
     runtime.reconnectListeners.add(options.onReconnect)
   }
+  if (options.onReconnectRecovery) {
+    runtime.reconnectRecoveryListeners.add(options.onReconnectRecovery)
+  }
 
   return () => {
     runtime.eventListeners.delete(listener)
     if (options.onReconnect) {
       runtime.reconnectListeners.delete(options.onReconnect)
     }
+    if (options.onReconnectRecovery) {
+      runtime.reconnectRecoveryListeners.delete(options.onReconnectRecovery)
+    }
     cleanupRuntime(runtime)
+  }
+}
+
+// Reconnect recovery runs should refetch authoritative state after an outage window.
+// This helper coalesces quick retry/live flaps into a single in-order recovery pipeline.
+export function createProjectReconnectRecoveryTask(
+  recover: (recovery: ProjectReconnectRecovery) => Promise<void> | void,
+) {
+  let running = false
+  let queued: ProjectReconnectRecovery | null = null
+
+  const drain = async () => {
+    if (running) {
+      return
+    }
+
+    running = true
+    try {
+      while (queued) {
+        const nextRecovery = queued
+        queued = null
+        await recover(nextRecovery)
+      }
+    } finally {
+      running = false
+      if (queued) {
+        void drain()
+      }
+    }
+  }
+
+  return (recovery: ProjectReconnectRecovery) => {
+    queued = recovery
+    void drain()
   }
 }
 
@@ -200,9 +247,11 @@ function getRuntime(projectId: string): Runtime {
     retainers: 0,
     state: 'idle',
     hasConnected: false,
+    reconnectSequence: 0,
     disconnect: null,
     eventListeners: new Set(),
     reconnectListeners: new Set(),
+    reconnectRecoveryListeners: new Set(),
     stateListeners: new Set(),
   }
   runtimes.set(projectId, created)
@@ -232,11 +281,17 @@ function ensureRuntimeConnection(runtime: Runtime) {
         runtime.hasConnected = true
       } else if (state === 'idle') {
         runtime.hasConnected = false
+        runtime.reconnectSequence = 0
       }
       setRuntimeState(runtime, state)
       if (reconnected) {
+        runtime.reconnectSequence += 1
+        const recovery = { sequence: runtime.reconnectSequence }
         for (const listener of [...runtime.reconnectListeners]) {
           listener()
+        }
+        for (const listener of [...runtime.reconnectRecoveryListeners]) {
+          listener(recovery)
         }
       }
     },

--- a/web/src/lib/features/project-events/project-event-bus.ts
+++ b/web/src/lib/features/project-events/project-event-bus.ts
@@ -1,4 +1,5 @@
 import { connectEventStream, type SSEFrame, type StreamConnectionState } from '$lib/api/sse'
+import type { ProjectReconnectRecovery } from './project-reconnect-recovery'
 
 export type ProjectEventEnvelope = {
   topic: string
@@ -21,9 +22,6 @@ export type ProjectDashboardRefreshSection =
 type ProjectEventListener = (event: ProjectEventEnvelope) => void
 type ProjectEventStateListener = (state: StreamConnectionState) => void
 type ProjectEventReconnectListener = () => void
-export type ProjectReconnectRecovery = {
-  sequence: number
-}
 type ProjectEventReconnectRecoveryListener = (recovery: ProjectReconnectRecovery) => void
 
 type ProjectEventSubscriptionOptions = {
@@ -100,40 +98,6 @@ export function subscribeProjectEvents(
   }
 }
 
-// Reconnect recovery runs should refetch authoritative state after an outage window.
-// This helper coalesces quick retry/live flaps into a single in-order recovery pipeline.
-export function createProjectReconnectRecoveryTask(
-  recover: (recovery: ProjectReconnectRecovery) => Promise<void> | void,
-) {
-  let running = false
-  let queued: ProjectReconnectRecovery | null = null
-
-  const drain = async () => {
-    if (running) {
-      return
-    }
-
-    running = true
-    try {
-      while (queued) {
-        const nextRecovery = queued
-        queued = null
-        await recover(nextRecovery)
-      }
-    } finally {
-      running = false
-      if (queued) {
-        void drain()
-      }
-    }
-  }
-
-  return (recovery: ProjectReconnectRecovery) => {
-    queued = recovery
-    void drain()
-  }
-}
-
 export function subscribeProjectEventBusState(
   projectId: string,
   listener: ProjectEventStateListener,
@@ -152,15 +116,12 @@ export function isProjectUpdateEvent(event: Pick<ProjectEventEnvelope, 'type' | 
   return event.topic === 'activity.events' && event.type.startsWith('project_update_')
 }
 
-export function isTicketRunProjectEvent(event: Pick<ProjectEventEnvelope, 'topic'>) {
-  return event.topic === 'ticket.run.events'
-}
+export const isTicketRunProjectEvent = (event: Pick<ProjectEventEnvelope, 'topic'>) =>
+  event.topic === 'ticket.run.events'
 
-export function isProjectDashboardRefreshEvent(
+export const isProjectDashboardRefreshEvent = (
   event: Pick<ProjectEventEnvelope, 'topic' | 'type'>,
-) {
-  return event.topic === projectDashboardRefreshTopic && event.type === projectDashboardRefreshType
-}
+) => event.topic === projectDashboardRefreshTopic && event.type === projectDashboardRefreshType
 
 export function readProjectDashboardRefreshSections(
   event: Pick<ProjectEventEnvelope, 'payload'>,
@@ -191,13 +152,9 @@ export function projectEventAffectsTicketDetailReferences(
   event: Pick<ProjectEventEnvelope, 'topic' | 'type' | 'payload'>,
   ticketId: string,
 ) {
-  if (event.topic === 'ticket.events') {
+  if (event.topic === 'ticket.events')
     return readNestedString(event.payload, ['ticket', 'id']) !== ticketId
-  }
-
-  if (event.topic !== 'activity.events') {
-    return false
-  }
+  if (event.topic !== 'activity.events') return false
 
   const eventType = readNestedString(event.payload, ['event', 'event_type']) ?? event.type
   return (
@@ -307,9 +264,8 @@ function cleanupRuntime(runtime: Runtime) {
     runtime.disconnect === null &&
     runtime.eventListeners.size === 0 &&
     runtime.stateListeners.size === 0
-  ) {
+  )
     runtimes.delete(runtime.projectId)
-  }
 }
 
 function setRuntimeState(runtime: Runtime, state: StreamConnectionState) {

--- a/web/src/lib/features/project-events/project-reconnect-recovery.ts
+++ b/web/src/lib/features/project-events/project-reconnect-recovery.ts
@@ -1,0 +1,37 @@
+export type ProjectReconnectRecovery = {
+  sequence: number
+}
+
+// Reconnect recovery runs should refetch authoritative state after an outage window.
+// This helper coalesces quick retry/live flaps into a single in-order recovery pipeline.
+export function createProjectReconnectRecoveryTask(
+  recover: (recovery: ProjectReconnectRecovery) => Promise<void> | void,
+) {
+  let running = false
+  let queued: ProjectReconnectRecovery | null = null
+
+  const drain = async () => {
+    if (running) {
+      return
+    }
+
+    running = true
+    try {
+      while (queued) {
+        const nextRecovery = queued
+        queued = null
+        await recover(nextRecovery)
+      }
+    } finally {
+      running = false
+      if (queued) {
+        void drain()
+      }
+    }
+  }
+
+  return (recovery: ProjectReconnectRecovery) => {
+    queued = recovery
+    void drain()
+  }
+}

--- a/web/src/lib/features/project-updates/components/project-updates-page.cache.test.ts
+++ b/web/src/lib/features/project-updates/components/project-updates-page.cache.test.ts
@@ -106,8 +106,9 @@ describe('ProjectUpdatesPage cache behavior', () => {
     expect(await view.findByText('Sprint 2 rollout')).toBeTruthy()
 
     for (const [, , options] of subscribeProjectEvents.mock.calls) {
-      ;(options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined)
-        ?.onReconnectRecovery?.({ sequence: 1 })
+      ;(
+        options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined
+      )?.onReconnectRecovery?.({ sequence: 1 })
     }
 
     await waitFor(() => {

--- a/web/src/lib/features/project-updates/components/project-updates-page.cache.test.ts
+++ b/web/src/lib/features/project-updates/components/project-updates-page.cache.test.ts
@@ -6,6 +6,7 @@ import {
   makeProjectUpdatesPayload,
   makeThreadRecord,
   projectFixture,
+  subscribeProjectEvents,
   setupProjectUpdatesPageTest,
 } from './project-updates-page.test-support'
 import { ProjectUpdatesPage } from '..'
@@ -78,6 +79,40 @@ describe('ProjectUpdatesPage cache behavior', () => {
 
     await waitFor(() => {
       expect(secondRender.getByText('Sprint 2 rollout (fresh)')).toBeTruthy()
+    })
+  })
+
+  it('revalidates updates after reconnect even when no later stream event arrives', async () => {
+    appStore.currentProject = projectFixture
+    listProjectUpdates
+      .mockResolvedValueOnce(
+        makeProjectUpdatesPayload({
+          threads: [makeThreadRecord({ body_markdown: 'Sprint 2 rollout' })],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeProjectUpdatesPayload({
+          threads: [
+            makeThreadRecord({
+              title: 'Recovered rollout status',
+              body_markdown: 'Recovered rollout status',
+              last_activity_at: '2026-04-01T12:00:00Z',
+            }),
+          ],
+        }),
+      )
+
+    const view = render(ProjectUpdatesPage)
+    expect(await view.findByText('Sprint 2 rollout')).toBeTruthy()
+
+    for (const [, , options] of subscribeProjectEvents.mock.calls) {
+      ;(options as { onReconnectRecovery?: (recovery: { sequence: number }) => void } | undefined)
+        ?.onReconnectRecovery?.({ sequence: 1 })
+    }
+
+    await waitFor(() => {
+      expect(listProjectUpdates).toHaveBeenCalledTimes(2)
+      expect(view.getByText('Recovered rollout status')).toBeTruthy()
     })
   })
 })

--- a/web/src/lib/features/project-updates/project-updates-cache.ts
+++ b/web/src/lib/features/project-updates/project-updates-cache.ts
@@ -1,4 +1,8 @@
-import { isProjectUpdateEvent, subscribeProjectEvents } from '$lib/features/project-events'
+import {
+  createProjectReconnectRecoveryTask,
+  isProjectUpdateEvent,
+  subscribeProjectEvents,
+} from '$lib/features/project-events'
 import type { ProjectUpdateThread } from './types'
 
 type ProjectUpdatesSnapshot = {
@@ -87,11 +91,21 @@ function getRuntime(projectId: string) {
     dirty: false,
     unsubscribe: null,
   }
-  created.unsubscribe = subscribeProjectEvents(projectId, (event) => {
-    if (created.snapshot && isProjectUpdateEvent(event)) {
-      created.dirty = true
-    }
-  })
+  created.unsubscribe = subscribeProjectEvents(
+    projectId,
+    (event) => {
+      if (created.snapshot && isProjectUpdateEvent(event)) {
+        created.dirty = true
+      }
+    },
+    {
+      onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
+        if (created.snapshot) {
+          created.dirty = true
+        }
+      }),
+    },
+  )
   runtimes.set(projectId, created)
   return created
 }

--- a/web/src/lib/features/project-updates/project-updates-controller.svelte.ts
+++ b/web/src/lib/features/project-updates/project-updates-controller.svelte.ts
@@ -1,6 +1,10 @@
 import { ApiError } from '$lib/api/client'
 import { listProjectUpdates } from '$lib/api/openase'
-import { isProjectUpdateEvent, subscribeProjectEvents } from '$lib/features/project-events'
+import {
+  createProjectReconnectRecoveryTask,
+  isProjectUpdateEvent,
+  subscribeProjectEvents,
+} from '$lib/features/project-events'
 import { toastStore } from '$lib/stores/toast.svelte'
 import { mergeProjectUpdateThreads, parseProjectUpdatePage } from './model'
 import {
@@ -71,13 +75,22 @@ export function createProjectUpdatesController(input: CreateProjectUpdatesContro
       void refreshLatestThreads(projectId, { showLoading: true })
     }
 
-    return subscribeProjectEvents(projectId, (event) => {
-      if (!isProjectUpdateEvent(event)) {
-        return
-      }
-      markProjectUpdatesCacheDirty(projectId)
-      requestReload(projectId)
-    })
+    return subscribeProjectEvents(
+      projectId,
+      (event) => {
+        if (!isProjectUpdateEvent(event)) {
+          return
+        }
+        markProjectUpdatesCacheDirty(projectId)
+        requestReload(projectId)
+      },
+      {
+        onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
+          markProjectUpdatesCacheDirty(projectId)
+          requestReload(projectId)
+        }),
+      },
+    )
   })
 
   async function refreshLatestThreads(projectId: string, options: LoadProjectUpdatesOptions = {}) {

--- a/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
+++ b/web/src/lib/features/ticket-detail/components/ticket-drawer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { appStore } from '$lib/stores/app.svelte'
+  import { createProjectReconnectRecoveryTask } from '$lib/features/project-events'
   import { statusSync } from '$lib/features/statuses/public'
   import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '$ui/sheet'
   import { createTicketDrawerState } from '../drawer-state.svelte'
@@ -95,7 +96,14 @@
       return
     }
 
-    let runStreamNeedsRecovery = false
+    const recoverAfterReconnect = createProjectReconnectRecoveryTask(async () => {
+      drawerState.invalidateReferences(projectId)
+      await drawerState.load(projectId, ticketId, {
+        background: true,
+        preserveMessages: true,
+      })
+      await drawerState.recoverRunTranscript(projectId, ticketId)
+    })
 
     return connectTicketDetailStreams(projectId, ticketId, {
       onRelevantEvent: () => {
@@ -108,16 +116,9 @@
       onRunFrame: (frame) => {
         drawerState.applyRunStreamFrame(frame)
       },
+      onReconnectRecovery: recoverAfterReconnect,
       onRunStateChange: (state) => {
         drawerState.setRunStreamState(state)
-        if (state === 'retrying') {
-          runStreamNeedsRecovery = true
-          return
-        }
-        if (state === 'live' && runStreamNeedsRecovery) {
-          runStreamNeedsRecovery = false
-          void drawerState.recoverRunTranscript(projectId, ticketId)
-        }
       },
     })
   })

--- a/web/src/lib/features/ticket-detail/drawer-state-loading.test.ts
+++ b/web/src/lib/features/ticket-detail/drawer-state-loading.test.ts
@@ -72,4 +72,85 @@ describe('createTicketDrawerState loading refresh handling', () => {
     expect(state.ticket?.title).toBe('Runtime updated after queued event refresh')
     expect(state.timeline).toEqual(refreshedContext.timeline)
   })
+
+  it('authoritatively reloads timeline and references after a reconnect without clearing loaded runs', async () => {
+    const initialReferenceData = buildReferenceData()
+    const refreshedReferenceData = buildReferenceData({
+      statuses: [
+        { id: 'status-1', name: 'Todo', color: '#2563eb' },
+        { id: 'status-2', name: 'In Progress', color: '#16a34a' },
+      ],
+      statusLookup: [
+        { id: 'status-1', stage: 'unstarted', color: '#2563eb' },
+        { id: 'status-2', stage: 'started', color: '#16a34a' },
+      ],
+      repoOptions: [
+        { id: 'repo-1', name: 'openase', defaultBranch: 'main' },
+        { id: 'repo-2', name: 'automation', defaultBranch: 'main' },
+      ],
+    })
+    const initialContext = buildLiveContext()
+    const refreshedContext = buildLiveContext({
+      ticket: {
+        ...initialContext.ticket,
+        title: 'Recovered after reconnect',
+        status: { id: 'status-2', name: 'In Progress', color: '#16a34a' },
+      },
+      timeline: [
+        ...initialContext.timeline,
+        {
+          id: 'activity:event-recovered',
+          ticketId: 'ticket-1',
+          kind: 'activity',
+          actor: { name: 'runtime', type: 'system' },
+          eventType: 'ticket.updated',
+          title: 'ticket.updated',
+          bodyText: 'Recovered authoritative ticket detail after reconnect.',
+          createdAt: '2026-03-29T10:06:00Z',
+          updatedAt: '2026-03-29T10:06:00Z',
+          editedAt: undefined,
+          isCollapsible: true,
+          isDeleted: false,
+          metadata: {},
+        },
+      ],
+    })
+
+    const runDeps = createRunDeps()
+    const state = createTicketDrawerState({
+      fetchLiveContext: vi
+        .fn<
+          (
+            projectId: string,
+            ticketId: string,
+            refs: TicketDetailProjectReferenceData,
+          ) => Promise<TicketDetailLiveContext>
+        >()
+        .mockResolvedValueOnce(initialContext)
+        .mockResolvedValueOnce(refreshedContext),
+      fetchReferenceData: vi
+        .fn<(projectId: string) => Promise<TicketDetailProjectReferenceData>>()
+        .mockResolvedValueOnce(initialReferenceData)
+        .mockResolvedValueOnce(refreshedReferenceData),
+      ...runDeps,
+    })
+
+    await state.load('project-1', 'ticket-1')
+    await state.ensureRunsLoaded('project-1', 'ticket-1')
+
+    const initialRuns = state.runs
+    const initialRunBlocks = state.runBlocks
+
+    state.invalidateReferences('project-1')
+    await state.load('project-1', 'ticket-1', { background: true, preserveMessages: true })
+
+    expect(state.ticket?.title).toBe('Recovered after reconnect')
+    expect(state.ticket?.status.name).toBe('In Progress')
+    expect(state.timeline).toEqual(refreshedContext.timeline)
+    expect(state.statuses).toEqual(refreshedReferenceData.statuses)
+    expect(state.repoOptions).toEqual(refreshedReferenceData.repoOptions)
+    expect(state.runs).toBe(initialRuns)
+    expect(state.runBlocks).toBe(initialRunBlocks)
+    expect(runDeps.fetchRuns).toHaveBeenCalledTimes(1)
+  })
 })

--- a/web/src/lib/features/ticket-detail/drawer-state-recovery.test.ts
+++ b/web/src/lib/features/ticket-detail/drawer-state-recovery.test.ts
@@ -125,6 +125,9 @@ describe('createTicketDrawerState recovery', () => {
             },
           ],
         }),
+      fetchRunActivities: vi.fn().mockResolvedValue({ activities: [] }),
+      fetchRunTranscriptEntries: vi.fn().mockResolvedValue({ transcript_entries_page: undefined }),
+      fetchRunRawEvents: vi.fn().mockResolvedValue({ raw_events_page: undefined }),
     }
 
     const state = createTicketDrawerState({

--- a/web/src/lib/features/ticket-detail/streams.test.ts
+++ b/web/src/lib/features/ticket-detail/streams.test.ts
@@ -95,4 +95,27 @@ describe('connectTicketDetailStreams', () => {
       expect(onRunFrame).not.toHaveBeenCalled()
     },
   )
+
+  it('passes shared reconnect recovery notifications through to the drawer handlers', () => {
+    let reconnectRecovery:
+      | ((recovery: { sequence: number }) => void)
+      | undefined
+
+    subscribeProjectEvents.mockImplementation((_projectId, _listener, options) => {
+      reconnectRecovery = options?.onReconnectRecovery
+      return () => {}
+    })
+
+    const onReconnectRecovery = vi.fn()
+
+    connectTicketDetailStreams('project-1', 'ticket-1', {
+      onRelevantEvent: vi.fn(),
+      onRunFrame: vi.fn(),
+      onReconnectRecovery,
+    })
+
+    reconnectRecovery?.({ sequence: 2 })
+
+    expect(onReconnectRecovery).toHaveBeenCalledWith({ sequence: 2 })
+  })
 })

--- a/web/src/lib/features/ticket-detail/streams.test.ts
+++ b/web/src/lib/features/ticket-detail/streams.test.ts
@@ -97,9 +97,7 @@ describe('connectTicketDetailStreams', () => {
   )
 
   it('passes shared reconnect recovery notifications through to the drawer handlers', () => {
-    let reconnectRecovery:
-      | ((recovery: { sequence: number }) => void)
-      | undefined
+    let reconnectRecovery: ((recovery: { sequence: number }) => void) | undefined
 
     subscribeProjectEvents.mockImplementation((_projectId, _listener, options) => {
       reconnectRecovery = options?.onReconnectRecovery

--- a/web/src/lib/features/ticket-detail/streams.ts
+++ b/web/src/lib/features/ticket-detail/streams.ts
@@ -3,6 +3,7 @@ import {
   isTicketRunProjectEvent,
   projectEventAffectsTicketDetailReferences,
   projectEventReferencesTicket,
+  type ProjectReconnectRecovery,
   subscribeProjectEvents,
   subscribeProjectEventBusState,
   toProjectEventFrame,
@@ -15,20 +16,27 @@ export function connectTicketDetailStreams(
     onRelevantEvent: () => void
     onReferenceEvent?: () => void
     onRunFrame: (frame: SSEFrame) => void
+    onReconnectRecovery?: (recovery: ProjectReconnectRecovery) => void
     onRunStateChange?: (state: StreamConnectionState) => void
   },
 ) {
-  const disconnectProjectEvents = subscribeProjectEvents(projectId, (event) => {
-    if (projectEventReferencesTicket(event, ticketId)) {
-      handlers.onRelevantEvent()
-    }
-    if (isTicketRunProjectEvent(event) && projectEventReferencesTicket(event, ticketId)) {
-      handlers.onRunFrame(toProjectEventFrame(event))
-    }
-    if (projectEventAffectsTicketDetailReferences(event, ticketId)) {
-      handlers.onReferenceEvent?.()
-    }
-  })
+  const disconnectProjectEvents = subscribeProjectEvents(
+    projectId,
+    (event) => {
+      if (projectEventReferencesTicket(event, ticketId)) {
+        handlers.onRelevantEvent()
+      }
+      if (isTicketRunProjectEvent(event) && projectEventReferencesTicket(event, ticketId)) {
+        handlers.onRunFrame(toProjectEventFrame(event))
+      }
+      if (projectEventAffectsTicketDetailReferences(event, ticketId)) {
+        handlers.onReferenceEvent?.()
+      }
+    },
+    {
+      onReconnectRecovery: handlers.onReconnectRecovery,
+    },
+  )
   const disconnectRunState = subscribeProjectEventBusState(projectId, (state) => {
     handlers.onRunStateChange?.(state)
   })

--- a/web/src/lib/features/tickets/board-cache.ts
+++ b/web/src/lib/features/tickets/board-cache.ts
@@ -1,4 +1,7 @@
-import { subscribeProjectEvents } from '$lib/features/project-events'
+import {
+  createProjectReconnectRecoveryTask,
+  subscribeProjectEvents,
+} from '$lib/features/project-events'
 import type { BoardData } from '$lib/features/board'
 
 type BoardSnapshot = BoardData & {
@@ -103,11 +106,11 @@ function getRuntime(projectId: string) {
       }
     },
     {
-      onReconnect: () => {
+      onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
         if (created.snapshot) {
           created.dirty = true
         }
-      },
+      }),
     },
   )
   runtimes.set(projectId, created)

--- a/web/src/lib/features/tickets/components/tickets-page-controller.svelte.ts
+++ b/web/src/lib/features/tickets/components/tickets-page-controller.svelte.ts
@@ -8,6 +8,7 @@ import {
   listWorkflows,
 } from '$lib/api/openase'
 import { subscribeProjectEvents } from '$lib/features/project-events'
+import { createProjectReconnectRecoveryTask } from '$lib/features/project-events'
 import { statusSync } from '$lib/features/statuses/public'
 import {
   markProjectBoardCacheDirty,
@@ -243,10 +244,10 @@ export function createTicketsPageController() {
         requestReload(projectId)
       },
       {
-        onReconnect: () => {
+        onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
           markProjectBoardCacheDirty(projectId)
           requestReload(projectId)
-        },
+        }),
       },
     )
 


### PR DESCRIPTION
## Summary
- add a shared reconnect recovery contract on the project event bus so project-scoped consumers can detect outage-window recovery with ordered, coalesced reconnect sequences
- revalidate board, agents, ticket detail, dashboard, and project updates after reconnect so views converge even when no later SSE event arrives
- add outage-window regression coverage for reconnect recovery across shared bus, dashboard, ticket detail, and project updates
- keep `eslint` emitting heartbeat logs in web CI so the self-hosted runner no longer kills the quiet lint step before the reconnect fixes can clear workflow checks

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/project-events/project-event-bus.test.ts src/lib/features/board/components/board-page-reconnect.test.ts src/lib/features/agents/components/agents-page-reconnect.test.ts src/lib/features/dashboard/components/org-dashboard.test.ts src/lib/features/project-updates/components/project-updates-page.cache.test.ts src/lib/features/ticket-detail/streams.test.ts src/lib/features/ticket-detail/drawer-state-loading.test.ts src/lib/features/ticket-detail/drawer-state-recovery.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci`

## Notes
- The previous `Frontend Checks` failure was a quiet-runner termination during `eslint . --quiet`; this branch now wraps that step with a heartbeat script and `pnpm run ci` passes locally after syncing to `origin/main` (`34682c4`).
