### PR TITLE
fix: stabilize Project AI conversation owners

### DIFF
--- a/internal/chat/project_conversation_lifecycle.go
+++ b/internal/chat/project_conversation_lifecycle.go
@@ -16,11 +16,30 @@ func (s *ProjectConversationService) normalizeConversationUser(
 	ctx context.Context,
 	conversation domain.Conversation,
 	userID UserID,
-) (domain.Conversation, error) {
-	if !isStableLocalProjectConversationUser(userID) || conversation.UserID == userID.String() {
-		return conversation, nil
+) (domain.Conversation, bool, error) {
+	access := resolveProjectConversationOwnerAccess(
+		userID,
+		conversation.UserID,
+		projectConversationAccessHintFromContext(ctx),
+	)
+	if !access.allowed {
+		return domain.Conversation{}, false, nil
 	}
-	return s.core.conversations.UpdateConversationUser(ctx, conversation.ID, userID.String())
+	if !access.needsMigration {
+		if conversation.UserID != access.normalizedUser.String() {
+			conversation.UserID = access.normalizedUser.String()
+		}
+		return conversation, true, nil
+	}
+	normalized, err := s.core.conversations.UpdateConversationUser(
+		ctx,
+		conversation.ID,
+		access.normalizedUser.String(),
+	)
+	if err != nil {
+		return domain.Conversation{}, false, err
+	}
+	return normalized, true, nil
 }
 
 func (s *ProjectConversationService) CreateConversation(
@@ -40,10 +59,11 @@ func (s *ProjectConversationService) CreateConversation(
 	if providerItem.OrganizationID != project.OrganizationID {
 		return domain.Conversation{}, fmt.Errorf("%w: provider is outside the project organization", ErrConversationConflict)
 	}
+	ownerUserID := normalizeProjectConversationOwnerForCreate(userID)
 
 	return s.core.conversations.CreateConversation(ctx, domain.CreateConversation{
 		ProjectID:  projectID,
-		UserID:     userID.String(),
+		UserID:     ownerUserID.String(),
 		Source:     domain.SourceProjectSidebar,
 		ProviderID: providerID,
 	})
@@ -58,28 +78,27 @@ func (s *ProjectConversationService) ListConversations(
 	source := domain.SourceProjectSidebar
 	filter := domain.ListConversationsFilter{
 		ProjectID:  projectID,
-		UserID:     userID.String(),
+		UserID:     "",
 		Source:     &source,
 		ProviderID: providerID,
-	}
-	if isStableLocalProjectConversationUser(userID) {
-		filter.UserID = ""
 	}
 	conversations, err := s.core.conversations.ListConversations(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
-	if !isStableLocalProjectConversationUser(userID) {
-		return conversations, nil
-	}
+	visible := make([]domain.Conversation, 0, len(conversations))
 	for index, conversation := range conversations {
-		normalized, normalizeErr := s.normalizeConversationUser(ctx, conversation, userID)
+		normalized, allowed, normalizeErr := s.normalizeConversationUser(ctx, conversation, userID)
 		if normalizeErr != nil {
 			return nil, normalizeErr
 		}
+		if !allowed {
+			continue
+		}
+		visible = append(visible, normalized)
 		conversations[index] = normalized
 	}
-	return conversations, nil
+	return visible, nil
 }
 
 func (s *ProjectConversationService) GetConversation(ctx context.Context, userID UserID, conversationID uuid.UUID) (domain.Conversation, error) {
@@ -87,10 +106,14 @@ func (s *ProjectConversationService) GetConversation(ctx context.Context, userID
 	if err != nil {
 		return domain.Conversation{}, err
 	}
-	if conversation.UserID != userID.String() && !isStableLocalProjectConversationUser(userID) {
+	normalized, allowed, err := s.normalizeConversationUser(ctx, conversation, userID)
+	if err != nil {
+		return domain.Conversation{}, err
+	}
+	if !allowed {
 		return domain.Conversation{}, ErrConversationNotFound
 	}
-	return s.normalizeConversationUser(ctx, conversation, userID)
+	return normalized, nil
 }
 
 func (s *ProjectConversationService) GetPrincipal(ctx context.Context, userID UserID, conversationID uuid.UUID) (domain.ProjectConversationPrincipal, error) {

--- a/internal/chat/project_conversation_owner.go
+++ b/internal/chat/project_conversation_owner.go
@@ -14,6 +14,9 @@ const (
 	// LegacyLocalProjectConversationUserID is the previous auth-disabled owner
 	// marker that now converges to instance-admin.
 	LegacyLocalProjectConversationUserID UserID = "local-user:default"
+)
+
+const (
 	browserSessionProjectConversationUserIDPrefix = "browser-session:"
 	humanProjectConversationUserIDPrefix          = "user:"
 )

--- a/internal/chat/project_conversation_owner.go
+++ b/internal/chat/project_conversation_owner.go
@@ -1,0 +1,211 @@
+package chat
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// InstanceAdminProjectConversationUserID is the stable non-OIDC owner used
+	// for persistent project conversations when browser login is disabled.
+	InstanceAdminProjectConversationUserID UserID = "instance-admin"
+	// LegacyLocalProjectConversationUserID is the previous auth-disabled owner
+	// marker that now converges to instance-admin.
+	LegacyLocalProjectConversationUserID UserID = "local-user:default"
+	browserSessionProjectConversationUserIDPrefix = "browser-session:"
+	humanProjectConversationUserIDPrefix          = "user:"
+)
+
+// LocalProjectConversationUserID is kept as a compatibility alias for older
+// call sites; new code should prefer InstanceAdminProjectConversationUserID.
+const LocalProjectConversationUserID = InstanceAdminProjectConversationUserID
+
+type projectConversationOwnerKind string
+
+const (
+	projectConversationOwnerKindHumanStable projectConversationOwnerKind = "human_stable"
+	projectConversationOwnerKindHumanLegacy projectConversationOwnerKind = "human_legacy"
+	projectConversationOwnerKindInstance    projectConversationOwnerKind = "instance_admin"
+	projectConversationOwnerKindLegacyLocal projectConversationOwnerKind = "legacy_local"
+	projectConversationOwnerKindAnonymous   projectConversationOwnerKind = "anonymous"
+	projectConversationOwnerKindBrowser     projectConversationOwnerKind = "browser_session"
+	projectConversationOwnerKindUnknown     projectConversationOwnerKind = "unknown"
+)
+
+type parsedProjectConversationOwner struct {
+	Raw         UserID
+	Kind        projectConversationOwnerKind
+	HumanUserID uuid.UUID
+}
+
+type ProjectConversationAccessHint struct {
+	LegacyBrowserOwner               UserID
+	AllowInstanceAdminLegacyAdoption bool
+}
+
+type projectConversationAccessHintContextKey struct{}
+
+func WithProjectConversationAccessHint(
+	ctx context.Context,
+	hint ProjectConversationAccessHint,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	normalized := ProjectConversationAccessHint{
+		AllowInstanceAdminLegacyAdoption: hint.AllowInstanceAdminLegacyAdoption,
+	}
+	if parsed, ok := parseProjectConversationOwnerLoose(hint.LegacyBrowserOwner.String()); ok &&
+		parsed.Kind == projectConversationOwnerKindBrowser {
+		normalized.LegacyBrowserOwner = parsed.Raw
+	}
+	if normalized.LegacyBrowserOwner == "" && !normalized.AllowInstanceAdminLegacyAdoption {
+		return ctx
+	}
+	return context.WithValue(ctx, projectConversationAccessHintContextKey{}, normalized)
+}
+
+func projectConversationAccessHintFromContext(ctx context.Context) ProjectConversationAccessHint {
+	if ctx == nil {
+		return ProjectConversationAccessHint{}
+	}
+	hint, _ := ctx.Value(projectConversationAccessHintContextKey{}).(ProjectConversationAccessHint)
+	return hint
+}
+
+func parseProjectConversationOwnerLoose(raw string) (parsedProjectConversationOwner, bool) {
+	userID, err := ParseUserID(raw)
+	if err != nil {
+		return parsedProjectConversationOwner{}, false
+	}
+	trimmed := strings.TrimSpace(userID.String())
+	switch {
+	case trimmed == InstanceAdminProjectConversationUserID.String():
+		return parsedProjectConversationOwner{Raw: InstanceAdminProjectConversationUserID, Kind: projectConversationOwnerKindInstance}, true
+	case trimmed == LegacyLocalProjectConversationUserID.String():
+		return parsedProjectConversationOwner{Raw: LegacyLocalProjectConversationUserID, Kind: projectConversationOwnerKindLegacyLocal}, true
+	case trimmed == AnonymousUserID.String():
+		return parsedProjectConversationOwner{Raw: AnonymousUserID, Kind: projectConversationOwnerKindAnonymous}, true
+	case strings.HasPrefix(trimmed, humanProjectConversationUserIDPrefix):
+		humanUserID, parseErr := uuid.Parse(strings.TrimPrefix(trimmed, humanProjectConversationUserIDPrefix))
+		if parseErr != nil {
+			return parsedProjectConversationOwner{Raw: userID, Kind: projectConversationOwnerKindUnknown}, true
+		}
+		return parsedProjectConversationOwner{Raw: userID, Kind: projectConversationOwnerKindHumanStable, HumanUserID: humanUserID}, true
+	case strings.HasPrefix(trimmed, browserSessionProjectConversationUserIDPrefix):
+		sessionID, parseErr := uuid.Parse(strings.TrimPrefix(trimmed, browserSessionProjectConversationUserIDPrefix))
+		if parseErr != nil {
+			return parsedProjectConversationOwner{Raw: userID, Kind: projectConversationOwnerKindUnknown}, true
+		}
+		return parsedProjectConversationOwner{Raw: UserID(browserSessionProjectConversationUserIDPrefix + sessionID.String()), Kind: projectConversationOwnerKindBrowser}, true
+	default:
+		humanUserID, parseErr := uuid.Parse(trimmed)
+		if parseErr == nil {
+			return parsedProjectConversationOwner{Raw: userID, Kind: projectConversationOwnerKindHumanLegacy, HumanUserID: humanUserID}, true
+		}
+		return parsedProjectConversationOwner{Raw: userID, Kind: projectConversationOwnerKindUnknown}, true
+	}
+}
+
+type projectConversationOwnerAccess struct {
+	allowed        bool
+	normalizedUser UserID
+	needsMigration bool
+}
+
+func normalizeProjectConversationOwnerForCreate(userID UserID) UserID {
+	parsed, ok := parseProjectConversationOwnerLoose(userID.String())
+	if !ok {
+		return InstanceAdminProjectConversationUserID
+	}
+
+	switch parsed.Kind {
+	case projectConversationOwnerKindHumanStable:
+		return parsed.Raw
+	case projectConversationOwnerKindHumanLegacy:
+		return UserID(humanProjectConversationUserIDPrefix + parsed.HumanUserID.String())
+	case projectConversationOwnerKindInstance,
+		projectConversationOwnerKindLegacyLocal,
+		projectConversationOwnerKindAnonymous,
+		projectConversationOwnerKindBrowser,
+		projectConversationOwnerKindUnknown:
+		return InstanceAdminProjectConversationUserID
+	default:
+		return InstanceAdminProjectConversationUserID
+	}
+}
+
+func resolveProjectConversationOwnerAccess(
+	requestedUser UserID,
+	storedUser string,
+	hint ProjectConversationAccessHint,
+) projectConversationOwnerAccess {
+	requested, ok := parseProjectConversationOwnerLoose(requestedUser.String())
+	if !ok {
+		return projectConversationOwnerAccess{}
+	}
+	stored, ok := parseProjectConversationOwnerLoose(storedUser)
+	if !ok {
+		return projectConversationOwnerAccess{}
+	}
+
+	switch requested.Kind {
+	case projectConversationOwnerKindInstance:
+		return projectConversationOwnerAccess{
+			allowed:        true,
+			normalizedUser: InstanceAdminProjectConversationUserID,
+			needsMigration: stored.Raw != InstanceAdminProjectConversationUserID,
+		}
+	case projectConversationOwnerKindHumanStable:
+		switch {
+		case stored.Raw == requested.Raw:
+			return projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: requested.Raw,
+			}
+		case stored.Kind == projectConversationOwnerKindHumanLegacy &&
+			stored.HumanUserID == requested.HumanUserID:
+			return projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: requested.Raw,
+				needsMigration: true,
+			}
+		case hint.LegacyBrowserOwner != "" && stored.Raw == hint.LegacyBrowserOwner:
+			return projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: requested.Raw,
+				needsMigration: true,
+			}
+		case hint.AllowInstanceAdminLegacyAdoption && projectConversationOwnerEligibleForAdminAdoption(stored):
+			return projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: requested.Raw,
+				needsMigration: stored.Raw != requested.Raw,
+			}
+		default:
+			return projectConversationOwnerAccess{}
+		}
+	default:
+		if stored.Raw != requested.Raw {
+			return projectConversationOwnerAccess{}
+		}
+		return projectConversationOwnerAccess{
+			allowed:        true,
+			normalizedUser: requested.Raw,
+		}
+	}
+}
+
+func projectConversationOwnerEligibleForAdminAdoption(owner parsedProjectConversationOwner) bool {
+	switch owner.Kind {
+	case projectConversationOwnerKindInstance,
+		projectConversationOwnerKindLegacyLocal,
+		projectConversationOwnerKindAnonymous,
+		projectConversationOwnerKindUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/chat/project_conversation_owner_test.go
+++ b/internal/chat/project_conversation_owner_test.go
@@ -74,9 +74,9 @@ func TestResolveProjectConversationOwnerAccess(t *testing.T) {
 	otherHuman := "user:" + uuid.MustParse("bf356dd8-aed8-4582-9278-69e72d68df79").String()
 
 	tests := []struct {
-		name string
-		hint ProjectConversationAccessHint
-		want projectConversationOwnerAccess
+		name   string
+		hint   ProjectConversationAccessHint
+		want   projectConversationOwnerAccess
 		stored string
 	}{
 		{

--- a/internal/chat/project_conversation_owner_test.go
+++ b/internal/chat/project_conversation_owner_test.go
@@ -1,0 +1,303 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	chatdomain "github.com/BetterAndBetterII/openase/internal/domain/chatconversation"
+	chatrepo "github.com/BetterAndBetterII/openase/internal/repo/chatconversation"
+	"github.com/google/uuid"
+)
+
+func TestNormalizeProjectConversationOwnerForCreate(t *testing.T) {
+	t.Parallel()
+
+	humanID := uuid.MustParse("8db7261e-e16d-458e-8926-cd01550686a5")
+	browserSessionID := uuid.MustParse("d2a5f692-24e8-421f-94cb-f4670e1f91c1")
+
+	tests := []struct {
+		name string
+		raw  UserID
+		want UserID
+	}{
+		{
+			name: "stable human owner stays stable",
+			raw:  UserID("user:" + humanID.String()),
+			want: UserID("user:" + humanID.String()),
+		},
+		{
+			name: "bare uuid converges to stable human owner",
+			raw:  UserID(humanID.String()),
+			want: UserID("user:" + humanID.String()),
+		},
+		{
+			name: "legacy local owner converges to instance admin",
+			raw:  LegacyLocalProjectConversationUserID,
+			want: InstanceAdminProjectConversationUserID,
+		},
+		{
+			name: "anonymous converges to instance admin",
+			raw:  AnonymousUserID,
+			want: InstanceAdminProjectConversationUserID,
+		},
+		{
+			name: "browser session converges to instance admin",
+			raw:  UserID(browserSessionProjectConversationUserIDPrefix + browserSessionID.String()),
+			want: InstanceAdminProjectConversationUserID,
+		},
+		{
+			name: "unknown owner converges to instance admin",
+			raw:  UserID("browser-user-a"),
+			want: InstanceAdminProjectConversationUserID,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeProjectConversationOwnerForCreate(tc.raw); got != tc.want {
+				t.Fatalf("normalizeProjectConversationOwnerForCreate(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveProjectConversationOwnerAccess(t *testing.T) {
+	t.Parallel()
+
+	humanID := uuid.MustParse("8db7261e-e16d-458e-8926-cd01550686a5")
+	humanUser := UserID("user:" + humanID.String())
+	legacyBrowser := UserID(browserSessionProjectConversationUserIDPrefix + uuid.MustParse("d2a5f692-24e8-421f-94cb-f4670e1f91c1").String())
+	otherHuman := "user:" + uuid.MustParse("bf356dd8-aed8-4582-9278-69e72d68df79").String()
+
+	tests := []struct {
+		name string
+		hint ProjectConversationAccessHint
+		want projectConversationOwnerAccess
+		stored string
+	}{
+		{
+			name:   "bare uuid adopts into stable human owner",
+			stored: humanID.String(),
+			want: projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: humanUser,
+				needsMigration: true,
+			},
+		},
+		{
+			name:   "matching legacy browser owner adopts into stable human owner",
+			stored: legacyBrowser.String(),
+			hint: ProjectConversationAccessHint{
+				LegacyBrowserOwner: legacyBrowser,
+			},
+			want: projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: humanUser,
+				needsMigration: true,
+			},
+		},
+		{
+			name:   "instance admin legacy owner can be adopted by human principal",
+			stored: LegacyLocalProjectConversationUserID.String(),
+			hint: ProjectConversationAccessHint{
+				AllowInstanceAdminLegacyAdoption: true,
+			},
+			want: projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: humanUser,
+				needsMigration: true,
+			},
+		},
+		{
+			name:   "foreign stable human owner stays hidden",
+			stored: otherHuman,
+			want:   projectConversationOwnerAccess{},
+		},
+		{
+			name:   "auth disabled access converges browser owner to instance admin",
+			stored: legacyBrowser.String(),
+			want: projectConversationOwnerAccess{
+				allowed:        true,
+				normalizedUser: InstanceAdminProjectConversationUserID,
+				needsMigration: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			requested := humanUser
+			if tc.name == "auth disabled access converges browser owner to instance admin" {
+				requested = InstanceAdminProjectConversationUserID
+			}
+
+			if got := resolveProjectConversationOwnerAccess(requested, tc.stored, tc.hint); got != tc.want {
+				t.Fatalf("resolveProjectConversationOwnerAccess(%q, %q, %+v) = %+v, want %+v", requested, tc.stored, tc.hint, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProjectConversationServiceListConversationsAdoptsLegacyOwnersForHumanPrincipal(t *testing.T) {
+	t.Parallel()
+
+	client := openTestEntClient(t)
+	ctx := context.Background()
+	_, project := createProjectConversationTestProject(ctx, t, client)
+	repoStore := chatrepo.NewEntRepository(client)
+	service := NewProjectConversationService(nil, repoStore, nil, nil, nil, nil, nil)
+
+	humanID := uuid.MustParse("8db7261e-e16d-458e-8926-cd01550686a5")
+	stableHumanUser := UserID("user:" + humanID.String())
+	legacyBrowserOwner := UserID(browserSessionProjectConversationUserIDPrefix + uuid.MustParse("d2a5f692-24e8-421f-94cb-f4670e1f91c1").String())
+	foreignStableOwner := "user:" + uuid.MustParse("bf356dd8-aed8-4582-9278-69e72d68df79").String()
+
+	createConversation := func(t *testing.T, userID string) chatdomain.Conversation {
+		t.Helper()
+
+		conversation, err := repoStore.CreateConversation(ctx, chatdomain.CreateConversation{
+			ProjectID:  project.ID,
+			UserID:     userID,
+			Source:     chatdomain.SourceProjectSidebar,
+			ProviderID: uuid.New(),
+		})
+		if err != nil {
+			t.Fatalf("create conversation for %q: %v", userID, err)
+		}
+		return conversation
+	}
+
+	bareUUIDConversation := createConversation(t, humanID.String())
+	browserConversation := createConversation(t, legacyBrowserOwner.String())
+	legacyLocalConversation := createConversation(t, LegacyLocalProjectConversationUserID.String())
+	anonymousConversation := createConversation(t, AnonymousUserID.String())
+	unknownConversation := createConversation(t, "browser-user-a")
+	foreignConversation := createConversation(t, foreignStableOwner)
+
+	hintCtx := WithProjectConversationAccessHint(ctx, ProjectConversationAccessHint{
+		LegacyBrowserOwner:               legacyBrowserOwner,
+		AllowInstanceAdminLegacyAdoption: true,
+	})
+
+	items, err := service.ListConversations(hintCtx, stableHumanUser, project.ID, nil)
+	if err != nil {
+		t.Fatalf("ListConversations() error = %v", err)
+	}
+	if len(items) != 5 {
+		t.Fatalf("ListConversations() returned %d conversations, want 5", len(items))
+	}
+	for _, item := range items {
+		if item.UserID != stableHumanUser.String() {
+			t.Fatalf("conversation %s user_id = %q, want %q", item.ID, item.UserID, stableHumanUser)
+		}
+	}
+
+	for _, conversationID := range []uuid.UUID{
+		bareUUIDConversation.ID,
+		browserConversation.ID,
+		legacyLocalConversation.ID,
+		anonymousConversation.ID,
+		unknownConversation.ID,
+	} {
+		reloaded, err := repoStore.GetConversation(ctx, conversationID)
+		if err != nil {
+			t.Fatalf("GetConversation(%s) error = %v", conversationID, err)
+		}
+		if reloaded.UserID != stableHumanUser.String() {
+			t.Fatalf("conversation %s stored user_id = %q, want %q", conversationID, reloaded.UserID, stableHumanUser)
+		}
+	}
+
+	reloadedForeign, err := repoStore.GetConversation(ctx, foreignConversation.ID)
+	if err != nil {
+		t.Fatalf("GetConversation(foreign) error = %v", err)
+	}
+	if reloadedForeign.UserID != foreignStableOwner {
+		t.Fatalf("foreign conversation user_id = %q, want %q", reloadedForeign.UserID, foreignStableOwner)
+	}
+}
+
+func TestProjectConversationServiceCreateConversationNormalizesOwnerOnWrite(t *testing.T) {
+	t.Parallel()
+
+	client := openTestEntClient(t)
+	ctx := context.Background()
+	org, project := createProjectConversationTestProject(ctx, t, client)
+	repoStore := chatrepo.NewEntRepository(client)
+	providerID := uuid.New()
+
+	catalog := fakeProjectConversationCatalog{
+		fakeCatalogReader: fakeCatalogReader{
+			project: catalogdomain.Project{
+				ID:             project.ID,
+				OrganizationID: org.ID,
+				Name:           "OpenASE",
+				Slug:           "openase",
+			},
+			providerByID: map[uuid.UUID]catalogdomain.AgentProvider{
+				providerID: {
+					ID:             providerID,
+					OrganizationID: org.ID,
+					MachineID:      uuid.New(),
+					AdapterType:    catalogdomain.AgentProviderAdapterTypeGeminiCLI,
+					CliCommand:     "gemini",
+				},
+			},
+		},
+	}
+	service := NewProjectConversationService(nil, repoStore, catalog, fakeTicketReader{}, nil, nil, nil)
+
+	humanID := uuid.MustParse("8db7261e-e16d-458e-8926-cd01550686a5")
+
+	tests := []struct {
+		name     string
+		userID   UserID
+		wantUser string
+	}{
+		{
+			name:     "bare uuid is written as stable human owner",
+			userID:   UserID(humanID.String()),
+			wantUser: "user:" + humanID.String(),
+		},
+		{
+			name:     "legacy local owner is written as instance admin",
+			userID:   LegacyLocalProjectConversationUserID,
+			wantUser: InstanceAdminProjectConversationUserID.String(),
+		},
+		{
+			name:     "browser session owner is written as instance admin",
+			userID:   UserID(browserSessionProjectConversationUserIDPrefix + uuid.NewString()),
+			wantUser: InstanceAdminProjectConversationUserID.String(),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conversation, err := service.CreateConversation(ctx, tc.userID, project.ID, providerID)
+			if err != nil {
+				t.Fatalf("CreateConversation() error = %v", err)
+			}
+			if conversation.UserID != tc.wantUser {
+				t.Fatalf("CreateConversation().UserID = %q, want %q", conversation.UserID, tc.wantUser)
+			}
+
+			reloaded, err := repoStore.GetConversation(ctx, conversation.ID)
+			if err != nil {
+				t.Fatalf("GetConversation() error = %v", err)
+			}
+			if reloaded.UserID != tc.wantUser {
+				t.Fatalf("stored conversation user_id = %q, want %q", reloaded.UserID, tc.wantUser)
+			}
+		})
+	}
+}

--- a/internal/chat/project_conversation_service.go
+++ b/internal/chat/project_conversation_service.go
@@ -250,5 +250,5 @@ func projectConversationTurnLockKey(conversation domain.Conversation) UserID {
 }
 
 func isStableLocalProjectConversationUser(userID UserID) bool {
-	return strings.TrimSpace(userID.String()) == strings.TrimSpace(LocalProjectConversationUserID.String())
+	return strings.TrimSpace(userID.String()) == strings.TrimSpace(InstanceAdminProjectConversationUserID.String())
 }

--- a/internal/chat/session_registry.go
+++ b/internal/chat/session_registry.go
@@ -12,10 +12,6 @@ type UserID string
 
 const AnonymousUserID UserID = "anonymous"
 
-// LocalProjectConversationUserID is the stable non-OIDC owner used for
-// persistent project conversations when browser login is disabled.
-const LocalProjectConversationUserID UserID = "local-user:default"
-
 func ParseUserID(raw string) (UserID, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {

--- a/internal/httpapi/ai_principal.go
+++ b/internal/httpapi/ai_principal.go
@@ -71,3 +71,19 @@ func parseAICookiePrincipal(raw string) (chatservice.UserID, error) {
 	}
 	return chatservice.ParseUserID(trimmed)
 }
+
+func projectConversationAccessHint(c echo.Context) chatservice.ProjectConversationAccessHint {
+	if c == nil {
+		return chatservice.ProjectConversationAccessHint{}
+	}
+
+	hint := chatservice.ProjectConversationAccessHint{
+		AllowInstanceAdminLegacyAdoption: strings.TrimSpace(actorFromHumanPrincipal(c)) != "",
+	}
+	if cookie, err := c.Cookie(aiPrincipalCookieName); err == nil {
+		if principal, parseErr := parseAICookiePrincipal(cookie.Value); parseErr == nil {
+			hint.LegacyBrowserOwner = principal
+		}
+	}
+	return hint
+}

--- a/internal/httpapi/chat_api.go
+++ b/internal/httpapi/chat_api.go
@@ -289,6 +289,12 @@ func optionalChatSessionIDString(value *chatservice.SessionID) string {
 }
 
 func (s *Server) currentProjectConversationUserID(c echo.Context) (chatservice.UserID, error) {
+	if c != nil {
+		c.SetRequest(c.Request().WithContext(chatservice.WithProjectConversationAccessHint(
+			c.Request().Context(),
+			projectConversationAccessHint(c),
+		)))
+	}
 	if actor := strings.TrimSpace(actorFromHumanPrincipal(c)); actor != "" {
 		return chatservice.ParseUserID(actor)
 	}

--- a/web/src/lib/features/chat/project-conversation-controller-restore-helpers.test.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-restore-helpers.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { listProjectConversations } = vi.hoisted(() => ({
+  listProjectConversations: vi.fn(),
+}))
+
+vi.mock('$lib/api/chat', () => ({
+  listProjectConversations,
+}))
+
+import {
+  fetchCrossProjectConversations,
+  mapPersistedToRestoredTabs,
+} from './project-conversation-controller-restore-helpers'
+import type { ProjectConversationTabState } from './project-conversation-controller-state'
+import type { PersistedProjectConversationTab } from './project-conversation-storage'
+
+function createTabState(
+  providerId = '',
+  projectId = '',
+  projectName = '',
+): ProjectConversationTabState {
+  return {
+    id: `tab-${providerId || 'blank'}-${projectId || 'global'}`,
+    providerId,
+    projectId,
+    projectName,
+    conversationId: '',
+    entries: [],
+    queuedTurns: [],
+    draft: '',
+    phase: 'idle',
+    restored: false,
+    needsHydration: false,
+  } as unknown as ProjectConversationTabState
+}
+
+describe('project conversation restore helpers', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('tracks failed project fetches without dropping the successful conversations', async () => {
+    listProjectConversations.mockImplementation(async ({ projectId }: { projectId: string }) => {
+      if (projectId === 'project-2') {
+        throw new Error('temporary failure')
+      }
+      return {
+        conversations: [
+          {
+            id: 'conversation-1',
+            projectId,
+            providerId: 'provider-1',
+            lastActivityAt: '2026-04-01T10:00:00Z',
+          },
+        ],
+      }
+    })
+
+    const persistedTabs: PersistedProjectConversationTab[] = [
+      {
+        projectId: 'project-2',
+        projectName: 'Project 2',
+        conversationId: 'conversation-2',
+        providerId: 'provider-2',
+        draft: 'keep me',
+      },
+    ]
+
+    const result = await fetchCrossProjectConversations('project-1', persistedTabs)
+
+    expect(result.allConversations).toHaveLength(1)
+    expect(result.allConversations[0]?.id).toBe('conversation-1')
+    expect(result.currentProjectConversationIds.has('conversation-1')).toBe(true)
+    expect(result.failedProjectIds.has('project-2')).toBe(true)
+  })
+
+  it('keeps persisted tabs hydration-ready when their project fetch fails', () => {
+    const persistedTabs: PersistedProjectConversationTab[] = [
+      {
+        projectId: 'project-2',
+        projectName: 'Project 2',
+        conversationId: 'conversation-2',
+        providerId: 'provider-2',
+        draft: 'recover me',
+      },
+    ]
+
+    const restoredTabs = mapPersistedToRestoredTabs(
+      persistedTabs,
+      new Map(),
+      new Set(['project-2']),
+      (providerId, _restored, projectId, projectName) =>
+        createTabState(providerId, projectId, projectName),
+      'provider-fallback',
+    )
+
+    expect(restoredTabs).toHaveLength(1)
+    expect(restoredTabs[0]?.conversationId).toBe('conversation-2')
+    expect(restoredTabs[0]?.restored).toBe(true)
+    expect(restoredTabs[0]?.tab.conversationId).toBe('conversation-2')
+    expect(restoredTabs[0]?.tab.providerId).toBe('provider-2')
+    expect(restoredTabs[0]?.tab.needsHydration).toBe(true)
+    expect(restoredTabs[0]?.tab.draft).toBe('recover me')
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-controller-restore-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-restore-helpers.ts
@@ -247,7 +247,9 @@ export async function restoreProjectConversationController(
       }
 
       if (tab.id === preferredActiveTabId) {
-        if (await input.runtime.loadTabConversation(tab, restored.conversationId, restored.restored)) {
+        if (
+          await input.runtime.loadTabConversation(tab, restored.conversationId, restored.restored)
+        ) {
           loadedTabIDs.add(tab.id)
         } else {
           loadedTabIDs.add(tab.id)

--- a/web/src/lib/features/chat/project-conversation-controller-restore-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-restore-helpers.ts
@@ -14,6 +14,7 @@ import {
 export type FetchedConversationsResult = {
   allConversations: ProjectConversation[]
   currentProjectConversationIds: Set<string>
+  failedProjectIds: Set<string>
 }
 
 export async function fetchCrossProjectConversations(
@@ -27,17 +28,21 @@ export async function fetchCrossProjectConversations(
 
   const allConversations: ProjectConversation[] = []
   const currentProjectConversationIds = new Set<string>()
+  const failedProjectIds = new Set<string>()
   const fetchResults = await Promise.all(
     [...projectIdsToFetch].map(async (pid) => {
       try {
         const payload = await listProjectConversations({ projectId: pid })
-        return { pid, conversations: payload.conversations }
+        return { pid, conversations: payload.conversations, ok: true }
       } catch {
-        return { pid, conversations: [] as ProjectConversation[] }
+        return { pid, conversations: [] as ProjectConversation[], ok: false }
       }
     }),
   )
   for (const result of fetchResults) {
+    if (!result.ok) {
+      failedProjectIds.add(result.pid)
+    }
     for (const conversation of result.conversations) {
       allConversations.push(conversation)
       if (result.pid === currentProjectId) {
@@ -46,7 +51,7 @@ export async function fetchCrossProjectConversations(
     }
   }
 
-  return { allConversations, currentProjectConversationIds }
+  return { allConversations, currentProjectConversationIds, failedProjectIds }
 }
 
 export type RestoredTabItem = {
@@ -58,6 +63,7 @@ export type RestoredTabItem = {
 export function mapPersistedToRestoredTabs(
   persistedTabs: PersistedProjectConversationTab[],
   conversationsByID: Map<string, ProjectConversation>,
+  failedProjectIds: Set<string>,
   newTabState: (
     providerId?: string,
     restored?: boolean,
@@ -80,6 +86,22 @@ export function mapPersistedToRestoredTabs(
         )
         tab.draft = persistedTab.draft
         return { tab, conversationId: conversation.id, restored: true }
+      }
+      if (
+        persistedTab.conversationId.trim() &&
+        persistedTab.projectId &&
+        failedProjectIds.has(persistedTab.projectId)
+      ) {
+        const tab = newTabState(
+          persistedTab.providerId || fallbackProviderId,
+          true,
+          persistedTab.projectId,
+          persistedTab.projectName,
+        )
+        tab.conversationId = persistedTab.conversationId.trim()
+        tab.needsHydration = true
+        tab.draft = persistedTab.draft
+        return { tab, conversationId: tab.conversationId, restored: true }
       }
       if (persistedTab.conversationId.trim()) {
         return null
@@ -146,7 +168,7 @@ export async function restoreProjectConversationController(
     migrateLegacyProjectConversationTabs(projectId)
     const persisted = readProjectConversationTabs()
 
-    const { allConversations, currentProjectConversationIds } =
+    const { allConversations, currentProjectConversationIds, failedProjectIds } =
       await fetchCrossProjectConversations(projectId, persisted.tabs)
     if (currentRestoreID !== input.getRestoreOperationID()) return
 
@@ -162,6 +184,7 @@ export async function restoreProjectConversationController(
     const restoredTabs = mapPersistedToRestoredTabs(
       persisted.tabs,
       conversationsByID,
+      failedProjectIds,
       input.newTabState,
       input.getPreferredProviderId(),
     )
@@ -219,16 +242,21 @@ export async function restoreProjectConversationController(
       const conversation = input
         .getConversations()
         .find((item) => item.id === restored.conversationId)
-      if (!tab || !conversation) {
+      if (!tab) {
         continue
       }
 
       if (tab.id === preferredActiveTabId) {
-        if (
-          await input.runtime.loadTabConversation(tab, restored.conversationId, restored.restored)
-        ) {
+        if (await input.runtime.loadTabConversation(tab, restored.conversationId, restored.restored)) {
+          loadedTabIDs.add(tab.id)
+        } else {
           loadedTabIDs.add(tab.id)
         }
+        continue
+      }
+
+      if (!conversation) {
+        loadedTabIDs.add(tab.id)
         continue
       }
 


### PR DESCRIPTION
## What
- stabilize Project AI conversation owners so OIDC users always resolve to `user:<uuid>` and auth-disabled mode converges persistent owners to `instance-admin`
- adopt and migrate legacy stored owners (`local-user:default`, `anonymous`, bare UUIDs, `browser-session:*`, and other unstable browser-local IDs) when conversations are listed or opened
- keep restored Project AI tabs hydration-ready when cross-project list requests fail instead of dropping persisted tabs

## Validation
- `PATH="$PWD/.tooling/go/bin:$HOME/.local/go1.26.1/bin:$PATH" OPENASE_PGTEST_SHARED_ROOT="$HOME/.cache/openase/pgtest" go test ./internal/chat ./internal/httpapi`
- `cd web && pnpm install --frozen-lockfile && pnpm exec vitest run src/lib/features/chat/project-conversation-controller-restore-helpers.test.ts src/lib/features/chat/project-conversation-controller-tabs.test.ts src/lib/features/chat/project-conversation-controller-runtime-effects.test.ts src/lib/features/chat/project-conversation-controller-turns.test.ts`
- `cd web && pnpm run check -- --fail-on-warnings false` (passes with one existing Svelte warning in `src/lib/features/settings/components/security-settings-human-auth-disabled-setup-draft-form.svelte:35`)

Closes ASE-246.
