### PR TITLE
fix(web): pin dompurify security upgrade

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -91,6 +91,7 @@
   "pnpm": {
     "overrides": {
       "cookie": "0.7.2",
+      "dompurify": "3.4.0",
       "lodash-es": "4.18.1"
     }
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cookie: 0.7.2
+  dompurify: 3.4.0
   lodash-es: 4.18.1
 
 importers:
@@ -2999,10 +3000,10 @@ packages:
         integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
       }
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     resolution:
       {
-        integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==,
+        integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==,
       }
 
   driver.js@1.4.0:
@@ -7860,7 +7861,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8887,7 +8888,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.44
       khroma: 2.1.0
       lodash-es: 4.18.1

--- a/web/scripts/check-lockfile-security.mjs
+++ b/web/scripts/check-lockfile-security.mjs
@@ -8,6 +8,12 @@ const lockfile = readFileSync(lockfilePath, 'utf8')
 
 const bannedEntries = [
   {
+    packageName: 'dompurify',
+    version: '3.3.3',
+    reason:
+      'GHSA-39q2-94rc-95cp allows ADD_TAGS function handling to bypass FORBID_TAGS enforcement; keep the lockfile on 3.4.0 or newer.',
+  },
+  {
     packageName: 'picomatch',
     version: '4.0.3',
     reason:

--- a/web/src/lib/features/markdown/markdown-content.test.ts
+++ b/web/src/lib/features/markdown/markdown-content.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, describe, expect, it } from 'vitest'
 import { ProjectUpdateMarkdownContent } from '$lib/features/project-updates'
 import { TicketMarkdownContent } from '$lib/features/ticket-detail'
 import { Streamdown } from 'streamdown-svelte'
+import type { DiagramPlugin, MermaidInstance } from 'streamdown-svelte'
 import MarkdownContent from './markdown-content.svelte'
 
 class MockIntersectionObserver implements IntersectionObserver {
@@ -38,12 +39,15 @@ class MockIntersectionObserver implements IntersectionObserver {
   unobserve(): void {}
 }
 
-function createAdvisoryMermaidPlugin() {
+function createAdvisoryMermaidPlugin(): DiagramPlugin {
   return {
+    language: 'mermaid',
+    name: 'mermaid',
+    type: 'diagram',
     getMermaid() {
-      return {
+      const mermaid: MermaidInstance = {
         initialize() {},
-        async render() {
+        async render(_id: string, _source: string) {
           const { default: createDOMPurify } =
             await import('../../../../node_modules/.pnpm/dompurify@3.4.0/node_modules/dompurify/dist/purify.es.mjs')
           const domPurify = createDOMPurify(window)
@@ -68,32 +72,32 @@ function createAdvisoryMermaidPlugin() {
           return { svg }
         },
       }
+
+      return mermaid
     },
   }
 }
 
 const originalIntersectionObserver = globalThis.IntersectionObserver
-const originalGetBBox = globalThis.SVGElement?.prototype.getBBox
+type SVGElementWithBBox = SVGElement & { getBBox: () => DOMRect }
+
+const svgElementPrototype = globalThis.SVGElement?.prototype as SVGElementWithBBox | undefined
+const originalGetBBox = svgElementPrototype?.getBBox
 
 globalThis.IntersectionObserver = MockIntersectionObserver
 
-if (globalThis.SVGElement && typeof globalThis.SVGElement.prototype.getBBox !== 'function') {
-  globalThis.SVGElement.prototype.getBBox = () => ({
-    x: 0,
-    y: 0,
-    width: 120,
-    height: 24,
-  })
+if (svgElementPrototype && typeof svgElementPrototype.getBBox !== 'function') {
+  svgElementPrototype.getBBox = () => DOMRect.fromRect({ x: 0, y: 0, width: 120, height: 24 })
 }
 
 afterAll(() => {
   globalThis.IntersectionObserver = originalIntersectionObserver
 
-  if (globalThis.SVGElement) {
+  if (svgElementPrototype) {
     if (originalGetBBox) {
-      globalThis.SVGElement.prototype.getBBox = originalGetBBox
+      svgElementPrototype.getBBox = originalGetBBox
     } else {
-      delete globalThis.SVGElement.prototype.getBBox
+      delete (svgElementPrototype as Partial<SVGElementWithBBox>).getBBox
     }
   }
 })

--- a/web/src/lib/features/markdown/markdown-content.test.ts
+++ b/web/src/lib/features/markdown/markdown-content.test.ts
@@ -44,9 +44,8 @@ function createAdvisoryMermaidPlugin() {
       return {
         initialize() {},
         async render() {
-          const { default: createDOMPurify } = await import(
-            '../../../../node_modules/.pnpm/dompurify@3.4.0/node_modules/dompurify/dist/purify.es.mjs'
-          )
+          const { default: createDOMPurify } =
+            await import('../../../../node_modules/.pnpm/dompurify@3.4.0/node_modules/dompurify/dist/purify.es.mjs')
           const domPurify = createDOMPurify(window)
           const svg = domPurify.sanitize(
             [
@@ -175,12 +174,7 @@ describe('Streamdown mermaid security', () => {
   it('preserves FORBID_TAGS when mermaid-style sanitization adds foreignObject tags', async () => {
     const { container } = render(Streamdown, {
       props: {
-        content: [
-          '```mermaid',
-          'graph TD',
-          '  A --> B',
-          '```',
-        ].join('\n'),
+        content: ['```mermaid', 'graph TD', '  A --> B', '```'].join('\n'),
         mode: 'static',
         plugins: {
           mermaid: createAdvisoryMermaidPlugin(),

--- a/web/src/lib/features/markdown/markdown-content.test.ts
+++ b/web/src/lib/features/markdown/markdown-content.test.ts
@@ -1,8 +1,103 @@
 import { cleanup, render, waitFor } from '@testing-library/svelte'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
 import { ProjectUpdateMarkdownContent } from '$lib/features/project-updates'
 import { TicketMarkdownContent } from '$lib/features/ticket-detail'
+import { Streamdown } from 'streamdown-svelte'
 import MarkdownContent from './markdown-content.svelte'
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = '0px'
+  readonly thresholds = [0]
+
+  constructor(private readonly callback: IntersectionObserverCallback) {}
+
+  disconnect(): void {}
+
+  observe(target: Element): void {
+    this.callback(
+      [
+        {
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRatio: 1,
+          intersectionRect: target.getBoundingClientRect(),
+          isIntersecting: true,
+          rootBounds: null,
+          target,
+          time: 0,
+        },
+      ],
+      this,
+    )
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+
+  unobserve(): void {}
+}
+
+function createAdvisoryMermaidPlugin() {
+  return {
+    getMermaid() {
+      return {
+        initialize() {},
+        async render() {
+          const { default: createDOMPurify } = await import(
+            '../../../../node_modules/.pnpm/dompurify@3.4.0/node_modules/dompurify/dist/purify.es.mjs'
+          )
+          const domPurify = createDOMPurify(window)
+          const svg = domPurify.sanitize(
+            [
+              '<svg xmlns="http://www.w3.org/2000/svg">',
+              '  <foreignObject>',
+              '    <div xmlns="http://www.w3.org/1999/xhtml">',
+              '      <style>body{background:red}</style>',
+              '      <span>safe label</span>',
+              '    </div>',
+              '  </foreignObject>',
+              '</svg>',
+            ].join('\n'),
+            {
+              ADD_TAGS: (tagName: string) => tagName === 'foreignobject',
+              FORBID_TAGS: ['style'],
+              HTML_INTEGRATION_POINTS: { foreignobject: true },
+            },
+          )
+
+          return { svg }
+        },
+      }
+    },
+  }
+}
+
+const originalIntersectionObserver = globalThis.IntersectionObserver
+const originalGetBBox = globalThis.SVGElement?.prototype.getBBox
+
+globalThis.IntersectionObserver = MockIntersectionObserver
+
+if (globalThis.SVGElement && typeof globalThis.SVGElement.prototype.getBBox !== 'function') {
+  globalThis.SVGElement.prototype.getBBox = () => ({
+    x: 0,
+    y: 0,
+    width: 120,
+    height: 24,
+  })
+}
+
+afterAll(() => {
+  globalThis.IntersectionObserver = originalIntersectionObserver
+
+  if (globalThis.SVGElement) {
+    if (originalGetBBox) {
+      globalThis.SVGElement.prototype.getBBox = originalGetBBox
+    } else {
+      delete globalThis.SVGElement.prototype.getBBox
+    }
+  }
+})
 
 describe('MarkdownContent policy', () => {
   afterEach(() => {
@@ -69,6 +164,39 @@ describe('MarkdownContent policy', () => {
     expect(fallbackMermaid?.textContent).toContain('graph TD')
     expect(fallbackMermaid?.querySelector('pre code')).toBeTruthy()
     expect(container.querySelector('[data-mermaid-svg]')).toBeNull()
+  })
+})
+
+describe('Streamdown mermaid security', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('preserves FORBID_TAGS when mermaid-style sanitization adds foreignObject tags', async () => {
+    const { container } = render(Streamdown, {
+      props: {
+        content: [
+          '```mermaid',
+          'graph TD',
+          '  A --> B',
+          '```',
+        ].join('\n'),
+        mode: 'static',
+        plugins: {
+          mermaid: createAdvisoryMermaidPlugin(),
+        },
+      },
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-mermaid-svg]')).toBeTruthy()
+    })
+
+    const renderedMermaid = container.querySelector('[data-mermaid-svg]')
+
+    expect(renderedMermaid?.querySelector('style')).toBeNull()
+    expect(renderedMermaid?.querySelector('foreignObject')).toBeTruthy()
+    expect(renderedMermaid?.textContent).toContain('safe label')
   })
 })
 


### PR DESCRIPTION
## What
- pin `dompurify` to `3.4.0` in `web/package.json` overrides and refresh the lockfile resolution
- extend the lockfile security gate to fail if `dompurify@3.3.3` reappears
- add a DOMPurify regression test that exercises the advisory scenario (`ADD_TAGS` function + `FORBID_TAGS`) through the shipped Streamdown mermaid surface

## Why
- Dependabot alert #37 flags `dompurify@3.3.3` in the web runtime dependency tree
- OpenASE does not currently combine DOMPurify `ADD_TAGS` function hooks with `FORBID_TAGS` in product code; `streamdown-svelte` is used without the mermaid plugin, and `mermaid` itself uses array-form `ADD_TAGS` plus a separate `FORBID_TAGS: ['style']` path
- the override + gate keep the lockfile on a patched DOMPurify while the regression test protects the advisory-specific sanitizer behavior

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec svelte-kit sync`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec eslint src/lib/features/markdown/markdown-content.test.ts scripts/check-lockfile-security.mjs`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm vitest run src/lib/features/markdown/markdown-content.test.ts`

Base synced to `origin/main` at `0210692f16c9923f810ecdcdce324bd79b48c257`.
