### PR TITLE
fix: patch desktop follow-redirects resolution

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,8 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "^1.15.0"
+      "axios": "^1.15.0",
+      "follow-redirects": "^1.16.0"
     },
     "onlyBuiltDependencies": [
       "electron",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   axios: ^1.15.0
+  follow-redirects: ^1.16.0
 
 importers:
 
@@ -752,8 +753,8 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2195,7 +2196,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -2604,7 +2605,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -2,14 +2,44 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 const desktopRoot = path.resolve(__dirname, '../..')
+const runtimeRoots = ['main', 'preload', 'scripts']
+
+function listFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return listFiles(fullPath)
+    }
+    return [fullPath]
+  })
+}
 
 describe('desktop dependency security guardrails', () => {
-  it('pins transitive axios to a patched version', () => {
+  it('pins redirect-following dependencies to patched versions', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
     expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
+    expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
     expect(lockfile).not.toContain('axios@1.14.0')
     expect(lockfile).toMatch(/axios@1\.15\./)
+    expect(lockfile).not.toContain('follow-redirects@1.15.')
+    expect(lockfile).toMatch(/follow-redirects@1\.16\./)
+  })
+
+  it('keeps desktop-owned code paths off custom axios redirect flows', () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
+    expect(packageJson.scripts?.dev).toContain('wait-on http://127.0.0.1:4174')
+    expect(packageJson.scripts?.dev).not.toMatch(/--header|--headers|authorization/i)
+
+    for (const relativeRoot of runtimeRoots) {
+      const files = listFiles(path.join(desktopRoot, relativeRoot))
+      for (const file of files) {
+        const source = fs.readFileSync(file, 'utf8')
+        expect(source).not.toMatch(/\b(?:require\(|from\s+)['"]axios['"]/)
+        expect(source).not.toMatch(/\b(?:require\(|from\s+)['"]follow-redirects['"]/)
+      }
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add a desktop pnpm override so the lockfile resolves `follow-redirects` to a patched `1.16.x` release
- extend the desktop dependency security test to guard both the lockfile version and the absence of desktop-owned axios/follow-redirects imports
- document in the checks that the only current transitive consumer is `wait-on` from the dev tooling path, without custom auth-header flags

## Validation
- `cd desktop && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm why follow-redirects`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-install-browsers`
- `DISPLAY= WAYLAND_DISPLAY= PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-validate`
