### PR TITLE
ASE-245 Support full Project AI remote workspace capabilities

### DIFF
--- a/internal/chat/conversation_terminal_service.go
+++ b/internal/chat/conversation_terminal_service.go
@@ -298,6 +298,7 @@ type conversationTerminalManagedSession struct {
 
 	mu                 sync.Mutex
 	client             *conversationTerminalAttachedClient
+	clientReady        bool
 	pendingOutput      [][]byte
 	pendingOutputBytes int
 	closing            bool
@@ -358,6 +359,7 @@ func (s *conversationTerminalManagedSession) attach(
 	s.pendingOutputBytes = 0
 	client := newConversationTerminalAttachedClient(len(pendingOutput) + 1)
 	s.client = client
+	s.clientReady = false
 	s.meta.LastAttachedAt = &attachedAt
 	meta := s.meta
 	s.mu.Unlock()
@@ -443,7 +445,7 @@ func (s *conversationTerminalManagedSession) emitOutput(chunk []byte) {
 	copied := append([]byte(nil), chunk...)
 	s.mu.Lock()
 	client := s.client
-	if client == nil {
+	if client == nil || !s.clientReady {
 		s.queuePendingOutputLocked(copied)
 		s.mu.Unlock()
 		return
@@ -491,10 +493,27 @@ func (s *conversationTerminalManagedSession) flushPendingOutput(
 	if !s.sendEvent(client, ConversationTerminalEvent{Type: "ready"}) {
 		return
 	}
-	for _, chunk := range pendingOutput {
-		if !s.sendEvent(client, ConversationTerminalEvent{Type: "output", Data: append([]byte(nil), chunk...)}) {
+	queued := pendingOutput
+	for {
+		for _, chunk := range queued {
+			if !s.sendEvent(client, ConversationTerminalEvent{Type: "output", Data: append([]byte(nil), chunk...)}) {
+				return
+			}
+		}
+		s.mu.Lock()
+		if s.client != client {
+			s.mu.Unlock()
 			return
 		}
+		if len(s.pendingOutput) == 0 {
+			s.clientReady = true
+			s.mu.Unlock()
+			return
+		}
+		queued = append([][]byte(nil), s.pendingOutput...)
+		s.pendingOutput = nil
+		s.pendingOutputBytes = 0
+		s.mu.Unlock()
 	}
 }
 

--- a/internal/chat/conversation_terminal_service.go
+++ b/internal/chat/conversation_terminal_service.go
@@ -19,6 +19,7 @@ import (
 
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	chatdomain "github.com/BetterAndBetterII/openase/internal/domain/chatconversation"
+	"github.com/BetterAndBetterII/openase/internal/infra/machinetransport"
 	"github.com/creack/pty"
 	"github.com/google/uuid"
 )
@@ -120,7 +121,7 @@ func (s *ConversationTerminalService) CreateSession(
 	if s == nil || s.conversations == nil {
 		return ConversationTerminalSession{}, fmt.Errorf("conversation terminal service unavailable")
 	}
-	cwd, err := s.resolveConversationTerminalCWD(ctx, userID, conversationID, input)
+	machine, cwd, err := s.resolveConversationTerminalTarget(ctx, userID, conversationID, input)
 	if err != nil {
 		return ConversationTerminalSession{}, err
 	}
@@ -130,7 +131,7 @@ func (s *ConversationTerminalService) CreateSession(
 	}
 	createdAt := s.now()
 	sessionCtx, cancel := context.WithCancel(context.Background())
-	process, err := s.launch(sessionCtx, conversationTerminalLaunchSpec{
+	process, err := s.startSessionProcess(sessionCtx, machine, conversationTerminalLaunchSpec{
 		CWD:         cwd,
 		Cols:        input.Cols,
 		Rows:        input.Rows,
@@ -138,7 +139,7 @@ func (s *ConversationTerminalService) CreateSession(
 	})
 	if err != nil {
 		cancel()
-		return ConversationTerminalSession{}, fmt.Errorf("start local terminal session: %w", err)
+		return ConversationTerminalSession{}, err
 	}
 
 	session := &conversationTerminalManagedSession{
@@ -183,14 +184,33 @@ func (s *ConversationTerminalService) CloseSession(conversationID uuid.UUID, ses
 	return session.close()
 }
 
-func (s *ConversationTerminalService) resolveConversationTerminalCWD(
+func (s *ConversationTerminalService) startSessionProcess(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	spec conversationTerminalLaunchSpec,
+) (conversationTerminalProcess, error) {
+	if machine.Host == catalogdomain.LocalMachineHost {
+		process, err := s.launch(ctx, spec)
+		if err != nil {
+			return nil, fmt.Errorf("start local terminal session: %w", err)
+		}
+		return process, nil
+	}
+	process, err := s.startRemoteProcess(ctx, machine, spec)
+	if err != nil {
+		return nil, fmt.Errorf("start remote terminal session: %w", err)
+	}
+	return process, nil
+}
+
+func (s *ConversationTerminalService) resolveConversationTerminalTarget(
 	ctx context.Context,
 	userID UserID,
 	conversationID uuid.UUID,
 	input chatdomain.OpenTerminalSessionInput,
-) (string, error) {
+) (catalogdomain.Machine, string, error) {
 	if s.conversations == nil {
-		return "", fmt.Errorf("project conversation service unavailable")
+		return catalogdomain.Machine{}, "", fmt.Errorf("project conversation service unavailable")
 	}
 	if input.RepoPath != nil {
 		resolved, relativePath, err := s.conversations.resolveConversationWorkspaceRepoPath(
@@ -202,26 +222,38 @@ func (s *ConversationTerminalService) resolveConversationTerminalCWD(
 			true,
 		)
 		if err != nil {
-			return "", err
+			return catalogdomain.Machine{}, "", err
 		}
-		if resolved.machine.Host != catalogdomain.LocalMachineHost {
-			return "", ErrConversationTerminalUnsupported
+		cwd := resolved.repo.repoPath
+		if resolved.machine.Host == catalogdomain.LocalMachineHost {
+			cwd, err = resolveLocalProjectConversationWorkspaceDirectory(resolved.repo.repoPath, relativePath)
+			if err != nil {
+				return catalogdomain.Machine{}, "", err
+			}
+		} else if relativePath != "" {
+			cwd = filepath.Join(resolved.repo.repoPath, filepath.FromSlash(relativePath))
 		}
-		return resolveLocalProjectConversationWorkspaceDirectory(resolved.repo.repoPath, relativePath)
+		return resolved.machine, cwd, nil
 	}
 
 	_, location, err := s.conversations.resolveConversationWorkspace(ctx, userID, conversationID)
 	if err != nil {
-		return "", err
-	}
-	if location.machine.Host != catalogdomain.LocalMachineHost {
-		return "", ErrConversationTerminalUnsupported
+		return catalogdomain.Machine{}, "", err
 	}
 	relativePath, err := parseProjectConversationWorkspaceRelativePath(valueOrEmpty(input.CWDPath), true)
 	if err != nil {
-		return "", err
+		return catalogdomain.Machine{}, "", err
 	}
-	return resolveLocalProjectConversationWorkspaceDirectory(location.workspacePath, relativePath)
+	cwd := location.workspacePath
+	if location.machine.Host == catalogdomain.LocalMachineHost {
+		cwd, err = resolveLocalProjectConversationWorkspaceDirectory(location.workspacePath, relativePath)
+		if err != nil {
+			return catalogdomain.Machine{}, "", err
+		}
+	} else if relativePath != "" {
+		cwd = filepath.Join(location.workspacePath, filepath.FromSlash(relativePath))
+	}
+	return location.machine, cwd, nil
 }
 
 type conversationTerminalRegistry struct {
@@ -513,6 +545,10 @@ func conversationTerminalExitFromError(err error) conversationTerminalExit {
 		}
 		return exit
 	}
+	var runtimeExit machinetransport.ProcessExitError
+	if errors.As(err, &runtimeExit) {
+		return conversationTerminalExit{Code: runtimeExit.ExitStatus()}
+	}
 	if errors.Is(err, context.Canceled) {
 		return conversationTerminalExit{Code: 0}
 	}
@@ -592,6 +628,153 @@ func (p *localConversationTerminalProcess) Resize(cols int, rows int) error {
 
 func (p *localConversationTerminalProcess) Wait() error {
 	return p.cmd.Wait()
+}
+
+type remoteConversationTerminalProcess struct {
+	session machinetransport.CommandSession
+	stdin   io.WriteCloser
+	merged  *io.PipeReader
+	writer  *io.PipeWriter
+	writeMu sync.Mutex
+	done    chan struct{}
+	waitErr error
+	once    sync.Once
+}
+
+func (p *remoteConversationTerminalProcess) Read(buffer []byte) (int, error) {
+	return p.merged.Read(buffer)
+}
+
+func (p *remoteConversationTerminalProcess) Write(buffer []byte) (int, error) {
+	return p.stdin.Write(buffer)
+}
+
+func (p *remoteConversationTerminalProcess) Close() error {
+	closeErr := error(nil)
+	p.once.Do(func() {
+		if p.stdin != nil {
+			_ = p.stdin.Close()
+		}
+		if p.session != nil {
+			closeErr = p.session.Close()
+		}
+	})
+	return closeErr
+}
+
+func (p *remoteConversationTerminalProcess) Resize(cols int, rows int) error {
+	size, err := conversationTerminalPTYSize(cols, rows)
+	if err != nil {
+		return err
+	}
+	_ = size
+	return nil
+}
+
+func (p *remoteConversationTerminalProcess) Wait() error {
+	if p == nil {
+		return fmt.Errorf("remote terminal session unavailable")
+	}
+	<-p.done
+	return p.waitErr
+}
+
+func (s *ConversationTerminalService) startRemoteProcess(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	spec conversationTerminalLaunchSpec,
+) (conversationTerminalProcess, error) {
+	if s == nil || s.conversations == nil {
+		return nil, ErrConversationTerminalUnsupported
+	}
+	session, err := s.conversations.openProjectConversationCommandSession(ctx, machine, "terminal")
+	if err != nil {
+		if errors.Is(err, machinetransport.ErrTransportUnavailable) {
+			return nil, ErrConversationTerminalUnsupported
+		}
+		return nil, err
+	}
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		_ = session.Close()
+		return nil, fmt.Errorf("open remote terminal stdin: %w", err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = session.Close()
+		return nil, fmt.Errorf("open remote terminal stdout: %w", err)
+	}
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = session.Close()
+		return nil, fmt.Errorf("open remote terminal stderr: %w", err)
+	}
+
+	reader, writer := io.Pipe()
+	process := &remoteConversationTerminalProcess{
+		session: session,
+		stdin:   stdin,
+		merged:  reader,
+		writer:  writer,
+		done:    make(chan struct{}),
+	}
+
+	if err := session.Start(buildRemoteConversationTerminalCommand(spec)); err != nil {
+		_ = stdin.Close()
+		_ = session.Close()
+		_ = writer.CloseWithError(err)
+		return nil, fmt.Errorf("start remote terminal shell: %w", err)
+	}
+	go process.copyOutput(stdout)
+	go process.copyOutput(stderr)
+	go process.waitLoop()
+	return process, nil
+}
+
+func (p *remoteConversationTerminalProcess) copyOutput(reader io.Reader) {
+	if reader == nil || p == nil || p.writer == nil {
+		return
+	}
+	buffer := make([]byte, 4096)
+	for {
+		count, err := reader.Read(buffer)
+		if count > 0 {
+			p.writeMu.Lock()
+			_, _ = p.writer.Write(buffer[:count])
+			p.writeMu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (p *remoteConversationTerminalProcess) waitLoop() {
+	if p == nil {
+		return
+	}
+	p.waitErr = p.session.Wait()
+	_ = p.writer.Close()
+	close(p.done)
+}
+
+func buildRemoteConversationTerminalCommand(spec conversationTerminalLaunchSpec) string {
+	cwd := strings.TrimSpace(spec.CWD)
+	command := []string{}
+	if cwd != "" {
+		command = append(command, "cd "+projectConversationShellQuote(cwd))
+	}
+	command = append(command,
+		`if [ -n "${SHELL:-}" ] && command -v "$SHELL" >/dev/null 2>&1; then shell="$SHELL"; `+
+			`elif command -v bash >/dev/null 2>&1; then shell="$(command -v bash)"; `+
+			`elif command -v zsh >/dev/null 2>&1; then shell="$(command -v zsh)"; `+
+			`else shell="$(command -v sh)"; fi`,
+		`exec env TERM=xterm-256color "$shell" -i`,
+	)
+	return "sh -lc " + projectConversationShellQuote(strings.Join(command, " && "))
 }
 
 func resolveLocalConversationTerminalShellArgs() ([]string, error) {

--- a/internal/chat/conversation_terminal_service_test.go
+++ b/internal/chat/conversation_terminal_service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -347,6 +348,115 @@ func TestConversationTerminalServiceCloseTriggersCleanup(t *testing.T) {
 		t.Fatal("expected process close to be called")
 	}
 	awaitConversationTerminalCleanup(t, service, fixture.conversation.ID, session.ID)
+}
+
+func TestConversationTerminalServiceSupportsWebsocketRuntime(t *testing.T) {
+	t.Parallel()
+
+	fixture := setupProjectConversationWorkspaceWebsocketFixture(t, []projectConversationWorkspaceRepoFixture{{
+		name: "backend",
+		files: map[string]string{
+			"src/main.go": "package main\n",
+		},
+	}})
+	service := NewConversationTerminalService(nil, fixture.service)
+
+	repoPath := "backend"
+	cwdPath := "src"
+	input, err := chatdomain.ParseOpenTerminalSessionInput(chatdomain.OpenTerminalSessionRawInput{
+		Mode:     "shell",
+		RepoPath: &repoPath,
+		CWDPath:  &cwdPath,
+	})
+	if err != nil {
+		t.Fatalf("ParseOpenTerminalSessionInput() error = %v", err)
+	}
+
+	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	if session.CWD != filepath.Join(fixture.repoPaths["backend"], "src") {
+		t.Fatalf("session cwd = %q", session.CWD)
+	}
+
+	attachment, err := service.AttachSession(
+		UserID("user:conversation"),
+		fixture.conversation.ID,
+		session.ID,
+		session.AttachToken,
+	)
+	if err != nil {
+		t.Fatalf("AttachSession() error = %v", err)
+	}
+	if ready := requireConversationTerminalEvent(t, attachment.Events); ready.Type != "ready" {
+		t.Fatalf("ready event = %+v", ready)
+	}
+
+	if err := attachment.Resize(120, 40); err != nil {
+		t.Fatalf("Resize() error = %v", err)
+	}
+	if err := attachment.WriteInput([]byte("printf 'REMOTE_OK\\n'; exit\n")); err != nil {
+		t.Fatalf("WriteInput() error = %v", err)
+	}
+
+	output := collectConversationTerminalOutput(t, attachment.Events, "REMOTE_OK")
+	if !strings.Contains(output, "REMOTE_OK") {
+		t.Fatalf("unexpected websocket terminal output %q", output)
+	}
+
+	exit := awaitConversationTerminalExit(t, attachment.Events)
+	if exit.Type != "exit" || exit.ExitCode != 0 {
+		t.Fatalf("exit event = %+v", exit)
+	}
+	awaitConversationTerminalCleanup(t, service, fixture.conversation.ID, session.ID)
+}
+
+func collectConversationTerminalOutput(
+	t *testing.T,
+	events <-chan ConversationTerminalEvent,
+	want string,
+) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var builder strings.Builder
+	for time.Now().Before(deadline) {
+		event := requireConversationTerminalEvent(t, events)
+		switch event.Type {
+		case "output":
+			builder.Write(event.Data)
+			if strings.Contains(builder.String(), want) {
+				return builder.String()
+			}
+		case "error":
+			t.Fatalf("unexpected terminal error event: %+v", event)
+		case "exit":
+			t.Fatalf("terminal exited before output %q arrived: %+v", want, event)
+		}
+	}
+	t.Fatalf("timed out waiting for terminal output %q", want)
+	return ""
+}
+
+func awaitConversationTerminalExit(
+	t *testing.T,
+	events <-chan ConversationTerminalEvent,
+) ConversationTerminalEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		event := requireConversationTerminalEvent(t, events)
+		switch event.Type {
+		case "exit":
+			return event
+		case "output":
+			continue
+		case "error":
+			t.Fatalf("unexpected terminal error event: %+v", event)
+		}
+	}
+	t.Fatal("timed out waiting for terminal exit")
+	return ConversationTerminalEvent{}
 }
 
 func requireConversationTerminalEvent(t *testing.T, events <-chan ConversationTerminalEvent) ConversationTerminalEvent {

--- a/internal/chat/conversation_terminal_service_test.go
+++ b/internal/chat/conversation_terminal_service_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const conversationTerminalTestEventTimeout = 2 * time.Second
+
 type fakeConversationTerminalProcess struct {
 	reader *io.PipeReader
 	writer *io.PipeWriter
@@ -467,7 +469,7 @@ func requireConversationTerminalEvent(t *testing.T, events <-chan ConversationTe
 			t.Fatal("expected terminal event, got closed channel")
 		}
 		return event
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(conversationTerminalTestEventTimeout):
 		t.Fatal("timed out waiting for terminal event")
 		return ConversationTerminalEvent{}
 	}

--- a/internal/chat/project_conversation_remote_command.go
+++ b/internal/chat/project_conversation_remote_command.go
@@ -1,0 +1,58 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	"github.com/BetterAndBetterII/openase/internal/infra/machinetransport"
+)
+
+func (s *ProjectConversationService) openProjectConversationCommandSession(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	purpose string,
+) (machinetransport.CommandSession, error) {
+	if s == nil || s.runtimeManager == nil {
+		return nil, fmt.Errorf("project conversation runtime manager unavailable for %s", purpose)
+	}
+	resolved, err := s.runtimeManager.resolveRuntimeTransport(machine)
+	if err != nil {
+		return nil, err
+	}
+	executor := resolved.CommandSessionExecutor()
+	if executor == nil {
+		return nil, fmt.Errorf(
+			"%w: command session unavailable for %s on machine %s",
+			machinetransport.ErrTransportUnavailable,
+			purpose,
+			machine.Name,
+		)
+	}
+	session, err := executor.OpenCommandSession(ctx, machine)
+	if err != nil {
+		return nil, fmt.Errorf("open remote command session for %s: %w", purpose, err)
+	}
+	return session, nil
+}
+
+func (s *ProjectConversationService) runProjectConversationRemoteCommand(
+	ctx context.Context,
+	machine catalogdomain.Machine,
+	command string,
+	allowExitCodeOne bool,
+	purpose string,
+) ([]byte, error) {
+	session, err := s.openProjectConversationCommandSession(ctx, machine, purpose)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = session.Close() }()
+
+	output, err := session.CombinedOutput(command)
+	if err != nil && (!allowExitCodeOne || !projectConversationCommandExitedWithCode(err, 1)) {
+		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}

--- a/internal/chat/project_conversation_service_test.go
+++ b/internal/chat/project_conversation_service_test.go
@@ -5607,6 +5607,122 @@ func TestProjectConversationWorkspaceBrowser(t *testing.T) {
 		}
 	})
 
+	t.Run("websocket runtime keeps workspace browse edit and git flows available", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := setupProjectConversationWorkspaceWebsocketFixture(t, []projectConversationWorkspaceRepoFixture{
+			{
+				name: "backend",
+				files: map[string]string{
+					"README.md":  "line one\nline two\n",
+					"src/app.ts": "export const app = 1\n",
+				},
+			},
+		})
+
+		metadata, err := fixture.service.GetWorkspaceMetadata(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+		)
+		if err != nil {
+			t.Fatalf("GetWorkspaceMetadata() error = %v", err)
+		}
+		if !metadata.Available || len(metadata.Repos) != 1 || metadata.Repos[0].Path != "backend" {
+			t.Fatalf("unexpected websocket workspace metadata: %+v", metadata)
+		}
+
+		tree, err := fixture.service.ListWorkspaceTree(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			"backend",
+			"src",
+		)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTree() error = %v", err)
+		}
+		if len(tree.Entries) != 1 || tree.Entries[0].Path != "src/app.ts" {
+			t.Fatalf("unexpected websocket tree entries: %+v", tree.Entries)
+		}
+
+		preview, err := fixture.service.ReadWorkspaceFilePreview(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			"backend",
+			"src/app.ts",
+		)
+		if err != nil {
+			t.Fatalf("ReadWorkspaceFilePreview() error = %v", err)
+		}
+		if preview.PreviewKind != ProjectConversationWorkspacePreviewKindText || !strings.Contains(preview.Content, "app = 1") {
+			t.Fatalf("unexpected websocket preview: %+v", preview)
+		}
+
+		saved, err := fixture.service.SaveWorkspaceFile(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			ProjectConversationWorkspaceFileSaveInput{
+				RepoPath:     WorkspaceRepoPath("backend"),
+				Path:         WorkspaceFilePath("src/app.ts"),
+				BaseRevision: WorkspaceFileRevision(preview.Revision),
+				Content:      WorkspaceTextContent("export const app = 2\n"),
+				Encoding:     WorkspaceEncodingUTF8,
+				LineEnding:   WorkspaceLineEndingLF,
+			},
+		)
+		if err != nil {
+			t.Fatalf("SaveWorkspaceFile() error = %v", err)
+		}
+		if saved.Revision == preview.Revision {
+			t.Fatalf("expected websocket save to update revision, got %+v", saved)
+		}
+
+		if _, err := fixture.service.StageWorkspaceFile(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			ProjectConversationWorkspaceStageFileInput{
+				RepoPath: WorkspaceRepoPath("backend"),
+				Path:     "src/app.ts",
+			},
+		); err != nil {
+			t.Fatalf("StageWorkspaceFile() error = %v", err)
+		}
+
+		committed, err := fixture.service.CommitWorkspace(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			ProjectConversationWorkspaceCommitInput{
+				RepoPath: WorkspaceRepoPath("backend"),
+				Message:  "workspace websocket edit",
+			},
+		)
+		if err != nil {
+			t.Fatalf("CommitWorkspace() error = %v", err)
+		}
+		if !strings.Contains(committed.Output, "workspace websocket edit") {
+			t.Fatalf("unexpected websocket commit output: %+v", committed)
+		}
+
+		graph, err := fixture.service.GetWorkspaceGitGraph(
+			fixture.ctx,
+			UserID("user:conversation"),
+			fixture.conversation.ID,
+			WorkspaceRepoPath("backend"),
+			WorkspaceGitGraphWindow{Limit: 10},
+		)
+		if err != nil {
+			t.Fatalf("GetWorkspaceGitGraph() error = %v", err)
+		}
+		if len(graph.Commits) == 0 || graph.Commits[0].Subject != "workspace websocket edit" {
+			t.Fatalf("unexpected websocket git graph: %+v", graph.Commits)
+		}
+	})
+
 	t.Run("scopes access to the repo root", func(t *testing.T) {
 		t.Parallel()
 
@@ -6539,6 +6655,109 @@ func setupProjectConversationWorkspaceDiffFixture(
 			Name:          catalogdomain.LocalMachineName,
 			Host:          catalogdomain.LocalMachineHost,
 			WorkspaceRoot: stringPointer(workspaceRoot),
+		},
+	}
+
+	service := NewProjectConversationService(
+		nil,
+		repoStore,
+		catalog,
+		fakeTicketReader{},
+		harnessWorkflowReader{},
+		nil,
+		nil,
+	)
+	workspace, err := service.ensureConversationWorkspace(ctx, catalog.machine, projectItem, providerItem, conversation.ID)
+	if err != nil {
+		t.Fatalf("ensureConversationWorkspace() error = %v", err)
+	}
+
+	repoPaths := make(map[string]string, len(projectRepos))
+	for _, repo := range projectRepos {
+		repoPaths[repo.Name] = workspaceinfra.RepoPath(workspace.String(), repo.WorkspaceDirname, repo.Name)
+	}
+
+	return projectConversationWorkspaceDiffFixture{
+		ctx:           ctx,
+		service:       service,
+		catalog:       catalog,
+		conversation:  conversation,
+		workspacePath: workspace.String(),
+		repoPaths:     repoPaths,
+	}
+}
+
+func setupProjectConversationWorkspaceWebsocketFixture(
+	t *testing.T,
+	repos []projectConversationWorkspaceRepoFixture,
+) projectConversationWorkspaceDiffFixture {
+	t.Helper()
+
+	server := httptest.NewServer(machinetransport.NewWebsocketListenerHandler(machinetransport.ListenerHandlerOptions{}))
+	t.Cleanup(server.Close)
+
+	client := openTestEntClient(t)
+	ctx := context.Background()
+	org, project := createProjectConversationTestProject(ctx, t, client)
+	repoStore := chatrepo.NewEntRepository(client)
+	providerID := uuid.New()
+	machineID := uuid.New()
+	conversation, err := repoStore.CreateConversation(ctx, chatdomain.CreateConversation{
+		ProjectID:  project.ID,
+		UserID:     "user:conversation",
+		Source:     chatdomain.SourceProjectSidebar,
+		ProviderID: providerID,
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	projectRepos := make([]catalogdomain.ProjectRepo, 0, len(repos))
+	for _, repo := range repos {
+		remoteRepoPath, _ := createConversationRemoteRepo(t, "main", repo.files)
+		projectRepo := catalogdomain.ProjectRepo{
+			ID:            uuid.New(),
+			ProjectID:     project.ID,
+			Name:          repo.name,
+			RepositoryURL: remoteRepoPath,
+			DefaultBranch: "main",
+		}
+		if strings.TrimSpace(repo.workspaceDirname) != "" {
+			projectRepo.WorkspaceDirname = repo.workspaceDirname
+		}
+		projectRepos = append(projectRepos, projectRepo)
+	}
+
+	workspaceRoot := t.TempDir()
+	projectItem := catalogdomain.Project{
+		ID:             project.ID,
+		OrganizationID: org.ID,
+		Name:           "OpenASE",
+		Slug:           "openase",
+		Description:    "Issue-driven automation",
+	}
+	providerItem := catalogdomain.AgentProvider{
+		ID:             providerID,
+		OrganizationID: org.ID,
+		MachineID:      machineID,
+		AdapterType:    catalogdomain.AgentProviderAdapterTypeGeminiCLI,
+		CliCommand:     "gemini",
+	}
+	catalog := &fakeProjectConversationCatalog{
+		fakeCatalogReader: fakeCatalogReader{
+			project:      projectItem,
+			projectRepos: projectRepos,
+			providerByID: map[uuid.UUID]catalogdomain.AgentProvider{
+				providerID: providerItem,
+			},
+		},
+		machine: catalogdomain.Machine{
+			ID:                 machineID,
+			Name:               "listener-01",
+			Host:               "listener.internal",
+			WorkspaceRoot:      stringPointer(workspaceRoot),
+			ConnectionMode:     catalogdomain.MachineConnectionModeWSListener,
+			AdvertisedEndpoint: stringPointer(projectConversationWebsocketURL(server.URL)),
 		},
 	}
 

--- a/internal/chat/project_conversation_workspace_browser.go
+++ b/internal/chat/project_conversation_workspace_browser.go
@@ -16,7 +16,6 @@ import (
 
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	chatdomain "github.com/BetterAndBetterII/openase/internal/domain/chatconversation"
-	sshinfra "github.com/BetterAndBetterII/openase/internal/infra/ssh"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
 	"github.com/google/uuid"
 )
@@ -734,24 +733,13 @@ func (s *ProjectConversationService) runProjectConversationShellCommand(
 		}
 		return output, nil
 	}
-	if s == nil || s.core.sshPool == nil {
-		return nil, fmt.Errorf("ssh pool unavailable for machine %s", machine.Name)
-	}
-	client, err := s.core.sshPool.Get(ctx, machine)
-	if err != nil {
-		return nil, err
-	}
-	session, err := client.NewSession()
-	if err != nil {
-		return nil, fmt.Errorf("open ssh session for workspace browser: %w", err)
-	}
-	defer func() { _ = session.Close() }()
-
-	output, err := session.CombinedOutput("sh -lc " + sshinfra.ShellQuote(script))
-	if err != nil && (!allowExitCodeOne || !strings.Contains(err.Error(), "exit status 1")) {
-		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
-	}
-	return output, nil
+	return s.runProjectConversationRemoteCommand(
+		ctx,
+		machine,
+		"sh -lc "+projectConversationShellQuote(script),
+		allowExitCodeOne,
+		"workspace browser",
+	)
 }
 
 func (s *ProjectConversationService) readConversationWorkspaceFilePreview(

--- a/internal/chat/project_conversation_workspace_diff.go
+++ b/internal/chat/project_conversation_workspace_diff.go
@@ -13,7 +13,7 @@ import (
 
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	chatdomain "github.com/BetterAndBetterII/openase/internal/domain/chatconversation"
-	sshinfra "github.com/BetterAndBetterII/openase/internal/infra/ssh"
+	"github.com/BetterAndBetterII/openase/internal/infra/machinetransport"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
 	"github.com/google/uuid"
 )
@@ -347,29 +347,17 @@ func (s *ProjectConversationService) runProjectConversationGitCommand(
 		}
 		return output, nil
 	}
-	if s == nil || s.core.sshPool == nil {
-		return nil, fmt.Errorf("ssh pool unavailable for machine %s", machine.Name)
-	}
-
-	client, err := s.core.sshPool.Get(ctx, machine)
-	if err != nil {
-		return nil, err
-	}
-	session, err := client.NewSession()
-	if err != nil {
-		return nil, fmt.Errorf("open ssh session for workspace diff: %w", err)
-	}
-	defer func() { _ = session.Close() }()
-
 	quoted := make([]string, 0, len(args))
 	for _, arg := range args {
-		quoted = append(quoted, sshinfra.ShellQuote(arg))
+		quoted = append(quoted, projectConversationShellQuote(arg))
 	}
-	output, err := session.CombinedOutput("sh -lc " + sshinfra.ShellQuote(strings.Join(quoted, " ")))
-	if err != nil && (!allowExitCodeOne || !strings.Contains(err.Error(), "exit status 1")) {
-		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
-	}
-	return output, nil
+	return s.runProjectConversationRemoteCommand(
+		ctx,
+		machine,
+		"sh -lc "+projectConversationShellQuote(strings.Join(quoted, " ")),
+		allowExitCodeOne,
+		"workspace git command",
+	)
 }
 
 func parseProjectConversationGitStatusEntries(raw []byte) ([]projectConversationGitStatusEntry, error) {
@@ -489,7 +477,14 @@ func projectConversationGitStatusHasUnstaged(code string) bool {
 
 func projectConversationCommandExitedWithCode(err error, code int) bool {
 	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr) && exitErr.ExitCode() == code
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == code {
+		return true
+	}
+	var runtimeExit machinetransport.ProcessExitError
+	if errors.As(err, &runtimeExit) && runtimeExit.ExitStatus() == code {
+		return true
+	}
+	return strings.Contains(strings.TrimSpace(err.Error()), fmt.Sprintf("exit status %d", code))
 }
 
 func projectConversationWorkspaceMayNotExistYet(conversation chatdomain.Conversation) bool {

--- a/internal/chat/project_conversation_workspace_file_edit.go
+++ b/internal/chat/project_conversation_workspace_file_edit.go
@@ -475,32 +475,25 @@ func (s *ProjectConversationService) writeRemoteConversationWorkspaceFile(
 	if encoding != WorkspaceEncodingUTF8 {
 		return "", 0, fmt.Errorf("workspace encoding %s is unsupported", encoding)
 	}
-	if s == nil || s.core.sshPool == nil {
-		return "", 0, fmt.Errorf("ssh pool unavailable for machine %s", machine.Name)
-	}
-	client, err := s.core.sshPool.Get(ctx, machine)
+	session, err := s.openProjectConversationCommandSession(ctx, machine, "workspace file save")
 	if err != nil {
 		return "", 0, err
-	}
-	session, err := client.NewSession()
-	if err != nil {
-		return "", 0, fmt.Errorf("open ssh session for workspace file save: %w", err)
 	}
 	defer func() { _ = session.Close() }()
 
 	stdin, err := session.StdinPipe()
 	if err != nil {
-		return "", 0, fmt.Errorf("open ssh stdin for workspace file save: %w", err)
+		return "", 0, fmt.Errorf("open remote stdin for workspace file save: %w", err)
 	}
 	stdout, err := session.StdoutPipe()
 	if err != nil {
 		_ = stdin.Close()
-		return "", 0, fmt.Errorf("open ssh stdout for workspace file save: %w", err)
+		return "", 0, fmt.Errorf("open remote stdout for workspace file save: %w", err)
 	}
 	stderr, err := session.StderrPipe()
 	if err != nil {
 		_ = stdin.Close()
-		return "", 0, fmt.Errorf("open ssh stderr for workspace file save: %w", err)
+		return "", 0, fmt.Errorf("open remote stderr for workspace file save: %w", err)
 	}
 
 	var stdoutBuffer bytes.Buffer
@@ -521,7 +514,7 @@ func (s *ProjectConversationService) writeRemoteConversationWorkspaceFile(
 		_ = stdin.Close()
 		<-stdoutDone
 		<-stderrDone
-		return "", 0, fmt.Errorf("start ssh workspace file save: %w", err)
+		return "", 0, fmt.Errorf("start remote workspace file save: %w", err)
 	}
 	_, writeErr := stdin.Write(content)
 	stdinCloseErr := stdin.Close()

--- a/web/src/lib/testing/e2e/mock-api/entities.test.ts
+++ b/web/src/lib/testing/e2e/mock-api/entities.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MockState } from './constants'
+import { createMachineRecord } from './entities'
+
+function mockState(): MockState {
+  return {
+    organizations: [],
+    projects: [],
+    machines: [],
+    providers: [],
+    agents: [],
+    agentRuns: [],
+    activityEvents: [],
+    projectUpdates: [],
+    tickets: [],
+    statuses: [],
+    repos: [],
+    workflows: [],
+    harnessByWorkflowId: {},
+    scheduledJobs: [],
+    projectConversations: [],
+    projectConversationEntries: [],
+    skills: [],
+    builtinRoles: [],
+    securitySettingsByProjectId: {},
+    harnessVariables: { groups: [] },
+    counters: {
+      machine: 0,
+      repo: 0,
+      workflow: 0,
+      agent: 0,
+      skill: 0,
+      scheduledJob: 0,
+      projectUpdateThread: 0,
+      projectUpdateComment: 0,
+      projectConversation: 0,
+      projectConversationEntry: 0,
+      projectConversationTurn: 0,
+    },
+  }
+}
+
+describe('mock machine execution capabilities', () => {
+  it('keeps reverse-connect runtimes aligned with the core remote capability set', () => {
+    const machine = createMachineRecord(mockState(), {
+      name: 'reverse-runtime',
+      host: 'remote.internal',
+      reachability_mode: 'reverse_connect',
+      execution_mode: 'websocket',
+    })
+
+    expect(machine.execution_capabilities).toEqual([
+      'probe',
+      'workspace_prepare',
+      'artifact_sync',
+      'process_streaming',
+    ])
+  })
+})

--- a/web/src/lib/testing/e2e/mock-api/entities.ts
+++ b/web/src/lib/testing/e2e/mock-api/entities.ts
@@ -154,9 +154,6 @@ function resolveMachineConnectionMode(reachabilityMode: string, _executionMode: 
 }
 
 function executionCapabilitiesForConnectionMode(connectionMode: string) {
-  if (connectionMode === 'ws_reverse') {
-    return []
-  }
   return ['probe', 'workspace_prepare', 'artifact_sync', 'process_streaming']
 }
 

--- a/web/src/lib/testing/e2e/mock-api/entities.ts
+++ b/web/src/lib/testing/e2e/mock-api/entities.ts
@@ -153,7 +153,7 @@ function resolveMachineConnectionMode(reachabilityMode: string, _executionMode: 
   return 'ws_listener'
 }
 
-function executionCapabilitiesForConnectionMode(connectionMode: string) {
+function executionCapabilitiesForConnectionMode(_connectionMode: string) {
   return ['probe', 'workspace_prepare', 'artifact_sync', 'process_streaming']
 }
 


### PR DESCRIPTION
## Summary
- route project conversation remote shell and git/file operations through the runtime command-session surface so websocket runtimes expose the same workspace capabilities as SSH/local machines
- add remote terminal support for Project AI workspaces and keep reverse-connect mock capability metadata aligned with the backend capability contract
- cover websocket workspace browse/edit/git flows and remote terminal attach flows with automated tests

## Validation
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/chat/...`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/httpapi/... -run TestProjectConversationTerminalAttachWebsocketFlow`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH ./node_modules/.bin/vitest run src/lib/testing/e2e/mock-api/entities.test.ts`

## Ticket
- ASE-245
