### PR TITLE
Harden remote runtime transport and terminal PTY support

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/BetterAndBetterII/openase/internal/agentplatform"
 	chatservice "github.com/BetterAndBetterII/openase/internal/chat"
 	"github.com/BetterAndBetterII/openase/internal/config"
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
 	"github.com/BetterAndBetterII/openase/internal/httpapi"
 	claudecodeadapter "github.com/BetterAndBetterII/openase/internal/infra/adapter/claudecode"
 	codex "github.com/BetterAndBetterII/openase/internal/infra/adapter/codex"
@@ -597,13 +597,26 @@ func (a *App) RunOrchestrate(ctx context.Context) error {
 }
 
 func (a *App) agentPlatformAPIURL() string {
-	host := strings.TrimSpace(a.config.Server.Host)
-	switch host {
-	case "", "0.0.0.0", "::":
-		host = "127.0.0.1"
+	controlPlaneURL, err := controlplaneurl.ResolveControlPlaneURL("", a.config.Server.Host, a.config.Server.Port)
+	if err != nil {
+		host := strings.TrimSpace(a.config.Server.Host)
+		switch host {
+		case "", "0.0.0.0", "::":
+			host = "127.0.0.1"
+		}
+		return "http://" + host + ":" + strconv.Itoa(a.config.Server.Port) + "/api/v1/platform"
 	}
 
-	return "http://" + net.JoinHostPort(host, strconv.Itoa(a.config.Server.Port)) + "/api/v1/platform"
+	apiURL, err := controlplaneurl.APIBaseURLFromControlPlaneURL(controlPlaneURL, true)
+	if err != nil {
+		host := strings.TrimSpace(a.config.Server.Host)
+		switch host {
+		case "", "0.0.0.0", "::":
+			host = "127.0.0.1"
+		}
+		return "http://" + host + ":" + strconv.Itoa(a.config.Server.Port) + "/api/v1/platform"
+	}
+	return apiURL
 }
 
 func sumSkipCounts(values map[string]int) int {

--- a/internal/app/app_control_plane_test.go
+++ b/internal/app/app_control_plane_test.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/BetterAndBetterII/openase/internal/config"
+)
+
+func TestAgentPlatformAPIURLPrefersOpenASEBaseURL(t *testing.T) {
+	t.Setenv("OPENASE_BASE_URL", "https://control.example.com")
+	app := &App{config: config.Config{Server: config.ServerConfig{Host: "127.0.0.1", Port: 19836}}}
+	if got := app.agentPlatformAPIURL(); got != "https://control.example.com/api/v1/platform" {
+		t.Fatalf("agentPlatformAPIURL() = %q", got)
+	}
+}

--- a/internal/chat/conversation_terminal_service.go
+++ b/internal/chat/conversation_terminal_service.go
@@ -682,12 +682,7 @@ func (p *remoteConversationTerminalProcess) Close() error {
 }
 
 func (p *remoteConversationTerminalProcess) Resize(cols int, rows int) error {
-	size, err := conversationTerminalPTYSize(cols, rows)
-	if err != nil {
-		return err
-	}
-	_ = size
-	return nil
+	return p.session.Resize(cols, rows)
 }
 
 func (p *remoteConversationTerminalProcess) Wait() error {
@@ -741,7 +736,7 @@ func (s *ConversationTerminalService) startRemoteProcess(
 		done:    make(chan struct{}),
 	}
 
-	if err := session.Start(buildRemoteConversationTerminalCommand(spec)); err != nil {
+	if err := session.StartPTY(buildRemoteConversationTerminalCommand(spec), spec.Cols, spec.Rows); err != nil {
 		_ = stdin.Close()
 		_ = session.Close()
 		_ = writer.CloseWithError(err)

--- a/internal/chat/conversation_terminal_service_test.go
+++ b/internal/chat/conversation_terminal_service_test.go
@@ -134,6 +134,9 @@ func TestConversationTerminalServiceCreateSessionResolvesRepoCWD(t *testing.T) {
 
 	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 	wantCWD := filepath.Join(fixture.repoPaths["backend"], "src")
@@ -194,6 +197,9 @@ func TestConversationTerminalServiceAttachStreamsAndCleansUp(t *testing.T) {
 	}
 	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 	if _, err := service.AttachSession(UserID("user:conversation"), fixture.conversation.ID, session.ID, "wrong-token"); !errors.Is(err, ErrConversationTerminalAttachForbidden) {
@@ -255,6 +261,9 @@ func TestConversationTerminalServiceDetachAllowsReattachAndReplaysBufferedOutput
 	}
 	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 
@@ -331,6 +340,9 @@ func TestConversationTerminalServiceCloseTriggersCleanup(t *testing.T) {
 	input, _ := chatdomain.ParseOpenTerminalSessionInput(chatdomain.OpenTerminalSessionRawInput{Mode: "shell"})
 	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 	attachment, err := service.AttachSession(UserID("user:conversation"), fixture.conversation.ID, session.ID, session.AttachToken)
@@ -376,6 +388,9 @@ func TestConversationTerminalServiceSupportsWebsocketRuntime(t *testing.T) {
 
 	session, err := service.CreateSession(fixture.ctx, UserID("user:conversation"), fixture.conversation.ID, input)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 	if session.CWD != filepath.Join(fixture.repoPaths["backend"], "src") {

--- a/internal/chat/project_conversation_runtime.go
+++ b/internal/chat/project_conversation_runtime.go
@@ -104,6 +104,7 @@ func (s *ProjectConversationService) startTurn(
 				ctx,
 				conversation,
 				project,
+				live.machine,
 				providerItem,
 				live.workspace,
 				resumePrompt,
@@ -200,7 +201,7 @@ func (s *ProjectConversationService) startTurn(
 		live.principal = principal
 	}
 
-	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, providerItem, promptFocus)
+	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, live.machine, providerItem, promptFocus)
 	if err != nil {
 		return domain.Turn{}, err
 	}
@@ -324,6 +325,7 @@ func (s *ProjectConversationService) RespondInterrupt(
 				ctx,
 				conversation,
 				project,
+				live.machine,
 				providerItem,
 				live.workspace,
 				systemPrompt,
@@ -349,7 +351,7 @@ func (s *ProjectConversationService) RespondInterrupt(
 	if err != nil {
 		return domain.PendingInterrupt{}, err
 	}
-	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, providerItem, storedFocus)
+	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, live.machine, providerItem, storedFocus)
 	if err != nil {
 		return domain.PendingInterrupt{}, err
 	}
@@ -438,6 +440,7 @@ func (s *ProjectConversationService) buildConversationRuntimeInput(
 	ctx context.Context,
 	conversation domain.Conversation,
 	project catalogdomain.Project,
+	machine catalogdomain.Machine,
 	providerItem catalogdomain.AgentProvider,
 	workspace provider.AbsolutePath,
 	systemPrompt string,
@@ -445,7 +448,7 @@ func (s *ProjectConversationService) buildConversationRuntimeInput(
 	resumeTurnID string,
 	focus *ProjectConversationFocus,
 ) (RuntimeTurnInput, error) {
-	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, providerItem, focus)
+	environment, err := s.buildConversationRuntimeEnvironment(ctx, conversation, project, machine, providerItem, focus)
 	if err != nil {
 		return RuntimeTurnInput{}, err
 	}
@@ -819,6 +822,7 @@ func (s *ProjectConversationService) buildConversationRuntimeEnvironment(
 	ctx context.Context,
 	conversation domain.Conversation,
 	project catalogdomain.Project,
+	machine catalogdomain.Machine,
 	providerItem catalogdomain.AgentProvider,
 	focus *ProjectConversationFocus,
 ) ([]string, error) {
@@ -827,6 +831,8 @@ func (s *ProjectConversationService) buildConversationRuntimeEnvironment(
 		if executable, err := os.Executable(); err == nil && strings.TrimSpace(executable) != "" {
 			environment = append(environment, "OPENASE_REAL_BIN="+executable)
 		}
+	} else if resolved := catalogdomain.ResolveMachineOpenASEBinaryPath(machine); resolved != nil {
+		environment = catalogdomain.UpsertMachineEnvironmentValue(environment, "OPENASE_REAL_BIN", *resolved)
 	}
 
 	if s != nil && s.core.agentPlatform != nil && s.core.catalog != nil && strings.TrimSpace(s.core.platformAPIURL) != "" {

--- a/internal/chat/project_conversation_runtime_manager.go
+++ b/internal/chat/project_conversation_runtime_manager.go
@@ -415,9 +415,13 @@ func (m *projectConversationRuntimeManager) runRemoteRuntimePreflight(
 	if resolved := catalogdomain.ResolveMachineAgentCLIPath(machine, providerItem.AdapterType); resolved != nil {
 		command = *resolved
 	}
+	environment := append([]string(nil), machine.EnvVars...)
+	if resolved := catalogdomain.ResolveMachineOpenASEBinaryPath(machine); resolved != nil {
+		environment = catalogdomain.UpsertMachineEnvironmentValue(environment, "OPENASE_REAL_BIN", *resolved)
+	}
 	return machinetransport.RunRemoteRuntimePreflight(ctx, resolved.CommandSessionExecutor(), machine, machinetransport.RuntimePreflightSpec{
 		WorkingDirectory: workspacePath,
 		AgentCommand:     command,
-		Environment:      append([]string(nil), machine.EnvVars...),
+		Environment:      environment,
 	})
 }

--- a/internal/chat/project_conversation_service_test.go
+++ b/internal/chat/project_conversation_service_test.go
@@ -421,6 +421,7 @@ func TestProjectConversationRuntimeEnvironmentInjectsTicketIDForTicketFocus(t *t
 		ctx,
 		conversation,
 		project,
+		catalogdomain.Machine{},
 		providerItem,
 		&ProjectConversationFocus{
 			Kind: ProjectConversationFocusTicket,
@@ -461,7 +462,7 @@ func TestProjectConversationRuntimeEnvironmentInjectsTicketIDForTicketFocus(t *t
 	}
 
 	platform.lastInput = agentplatform.IssueInput{}
-	environment, err = service.buildConversationRuntimeEnvironment(ctx, conversation, project, providerItem, nil)
+	environment, err = service.buildConversationRuntimeEnvironment(ctx, conversation, project, catalogdomain.Machine{}, providerItem, nil)
 	if err != nil {
 		t.Fatalf("build conversation runtime environment without ticket focus: %v", err)
 	}
@@ -546,7 +547,7 @@ func TestProjectConversationRuntimeEnvironmentFiltersLegacyInvalidScopes(t *test
 		MachineHost:    catalogdomain.LocalMachineHost,
 	}
 
-	environment, err := service.buildConversationRuntimeEnvironment(ctx, conversation, project, providerItem, nil)
+	environment, err := service.buildConversationRuntimeEnvironment(ctx, conversation, project, catalogdomain.Machine{}, providerItem, nil)
 	if err != nil {
 		t.Fatalf("build conversation runtime environment: %v", err)
 	}
@@ -561,6 +562,43 @@ func TestProjectConversationRuntimeEnvironmentFiltersLegacyInvalidScopes(t *test
 	}
 	if !containsEnvironmentPrefix(environment, "OPENASE_AGENT_SCOPES=tickets.list") {
 		t.Fatalf("expected filtered OPENASE_AGENT_SCOPES in environment, got %+v", environment)
+	}
+}
+
+func TestProjectConversationRuntimeEnvironmentInjectsRemoteOpenASERealBin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := NewProjectConversationService(nil, nil, nil, nil, nil, nil, nil)
+	conversation := chatdomain.Conversation{
+		ID:         uuid.New(),
+		ProjectID:  uuid.New(),
+		ProviderID: uuid.New(),
+	}
+	project := catalogdomain.Project{
+		ID:             conversation.ProjectID,
+		OrganizationID: uuid.New(),
+		Name:           "OpenASE",
+		Slug:           "openase",
+	}
+	providerItem := catalogdomain.AgentProvider{
+		ID:             conversation.ProviderID,
+		OrganizationID: project.OrganizationID,
+		AdapterType:    catalogdomain.AgentProviderAdapterTypeCodexAppServer,
+		MachineHost:    "listener.internal",
+	}
+	sshUser := "agentuser"
+	machine := catalogdomain.Machine{
+		Host:    "listener.internal",
+		SSHUser: &sshUser,
+	}
+
+	environment, err := service.buildConversationRuntimeEnvironment(ctx, conversation, project, machine, providerItem, nil)
+	if err != nil {
+		t.Fatalf("build conversation runtime environment: %v", err)
+	}
+	if !containsEnvironmentPrefix(environment, "OPENASE_REAL_BIN=/home/agentuser/.openase/bin/openase") {
+		t.Fatalf("expected remote OPENASE_REAL_BIN in environment, got %+v", environment)
 	}
 }
 
@@ -6339,6 +6377,12 @@ func (s *projectConversationSSHPrepareSession) Start(string) error {
 	return fmt.Errorf("not supported")
 }
 
+func (s *projectConversationSSHPrepareSession) StartPTY(string, int, int) error {
+	return fmt.Errorf("not supported")
+}
+
+func (s *projectConversationSSHPrepareSession) Resize(int, int) error { return nil }
+
 func (s *projectConversationSSHPrepareSession) Signal(string) error { return nil }
 
 func (s *projectConversationSSHPrepareSession) Wait() error { return nil }
@@ -6376,6 +6420,13 @@ func (s *projectConversationSSHProcessSession) Start(cmd string) error {
 	s.startedCommand = cmd
 	return nil
 }
+
+func (s *projectConversationSSHProcessSession) StartPTY(cmd string, _ int, _ int) error {
+	s.startedCommand = cmd
+	return nil
+}
+
+func (s *projectConversationSSHProcessSession) Resize(int, int) error { return nil }
 
 func (s *projectConversationSSHProcessSession) Signal(string) error { return nil }
 

--- a/internal/cli/api_http.go
+++ b/internal/cli/api_http.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"unicode"
 
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
 	"github.com/BetterAndBetterII/openase/internal/httpapi"
 	"github.com/spf13/pflag"
 )
@@ -110,6 +111,18 @@ func normalizeResourceAPIBaseURL(baseURL string) string {
 		parsed.RawPath = ""
 	}
 	return parsed.String()
+}
+
+func defaultAPIURLFromEnvironment() string {
+	controlPlaneURL := strings.TrimSpace(os.Getenv(controlplaneurl.EnvMachineControlPlaneURL))
+	if controlPlaneURL == "" {
+		return defaultAPIURL
+	}
+	apiURL, err := controlplaneurl.APIBaseURLFromControlPlaneURL(controlPlaneURL, false)
+	if err != nil {
+		return defaultAPIURL
+	}
+	return apiURL
 }
 
 func (ctx apiCommandContext) do(ctx2 context.Context, deps apiCommandDeps, request apiRequest) (apiResponse, error) {
@@ -294,7 +307,7 @@ func (options apiCommandOptions) resolveHumanSessionState() (*humanSessionState,
 }
 
 func (options apiCommandOptions) resolveWithResourceBase(normalizeResourceBase bool) (apiCommandContext, error) {
-	baseURL := strings.TrimRight(strings.TrimSpace(firstNonEmpty(options.apiURL, os.Getenv("OPENASE_API_URL"), defaultAPIURL)), "/")
+	baseURL := strings.TrimRight(strings.TrimSpace(firstNonEmpty(options.apiURL, os.Getenv("OPENASE_API_URL"), defaultAPIURLFromEnvironment())), "/")
 	if baseURL == "" {
 		return apiCommandContext{}, fmt.Errorf("api url must not be empty")
 	}

--- a/internal/cli/auth_bootstrap.go
+++ b/internal/cli/auth_bootstrap.go
@@ -68,7 +68,7 @@ func newAuthBootstrapCommand(options *rootOptions) *cobra.Command {
 		Short: "Create and redeem local bootstrap browser authorization links.",
 	}
 	command.AddCommand(newAuthBootstrapCreateLinkCommand(options))
-	command.AddCommand(newAuthBootstrapLoginCommand(options, authBootstrapLoginDeps{httpClient: http.DefaultClient}))
+	command.AddCommand(newAuthBootstrapLoginCommand(options, authBootstrapLoginDeps{httpClient: defaultCLIHTTPDoer()}))
 	return command
 }
 
@@ -158,7 +158,7 @@ long-lived bearer token.
 
 func newAuthBootstrapLoginCommand(options *rootOptions, deps authBootstrapLoginDeps) *cobra.Command {
 	if deps.httpClient == nil {
-		deps.httpClient = http.DefaultClient
+		deps.httpClient = defaultCLIHTTPDoer()
 	}
 
 	var (

--- a/internal/cli/http_client.go
+++ b/internal/cli/http_client.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	domain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+)
+
+func defaultCLIHTTPDoer() platformHTTPDoer {
+	relayURL := strings.TrimSpace(os.Getenv(domain.EnvMachineLocalRelayURL))
+	if relayURL == "" {
+		return http.DefaultClient
+	}
+	return machineRelayHTTPDoer{relayURL: relayURL, client: http.DefaultClient}
+}
+
+type machineRelayHTTPDoer struct {
+	relayURL string
+	client   platformHTTPDoer
+}
+
+func (d machineRelayHTTPDoer) Do(request *http.Request) (*http.Response, error) {
+	if request == nil {
+		return nil, fmt.Errorf("relay request must not be nil")
+	}
+	var body []byte
+	if request.Body != nil {
+		payload, err := io.ReadAll(request.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read request body for relay: %w", err)
+		}
+		body = payload
+		request.Body = io.NopCloser(bytes.NewReader(payload))
+	}
+	localRequestBody, err := json.Marshal(domain.LocalRelayRequest{
+		Method:  request.Method,
+		URL:     request.URL.String(),
+		Headers: map[string][]string(request.Header.Clone()),
+		Body:    body,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal relay payload: %w", err)
+	}
+	bridgeURL := strings.TrimRight(strings.TrimSpace(d.relayURL), "/") + "/__openase_cli_relay"
+	localRequest, err := http.NewRequestWithContext(request.Context(), http.MethodPost, bridgeURL, bytes.NewReader(localRequestBody))
+	if err != nil {
+		return nil, fmt.Errorf("build local relay request: %w", err)
+	}
+	localRequest.Header.Set("Content-Type", "application/json")
+	client := d.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	localResponse, err := client.Do(localRequest)
+	if err != nil {
+		return nil, fmt.Errorf("local relay transport: %w", err)
+	}
+	defer func() {
+		_ = localResponse.Body.Close()
+	}()
+	payload, err := io.ReadAll(localResponse.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read local relay response: %w", err)
+	}
+	var relayResponse domain.LocalRelayResponse
+	if err := json.Unmarshal(payload, &relayResponse); err != nil {
+		return nil, fmt.Errorf("decode local relay response: %w", err)
+	}
+	if localResponse.StatusCode < http.StatusOK || localResponse.StatusCode >= http.StatusMultipleChoices {
+		message := strings.TrimSpace(relayResponse.Error)
+		if message == "" {
+			message = strings.TrimSpace(string(payload))
+		}
+		return nil, fmt.Errorf("local relay transport: %s", message)
+	}
+	statusCode := relayResponse.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	status := strings.TrimSpace(relayResponse.Status)
+	if status == "" {
+		status = fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode))
+	}
+	return &http.Response{
+		StatusCode:    statusCode,
+		Status:        status,
+		Header:        http.Header(cloneRelayHeaders(relayResponse.Headers)),
+		Body:          io.NopCloser(bytes.NewReader(relayResponse.Body)),
+		ContentLength: int64(len(relayResponse.Body)),
+		Request:       request,
+	}, nil
+}

--- a/internal/cli/http_client.go
+++ b/internal/cli/http_client.go
@@ -97,35 +97,13 @@ func (d machineRelayHTTPDoer) Do(request *http.Request) (*http.Response, error) 
 	}, nil
 }
 
-func cloneRelayHeaders(headers map[string][]string) map[string][]string {
-	if len(headers) == 0 {
-		return nil
-	}
-	cloned := make(map[string][]string, len(headers))
-	for key, values := range headers {
-		trimmedKey := strings.TrimSpace(key)
-		if trimmedKey == "" {
-			continue
-		}
-		cloned[trimmedKey] = append([]string(nil), values...)
-	}
-	if len(cloned) == 0 {
-		return nil
-	}
-	return cloned
-}
-
 func cloneRelayHeaderMap(headers map[string][]string) map[string][]string {
 	if len(headers) == 0 {
 		return nil
 	}
 	cloned := make(map[string][]string, len(headers))
 	for key, values := range headers {
-		copied := make([]string, 0, len(values))
-		for _, value := range values {
-			copied = append(copied, value)
-		}
-		cloned[key] = copied
+		cloned[key] = append([]string(nil), values...)
 	}
 	return cloned
 }

--- a/internal/cli/http_client.go
+++ b/internal/cli/http_client.go
@@ -96,3 +96,21 @@ func (d machineRelayHTTPDoer) Do(request *http.Request) (*http.Response, error) 
 		Request:       request,
 	}, nil
 }
+
+func cloneRelayHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		cloned[trimmedKey] = append([]string(nil), values...)
+	}
+	if len(cloned) == 0 {
+		return nil
+	}
+	return cloned
+}

--- a/internal/cli/http_client.go
+++ b/internal/cli/http_client.go
@@ -55,7 +55,7 @@ func (d machineRelayHTTPDoer) Do(request *http.Request) (*http.Response, error) 
 	localRequest.Header.Set("Content-Type", "application/json")
 	client := d.client
 	if client == nil {
-		client = http.DefaultClient
+		client = defaultCLIHTTPDoer()
 	}
 	localResponse, err := client.Do(localRequest)
 	if err != nil {
@@ -90,7 +90,7 @@ func (d machineRelayHTTPDoer) Do(request *http.Request) (*http.Response, error) 
 	return &http.Response{
 		StatusCode:    statusCode,
 		Status:        status,
-		Header:        http.Header(cloneRelayHeaders(relayResponse.Headers)),
+		Header:        http.Header(cloneRelayHeaderMap(relayResponse.Headers)),
 		Body:          io.NopCloser(bytes.NewReader(relayResponse.Body)),
 		ContentLength: int64(len(relayResponse.Body)),
 		Request:       request,
@@ -111,6 +111,21 @@ func cloneRelayHeaders(headers map[string][]string) map[string][]string {
 	}
 	if len(cloned) == 0 {
 		return nil
+	}
+	return cloned
+}
+
+func cloneRelayHeaderMap(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		copied := make([]string, 0, len(values))
+		for _, value := range values {
+			copied = append(copied, value)
+		}
+		cloned[key] = copied
 	}
 	return cloned
 }

--- a/internal/cli/human_session.go
+++ b/internal/cli/human_session.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
 )
 
 const (
@@ -118,25 +120,7 @@ func removeHumanSessionState(path string) error {
 }
 
 func apiBaseURLFromControlPlaneURL(base string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(base))
-	if err != nil {
-		return "", fmt.Errorf("parse control-plane url: %w", err)
-	}
-	path := strings.TrimRight(parsed.Path, "/")
-	switch {
-	case path == "":
-		parsed.Path = "/api/v1"
-	case strings.HasSuffix(path, "/api/v1/platform"):
-		parsed.Path = strings.TrimSuffix(path, "/platform")
-	case strings.HasSuffix(path, "/api/v1"):
-		parsed.Path = path
-	default:
-		parsed.Path = path + "/api/v1"
-	}
-	parsed.RawPath = ""
-	parsed.RawQuery = ""
-	parsed.Fragment = ""
-	return strings.TrimRight(parsed.String(), "/"), nil
+	return controlplaneurl.APIBaseURLFromControlPlaneURL(base, false)
 }
 
 func originFromAPIURL(apiURL string) (string, error) {

--- a/internal/cli/issue_agent_token.go
+++ b/internal/cli/issue_agent_token.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/BetterAndBetterII/openase/internal/agentplatform"
 	"github.com/BetterAndBetterII/openase/internal/config"
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
 	agentplatformrepo "github.com/BetterAndBetterII/openase/internal/repo/agentplatform"
 	"github.com/BetterAndBetterII/openase/internal/runtime/database"
 	"github.com/google/uuid"
@@ -157,21 +156,11 @@ func parseUUIDFlag(name string, raw string) (uuid.UUID, error) {
 }
 
 func resolveAgentPlatformAPIURL(cfg config.Config, explicit string) (string, error) {
-	trimmed := strings.TrimSpace(explicit)
-	if trimmed != "" {
-		if _, err := url.ParseRequestURI(trimmed); err != nil {
-			return "", fmt.Errorf("parse api-url: %w", err)
-		}
-		return strings.TrimRight(trimmed, "/"), nil
+	controlPlaneURL, err := controlplaneurl.ResolveControlPlaneURL(explicit, cfg.Server.Host, cfg.Server.Port)
+	if err != nil {
+		return "", err
 	}
-
-	host := strings.TrimSpace(cfg.Server.Host)
-	switch host {
-	case "", "0.0.0.0", "::", "[::]":
-		host = "127.0.0.1"
-	}
-
-	return "http://" + net.JoinHostPort(host, fmt.Sprintf("%d", cfg.Server.Port)) + "/api/v1/platform", nil
+	return controlplaneurl.APIBaseURLFromControlPlaneURL(controlPlaneURL, true)
 }
 
 func buildIssueAgentTokenEnvironment(apiURL string, token string, projectID uuid.UUID, ticketID uuid.UUID, expiresAt time.Time) map[string]string {

--- a/internal/cli/machine_agent.go
+++ b/internal/cli/machine_agent.go
@@ -173,6 +173,12 @@ contract and optionally protects the endpoint with a static bearer token.
   openase machine-agent listen
 `),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			relayManager := machinetransport.NewRuntimeLocalRelayManagerForCLI()
+			if _, relayURL, err := machinetransport.StartRuntimeLocalRelayServerForCLI(cmd.Context(), relayManager, os.Getenv(machinechanneldomain.EnvMachineLocalRelayAddress)); err != nil {
+				return err
+			} else {
+				_ = relayURL
+			}
 			resolvedAddress := firstNonEmpty(listenAddress, os.Getenv(envMachineListenerAddress))
 			if strings.TrimSpace(resolvedAddress) == "" {
 				resolvedAddress = defaultMachineListenerAddress
@@ -189,6 +195,7 @@ contract and optionally protects the endpoint with a static bearer token.
 			mux := http.NewServeMux()
 			mux.Handle(resolvedPath, machinetransport.NewWebsocketListenerHandler(machinetransport.ListenerHandlerOptions{
 				BearerToken: resolvedToken,
+				APIRelay:    relayManager,
 			}))
 			server := &http.Server{
 				Addr:              resolvedAddress,

--- a/internal/cli/machine_agent.go
+++ b/internal/cli/machine_agent.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"

--- a/internal/cli/machine_agent.go
+++ b/internal/cli/machine_agent.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BetterAndBetterII/openase/internal/config"
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
 	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
 	machinetransport "github.com/BetterAndBetterII/openase/internal/infra/machinetransport"
 	machinechannelservice "github.com/BetterAndBetterII/openase/internal/machinechannel"
@@ -373,21 +374,7 @@ correct machine-bound reverse websocket credential is revoked.
 }
 
 func resolveControlPlaneURL(cfg config.Config, explicit string) (string, error) {
-	trimmed := strings.TrimSpace(explicit)
-	if trimmed != "" {
-		if _, err := url.ParseRequestURI(trimmed); err != nil {
-			return "", fmt.Errorf("parse control-plane-url: %w", err)
-		}
-		return strings.TrimRight(trimmed, "/"), nil
-	}
-
-	host := strings.TrimSpace(cfg.Server.Host)
-	switch host {
-	case "", "0.0.0.0", "::", "[::]":
-		host = "127.0.0.1"
-	}
-
-	return "http://" + net.JoinHostPort(host, fmt.Sprintf("%d", cfg.Server.Port)), nil
+	return controlplaneurl.ResolveControlPlaneURL(explicit, cfg.Server.Host, cfg.Server.Port)
 }
 
 func parseEnvDuration(key string) time.Duration {

--- a/internal/cli/machine_agent.go
+++ b/internal/cli/machine_agent.go
@@ -35,7 +35,7 @@ const (
 	envMachineListenerAddress     = "OPENASE_MACHINE_LISTENER_ADDRESS"
 	envMachineListenerPath        = "OPENASE_MACHINE_LISTENER_PATH"
 	envMachineListenerBearerToken = "OPENASE_MACHINE_LISTENER_BEARER_TOKEN"
-	defaultMachineListenerAddress = "127.0.0.1:19837"
+	defaultMachineListenerAddress = "0.0.0.0:19837"
 	defaultMachineListenerPath    = "/openase/runtime"
 )
 

--- a/internal/cli/machine_ssh_helper.go
+++ b/internal/cli/machine_ssh_helper.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -255,7 +256,7 @@ when you can still reach the machine over SSH.
 	command.Flags().StringVar(&controlPlaneURL, "control-plane-url", "", "Control-plane base URL override. Required when reusing --channel-token and defaults to the local server URL when issuing a fresh token.")
 	command.Flags().StringVar(&openaseBinaryPath, "openase-binary-path", "", "Local OpenASE binary to upload. Defaults to the current executable.")
 	command.Flags().DurationVar(&heartbeatInterval, "heartbeat-interval", machinechannelservice.DefaultHeartbeatInterval, "Daemon heartbeat interval written into the remote environment file.")
-	command.Flags().StringVar(&listenerAddress, "listener-address", defaultMachineListenerAddress, "Remote websocket listener bind address when installing the remote-listener topology.")
+	command.Flags().StringVar(&listenerAddress, "listener-address", "", "Remote websocket listener bind address when installing the remote-listener topology. Defaults to a bind inferred from advertised_endpoint, or "+defaultMachineListenerAddress+" when inference is unavailable.")
 	command.Flags().StringVar(&listenerPath, "listener-path", defaultMachineListenerPath, "Remote websocket listener HTTP path when installing the remote-listener topology.")
 	command.Flags().StringVar(&listenerBearerToken, "listener-bearer-token", "", "Optional bearer token override for the remote-listener topology. Defaults to the machine channel credential token when present.")
 	return command
@@ -394,7 +395,7 @@ func buildMachineSSHBootstrapPlan(
 			),
 		}, nil
 	case catalogdomain.MachineWebsocketTopologyRemoteListener:
-		listenerAddress := firstNonEmpty(input.ListenerAddress, defaultMachineListenerAddress)
+		listenerAddress := inferMachineListenerAddress(input.Machine, input.ListenerAddress)
 		listenerPath := normalizeMachineListenerPath(input.ListenerPath)
 		listenerToken := firstNonEmpty(input.ListenerBearerToken, strings.TrimSpace(pointerString(input.Machine.ChannelCredential.TokenID)))
 		values := map[string]string{
@@ -987,6 +988,52 @@ type machineSSHServiceInstallInput struct {
 	AgentCLIPath      string
 	HeartbeatInterval time.Duration
 	UID               string
+}
+
+func inferMachineListenerAddress(machine catalogdomain.Machine, explicit string) string {
+	trimmedExplicit := strings.TrimSpace(explicit)
+	if trimmedExplicit != "" {
+		return trimmedExplicit
+	}
+	endpoint := strings.TrimSpace(pointerString(machine.AdvertisedEndpoint))
+	if endpoint == "" {
+		return defaultMachineListenerAddress
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return defaultMachineListenerAddress
+	}
+	port := strings.TrimSpace(parsed.Port())
+	if port == "" {
+		switch strings.ToLower(strings.TrimSpace(parsed.Scheme)) {
+		case "wss", "https":
+			port = "443"
+		default:
+			port = "80"
+		}
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return net.JoinHostPort("0.0.0.0", port)
+	}
+	switch strings.ToLower(host) {
+	case "localhost":
+		return net.JoinHostPort("127.0.0.1", port)
+	case "127.0.0.1":
+		return net.JoinHostPort("127.0.0.1", port)
+	case "::1":
+		return net.JoinHostPort("::1", port)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return net.JoinHostPort(host, port)
+		}
+		if ip.To4() == nil {
+			return net.JoinHostPort("::", port)
+		}
+		return net.JoinHostPort("0.0.0.0", port)
+	}
+	return net.JoinHostPort("0.0.0.0", port)
 }
 
 func buildMachineSSHEnvironmentFile(

--- a/internal/cli/machine_ssh_helper.go
+++ b/internal/cli/machine_ssh_helper.go
@@ -808,7 +808,7 @@ func checkMachineSSHAgentCLIPath(
 }
 
 func fetchCLIMachine(ctx context.Context, apiContext apiCommandContext, machineID string) (catalogdomain.Machine, error) {
-	response, err := apiContext.do(ctx, apiCommandDeps{httpClient: http.DefaultClient}, apiRequest{
+	response, err := apiContext.do(ctx, apiCommandDeps{httpClient: defaultCLIHTTPDoer()}, apiRequest{
 		Method: http.MethodGet,
 		Path:   "machines/" + urlPathEscape(strings.TrimSpace(machineID)),
 	})

--- a/internal/cli/machine_ssh_helper_test.go
+++ b/internal/cli/machine_ssh_helper_test.go
@@ -500,6 +500,13 @@ func (s *machineSSHTestSession) Start(cmd string) error {
 	return nil
 }
 
+func (s *machineSSHTestSession) StartPTY(cmd string, _ int, _ int) error {
+	s.startCommand = cmd
+	return nil
+}
+
+func (s *machineSSHTestSession) Resize(int, int) error { return nil }
+
 func (s *machineSSHTestSession) Signal(string) error { return nil }
 
 func (s *machineSSHTestSession) Wait() error { return nil }

--- a/internal/cli/machine_ssh_helper_test.go
+++ b/internal/cli/machine_ssh_helper_test.go
@@ -518,3 +518,33 @@ type nopWriteCloser struct {
 }
 
 func (nopWriteCloser) Close() error { return nil }
+
+func TestInferMachineListenerAddressFromAdvertisedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "ws://143.198.200.192:19837/openase/runtime"
+	got := inferMachineListenerAddress(catalogdomain.Machine{AdvertisedEndpoint: &endpoint}, "")
+	if got != "0.0.0.0:19837" {
+		t.Fatalf("inferMachineListenerAddress(ipv4) = %q, want %q", got, "0.0.0.0:19837")
+	}
+}
+
+func TestInferMachineListenerAddressKeepsLoopbackAdvertisedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "ws://127.0.0.1:19837/openase/runtime"
+	got := inferMachineListenerAddress(catalogdomain.Machine{AdvertisedEndpoint: &endpoint}, "")
+	if got != "127.0.0.1:19837" {
+		t.Fatalf("inferMachineListenerAddress(loopback) = %q, want %q", got, "127.0.0.1:19837")
+	}
+}
+
+func TestInferMachineListenerAddressUsesExplicitOverride(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "ws://143.198.200.192:19837/openase/runtime"
+	got := inferMachineListenerAddress(catalogdomain.Machine{AdvertisedEndpoint: &endpoint}, "192.0.2.10:19837")
+	if got != "192.0.2.10:19837" {
+		t.Fatalf("inferMachineListenerAddress(explicit) = %q, want %q", got, "192.0.2.10:19837")
+	}
+}

--- a/internal/cli/root_resources.go
+++ b/internal/cli/root_resources.go
@@ -1,46 +1,45 @@
 package cli
 
 import (
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 func newRootTicketCommand() *cobra.Command {
-	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: http.DefaultClient})
+	command := newAgentPlatformTicketCommandWithDeps(platformCommandDeps{httpClient: defaultCLIHTTPDoer()})
 	command.Short = "Operate on tickets through OpenASE."
 	command.Long = strings.TrimSpace(command.Long +
 		"\n\nAll ticket subcommands use the agent-platform wrapper semantics so agent workspaces can rely on `--status-name` / `--status_name` and `--body-file` / `--body_file` consistently.")
 
-	command.AddCommand(newAgentPlatformTicketArchivedCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketGetCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketDetailCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketRetryResumeCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketDependencyCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketExternalLinkCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformTicketRunCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
+	command.AddCommand(newAgentPlatformTicketArchivedCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketGetCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketDetailCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketRetryResumeCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketDependencyCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketExternalLinkCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformTicketRunCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
 	return command
 }
 
 func newRootProjectCommand() *cobra.Command {
-	command := newAgentPlatformProjectCommandWithDeps(platformCommandDeps{httpClient: http.DefaultClient})
+	command := newAgentPlatformProjectCommandWithDeps(platformCommandDeps{httpClient: defaultCLIHTTPDoer()})
 	command.Short = "Operate on projects through OpenASE."
 	command.Long = strings.TrimSpace(command.Long +
 		"\n\nAll project subcommands use the agent-platform wrapper semantics in agent workspaces." +
 		"\n\nUse `openase project current` to inspect the active project from `OPENASE_PROJECT_ID`, `openase project updates ...` for curated project updates, or `openase machine list --project-id $OPENASE_PROJECT_ID` to move from project context into machine inspection without raw API fallback.")
 
-	command.AddCommand(newAgentPlatformProjectCurrentCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformProjectUpdatesCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformProjectListCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformProjectGetCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformProjectCreateCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
-	command.AddCommand(newAgentPlatformProjectDeleteCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient}))
+	command.AddCommand(newAgentPlatformProjectCurrentCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformProjectUpdatesCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformProjectListCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformProjectGetCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformProjectCreateCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
+	command.AddCommand(newAgentPlatformProjectDeleteCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()}))
 	return command
 }
 
 func newRootStatusCommand() *cobra.Command {
-	command := newAgentPlatformStatusCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient})
+	command := newAgentPlatformStatusCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()})
 	command.Short = "Operate on ticket statuses through OpenASE."
 	command.Long = strings.TrimSpace(command.Long +
 		"\n\nAll status subcommands use the agent-platform wrapper semantics so Project AI runtimes can rely on OPENASE_API_URL, OPENASE_AGENT_TOKEN, and OPENASE_PROJECT_ID consistently.")
@@ -48,7 +47,7 @@ func newRootStatusCommand() *cobra.Command {
 }
 
 func newRootWorkflowCommand() *cobra.Command {
-	command := newAgentPlatformWorkflowCommandWithDeps(apiCommandDeps{httpClient: http.DefaultClient})
+	command := newAgentPlatformWorkflowCommandWithDeps(apiCommandDeps{httpClient: defaultCLIHTTPDoer()})
 	command.Short = "Operate on workflows through OpenASE."
 	command.Long = strings.TrimSpace(command.Long +
 		"\n\nAll workflow and workflow harness subcommands use the agent-platform wrapper semantics so Project AI runtimes keep platform-aware routing, authentication, and project defaults aligned with `openase ticket` and `openase project`.")

--- a/internal/cli/skill_bundle.go
+++ b/internal/cli/skill_bundle.go
@@ -83,7 +83,7 @@ openase skill import $OPENASE_PROJECT_ID ./skills/deploy-openase --enable
 			if err != nil {
 				return err
 			}
-			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: http.DefaultClient}, apiRequest{
+			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: defaultCLIHTTPDoer()}, apiRequest{
 				Method: http.MethodPost,
 				Path:   "projects/" + urlPathEscape(projectID) + "/skills/import",
 				Body:   body,

--- a/internal/cli/typed_commands.go
+++ b/internal/cli/typed_commands.go
@@ -90,7 +90,7 @@ var (
 )
 
 func newAPICommand() *cobra.Command {
-	deps := apiCommandDeps{httpClient: http.DefaultClient}
+	deps := apiCommandDeps{httpClient: defaultCLIHTTPDoer()}
 	var options apiCommandOptions
 	var output apiOutputOptions
 	var headers []string
@@ -308,7 +308,7 @@ func newAuthCommand(options *rootOptions) *cobra.Command {
 }
 
 func newAuthLogoutCommand() *cobra.Command {
-	deps := apiCommandDeps{httpClient: http.DefaultClient}
+	deps := apiCommandDeps{httpClient: defaultCLIHTTPDoer()}
 	var output apiOutputOptions
 	command := &cobra.Command{
 		Use:   "logout",
@@ -1168,7 +1168,7 @@ machine inspection with ` + "`openase machine list --project-id $OPENASE_PROJECT
 				return fmt.Errorf("project id is required via --project-id or OPENASE_PROJECT_ID")
 			}
 
-			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: http.DefaultClient}, apiRequest{
+			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: defaultCLIHTTPDoer()}, apiRequest{
 				Method: http.MethodGet,
 				Path:   "projects/" + urlPathEscape(resolvedProjectID),
 			})
@@ -1230,7 +1230,7 @@ When project context is used, the CLI fetches the project first and derives orga
 
 			resolvedOrgID, err := resolveOrganizationIDForMachineCommand(
 				cmd.Context(),
-				apiCommandDeps{httpClient: http.DefaultClient},
+				apiCommandDeps{httpClient: defaultCLIHTTPDoer()},
 				apiContext,
 				firstNonEmpty(firstArg(args), orgID, os.Getenv("OPENASE_ORG_ID")),
 				firstNonEmpty(projectID, os.Getenv("OPENASE_PROJECT_ID")),
@@ -1239,7 +1239,7 @@ When project context is used, the CLI fetches the project first and derives orga
 				return err
 			}
 
-			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: http.DefaultClient}, apiRequest{
+			response, err := apiContext.do(cmd.Context(), apiCommandDeps{httpClient: defaultCLIHTTPDoer()}, apiRequest{
 				Method: http.MethodGet,
 				Path:   "orgs/" + urlPathEscape(resolvedOrgID) + "/machines",
 			})
@@ -1296,7 +1296,7 @@ Use Ctrl-C to stop the stream when running interactively.
 
 			resolvedOrgID, err := resolveOrganizationIDForMachineCommand(
 				cmd.Context(),
-				apiCommandDeps{httpClient: http.DefaultClient},
+				apiCommandDeps{httpClient: defaultCLIHTTPDoer()},
 				apiContext,
 				firstNonEmpty(firstArg(args), orgID, os.Getenv("OPENASE_ORG_ID")),
 				firstNonEmpty(projectID, os.Getenv("OPENASE_PROJECT_ID")),
@@ -1305,7 +1305,7 @@ Use Ctrl-C to stop the stream when running interactively.
 				return err
 			}
 
-			return apiContext.stream(cmd.Context(), apiCommandDeps{httpClient: http.DefaultClient}, apiStreamRequest{
+			return apiContext.stream(cmd.Context(), apiCommandDeps{httpClient: defaultCLIHTTPDoer()}, apiStreamRequest{
 				Method: http.MethodGet,
 				Path:   "orgs/" + urlPathEscape(resolvedOrgID) + "/machines/stream",
 			}, cmd.OutOrStdout())
@@ -1535,7 +1535,7 @@ func newStreamNamespaceCommand(use string, short string) *cobra.Command {
 
 func newOpenAPIOperationCommand(spec openAPICommandSpec) *cobra.Command {
 	contract := mustOpenAPICommandContract(spec)
-	deps := apiCommandDeps{httpClient: http.DefaultClient}
+	deps := apiCommandDeps{httpClient: defaultCLIHTTPDoer()}
 	command := &cobra.Command{
 		Use:     spec.Use,
 		Short:   contract.summary,
@@ -1554,7 +1554,7 @@ func newOpenAPIOperationCommand(spec openAPICommandSpec) *cobra.Command {
 
 func newRawBodyOpenAPIOperationCommand(spec openAPICommandSpec) *cobra.Command {
 	contract := mustOpenAPICommandContract(spec)
-	deps := apiCommandDeps{httpClient: http.DefaultClient}
+	deps := apiCommandDeps{httpClient: defaultCLIHTTPDoer()}
 	var fields []string
 	var inputPath string
 	command := &cobra.Command{
@@ -1622,7 +1622,7 @@ func buildOpenAPIOperationHelp(spec openAPICommandSpec, summary string) string {
 
 func newOpenAPIStreamCommand(spec openAPICommandSpec) *cobra.Command {
 	contract := mustOpenAPICommandContract(spec)
-	deps := apiCommandDeps{httpClient: http.DefaultClient}
+	deps := apiCommandDeps{httpClient: defaultCLIHTTPDoer()}
 	command := &cobra.Command{
 		Use:     spec.Use,
 		Short:   contract.summary,

--- a/internal/controlplaneurl/controlplane_url.go
+++ b/internal/controlplaneurl/controlplane_url.go
@@ -1,0 +1,83 @@
+package controlplaneurl
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	EnvBaseURL                = "OPENASE_BASE_URL"
+	EnvControlPlaneURL        = "OPENASE_CONTROL_PLANE_URL"
+	EnvMachineControlPlaneURL = "OPENASE_MACHINE_CONTROL_PLANE_URL"
+)
+
+func ResolveControlPlaneURL(explicit string, host string, port int) (string, error) {
+	for _, candidate := range []string{strings.TrimSpace(explicit), strings.TrimSpace(os.Getenv(EnvControlPlaneURL)), strings.TrimSpace(os.Getenv(EnvBaseURL))} {
+		if candidate == "" {
+			continue
+		}
+		parsed, err := url.ParseRequestURI(candidate)
+		if err != nil {
+			return "", fmt.Errorf("parse control-plane-url: %w", err)
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return "", fmt.Errorf("parse control-plane-url: url must include scheme and host")
+		}
+		return strings.TrimRight(candidate, "/"), nil
+	}
+
+	trimmedHost := strings.TrimSpace(host)
+	switch trimmedHost {
+	case "", "0.0.0.0", "::", "[::]":
+		trimmedHost = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(trimmedHost, strconv.Itoa(port)), nil
+}
+
+func APIBaseURLFromControlPlaneURL(raw string, platform bool) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse control-plane url: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("control-plane url must include scheme and host")
+	}
+	switch parsed.Scheme {
+	case "ws":
+		parsed.Scheme = "http"
+	case "wss":
+		parsed.Scheme = "https"
+	case "http", "https":
+	default:
+		return "", fmt.Errorf("unsupported control-plane url scheme %q", parsed.Scheme)
+	}
+
+	path := strings.TrimRight(strings.TrimSpace(parsed.Path), "/")
+	switch {
+	case path == "":
+		parsed.Path = "/api/v1"
+	case strings.HasSuffix(path, "/api/v1/platform"):
+		if platform {
+			parsed.Path = path
+		} else {
+			parsed.Path = strings.TrimSuffix(path, "/platform")
+		}
+	case strings.HasSuffix(path, "/api/v1/machines/connect"):
+		parsed.Path = strings.TrimSuffix(path, "/machines/connect")
+	case strings.HasSuffix(path, "/api/v1"):
+		parsed.Path = path
+	default:
+		parsed.Path = path + "/api/v1"
+	}
+	if platform && !strings.HasSuffix(parsed.Path, "/api/v1/platform") {
+		parsed.Path = strings.TrimRight(parsed.Path, "/") + "/platform"
+	}
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}

--- a/internal/controlplaneurl/controlplane_url_test.go
+++ b/internal/controlplaneurl/controlplane_url_test.go
@@ -1,0 +1,34 @@
+package controlplaneurl
+
+import "testing"
+
+func TestAPIBaseURLFromControlPlaneURLConvertsWebsocketConnectEndpoint(t *testing.T) {
+	t.Parallel()
+
+	apiURL, err := APIBaseURLFromControlPlaneURL("wss://control.example.com/api/v1/machines/connect", false)
+	if err != nil {
+		t.Fatalf("APIBaseURLFromControlPlaneURL(resource) error = %v", err)
+	}
+	if apiURL != "https://control.example.com/api/v1" {
+		t.Fatalf("APIBaseURLFromControlPlaneURL(resource) = %q", apiURL)
+	}
+
+	platformURL, err := APIBaseURLFromControlPlaneURL("wss://control.example.com/api/v1/machines/connect", true)
+	if err != nil {
+		t.Fatalf("APIBaseURLFromControlPlaneURL(platform) error = %v", err)
+	}
+	if platformURL != "https://control.example.com/api/v1/platform" {
+		t.Fatalf("APIBaseURLFromControlPlaneURL(platform) = %q", platformURL)
+	}
+}
+
+func TestResolveControlPlaneURLPrefersConfiguredBaseURL(t *testing.T) {
+	t.Setenv(EnvBaseURL, "https://openase.example.com")
+	resolved, err := ResolveControlPlaneURL("", "127.0.0.1", 19836)
+	if err != nil {
+		t.Fatalf("ResolveControlPlaneURL() error = %v", err)
+	}
+	if resolved != "https://openase.example.com" {
+		t.Fatalf("ResolveControlPlaneURL() = %q", resolved)
+	}
+}

--- a/internal/domain/catalog/machine_openase.go
+++ b/internal/domain/catalog/machine_openase.go
@@ -18,7 +18,7 @@ func ResolveMachineOpenASEBinaryPath(machine Machine) *string {
 		}
 	}
 
-	if telemetry := strings.TrimSpace(machineChannelString(machine.Resources, "openase_binary_path")); telemetry != "" {
+	if telemetry := strings.TrimSpace(machineChannelOpenASEBinaryPath(machine.Resources)); telemetry != "" {
 		return &telemetry
 	}
 
@@ -75,7 +75,7 @@ func lookupMachineEnvironmentValue(environment []string, key string) (string, bo
 	return "", false
 }
 
-func machineChannelString(resources map[string]any, key string) string {
+func machineChannelOpenASEBinaryPath(resources map[string]any) string {
 	if len(resources) == 0 {
 		return ""
 	}
@@ -87,6 +87,6 @@ func machineChannelString(resources map[string]any, key string) string {
 	if !ok {
 		return ""
 	}
-	value, _ := channel[key].(string)
+	value, _ := channel["openase_binary_path"].(string)
 	return value
 }

--- a/internal/domain/catalog/machine_openase.go
+++ b/internal/domain/catalog/machine_openase.go
@@ -1,0 +1,92 @@
+package catalog
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const machineOpenASEEnvKey = "OPENASE_REAL_BIN"
+
+// ResolveMachineOpenASEBinaryPath returns the best-known runnable openase path
+// for a machine. Prefer explicit machine env, then machine-channel telemetry,
+// then the ssh-bootstrap default install location under the remote user's home.
+func ResolveMachineOpenASEBinaryPath(machine Machine) *string {
+	if value, ok := lookupMachineEnvironmentValue(machine.EnvVars, machineOpenASEEnvKey); ok {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return &trimmed
+		}
+	}
+
+	if telemetry := strings.TrimSpace(machineChannelString(machine.Resources, "openase_binary_path")); telemetry != "" {
+		return &telemetry
+	}
+
+	if machine.Host == LocalMachineHost || machine.SSHUser == nil {
+		return nil
+	}
+
+	sshUser := strings.TrimSpace(*machine.SSHUser)
+	if sshUser == "" {
+		return nil
+	}
+
+	defaultPath := filepath.ToSlash(filepath.Join("/home", sshUser, ".openase", "bin", "openase"))
+	return &defaultPath
+}
+
+func UpsertMachineEnvironmentValue(environment []string, key string, value string) []string {
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return append([]string(nil), environment...)
+	}
+
+	trimmedValue := strings.TrimSpace(value)
+	filtered := make([]string, 0, len(environment)+1)
+	found := false
+	for _, entry := range environment {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(strings.TrimSpace(name), trimmedKey) {
+			if !found && trimmedValue != "" {
+				filtered = append(filtered, trimmedKey+"="+trimmedValue)
+				found = true
+			}
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	if !found && trimmedValue != "" {
+		filtered = append(filtered, trimmedKey+"="+trimmedValue)
+	}
+	return filtered
+}
+
+func lookupMachineEnvironmentValue(environment []string, key string) (string, bool) {
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return "", false
+	}
+	for _, entry := range environment {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(strings.TrimSpace(name), trimmedKey) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func machineChannelString(resources map[string]any, key string) string {
+	if len(resources) == 0 {
+		return ""
+	}
+	raw, ok := resources["machine_channel"]
+	if !ok {
+		return ""
+	}
+	channel, ok := raw.(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, _ := channel[key].(string)
+	return value
+}

--- a/internal/domain/catalog/machine_openase_test.go
+++ b/internal/domain/catalog/machine_openase_test.go
@@ -1,0 +1,52 @@
+package catalog
+
+import "testing"
+
+func TestResolveMachineOpenASEBinaryPath(t *testing.T) {
+	t.Parallel()
+
+	sshUser := "agentuser"
+	explicit := ResolveMachineOpenASEBinaryPath(Machine{
+		Host:    "listener.internal",
+		SSHUser: &sshUser,
+		EnvVars: []string{"OPENASE_REAL_BIN=/opt/openase/bin/openase"},
+	})
+	if explicit == nil || *explicit != "/opt/openase/bin/openase" {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(explicit) = %v", explicit)
+	}
+
+	telemetry := ResolveMachineOpenASEBinaryPath(Machine{
+		Host:    "listener.internal",
+		SSHUser: &sshUser,
+		Resources: map[string]any{
+			"machine_channel": map[string]any{
+				"openase_binary_path": "/srv/openase/bin/openase",
+			},
+		},
+	})
+	if telemetry == nil || *telemetry != "/srv/openase/bin/openase" {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(telemetry) = %v", telemetry)
+	}
+
+	fallback := ResolveMachineOpenASEBinaryPath(Machine{
+		Host:    "listener.internal",
+		SSHUser: &sshUser,
+	})
+	if fallback == nil || *fallback != "/home/agentuser/.openase/bin/openase" {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(fallback) = %v", fallback)
+	}
+}
+
+func TestUpsertMachineEnvironmentValue(t *testing.T) {
+	t.Parallel()
+
+	got := UpsertMachineEnvironmentValue([]string{"PATH=/usr/bin", "OPENASE_REAL_BIN="}, "OPENASE_REAL_BIN", "/home/agentuser/.openase/bin/openase")
+	if len(got) != 2 || got[1] != "OPENASE_REAL_BIN=/home/agentuser/.openase/bin/openase" {
+		t.Fatalf("UpsertMachineEnvironmentValue(replace) = %+v", got)
+	}
+
+	got = UpsertMachineEnvironmentValue([]string{"PATH=/usr/bin"}, "OPENASE_REAL_BIN", "/home/agentuser/.openase/bin/openase")
+	if len(got) != 2 || got[1] != "OPENASE_REAL_BIN=/home/agentuser/.openase/bin/openase" {
+		t.Fatalf("UpsertMachineEnvironmentValue(append) = %+v", got)
+	}
+}

--- a/internal/domain/catalog/machine_openase_test.go
+++ b/internal/domain/catalog/machine_openase_test.go
@@ -35,6 +35,25 @@ func TestResolveMachineOpenASEBinaryPath(t *testing.T) {
 	if fallback == nil || *fallback != "/home/agentuser/.openase/bin/openase" {
 		t.Fatalf("ResolveMachineOpenASEBinaryPath(fallback) = %v", fallback)
 	}
+
+	if got := ResolveMachineOpenASEBinaryPath(Machine{Host: LocalMachineHost}); got != nil {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(local) = %v, want nil", got)
+	}
+
+	blankUser := "   "
+	if got := ResolveMachineOpenASEBinaryPath(Machine{Host: "listener.internal", SSHUser: &blankUser}); got != nil {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(blank user) = %v, want nil", got)
+	}
+
+	if got := ResolveMachineOpenASEBinaryPath(Machine{
+		Host: "listener.internal",
+		Resources: map[string]any{
+			"machine_channel": "invalid",
+		},
+		SSHUser: &sshUser,
+	}); got == nil || *got != "/home/agentuser/.openase/bin/openase" {
+		t.Fatalf("ResolveMachineOpenASEBinaryPath(invalid telemetry) = %v", got)
+	}
 }
 
 func TestUpsertMachineEnvironmentValue(t *testing.T) {
@@ -48,5 +67,28 @@ func TestUpsertMachineEnvironmentValue(t *testing.T) {
 	got = UpsertMachineEnvironmentValue([]string{"PATH=/usr/bin"}, "OPENASE_REAL_BIN", "/home/agentuser/.openase/bin/openase")
 	if len(got) != 2 || got[1] != "OPENASE_REAL_BIN=/home/agentuser/.openase/bin/openase" {
 		t.Fatalf("UpsertMachineEnvironmentValue(append) = %+v", got)
+	}
+
+	got = UpsertMachineEnvironmentValue([]string{"PATH=/usr/bin"}, "   ", "/ignored")
+	if len(got) != 1 || got[0] != "PATH=/usr/bin" {
+		t.Fatalf("UpsertMachineEnvironmentValue(blank key) = %+v", got)
+	}
+
+	if value, ok := lookupMachineEnvironmentValue([]string{"PATH=/usr/bin"}, "   "); ok || value != "" {
+		t.Fatalf("lookupMachineEnvironmentValue(blank key) = %q, %t", value, ok)
+	}
+
+	if value, ok := lookupMachineEnvironmentValue([]string{"PATH=/usr/bin"}, "OPENASE_REAL_BIN"); ok || value != "" {
+		t.Fatalf("lookupMachineEnvironmentValue(missing) = %q, %t", value, ok)
+	}
+
+	if got := machineChannelString(map[string]any{}, "openase_binary_path"); got != "" {
+		t.Fatalf("machineChannelString(empty) = %q", got)
+	}
+	if got := machineChannelString(map[string]any{"other": "value"}, "openase_binary_path"); got != "" {
+		t.Fatalf("machineChannelString(missing channel) = %q", got)
+	}
+	if got := machineChannelString(map[string]any{"machine_channel": map[string]any{}}, "openase_binary_path"); got != "" {
+		t.Fatalf("machineChannelString(missing field) = %q", got)
 	}
 }

--- a/internal/domain/catalog/machine_openase_test.go
+++ b/internal/domain/catalog/machine_openase_test.go
@@ -82,13 +82,13 @@ func TestUpsertMachineEnvironmentValue(t *testing.T) {
 		t.Fatalf("lookupMachineEnvironmentValue(missing) = %q, %t", value, ok)
 	}
 
-	if got := machineChannelString(map[string]any{}, "openase_binary_path"); got != "" {
-		t.Fatalf("machineChannelString(empty) = %q", got)
+	if got := machineChannelOpenASEBinaryPath(map[string]any{}); got != "" {
+		t.Fatalf("machineChannelOpenASEBinaryPath(empty) = %q", got)
 	}
-	if got := machineChannelString(map[string]any{"other": "value"}, "openase_binary_path"); got != "" {
-		t.Fatalf("machineChannelString(missing channel) = %q", got)
+	if got := machineChannelOpenASEBinaryPath(map[string]any{"other": "value"}); got != "" {
+		t.Fatalf("machineChannelOpenASEBinaryPath(missing channel) = %q", got)
 	}
-	if got := machineChannelString(map[string]any{"machine_channel": map[string]any{}}, "openase_binary_path"); got != "" {
-		t.Fatalf("machineChannelString(missing field) = %q", got)
+	if got := machineChannelOpenASEBinaryPath(map[string]any{"machine_channel": map[string]any{}}); got != "" {
+		t.Fatalf("machineChannelOpenASEBinaryPath(missing field) = %q", got)
 	}
 }

--- a/internal/domain/catalog/machine_parse_test.go
+++ b/internal/domain/catalog/machine_parse_test.go
@@ -1,0 +1,20 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestParseCreateMachineRejectsInvalidAgentCLIPaths(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCreateMachine(uuid.New(), MachineInput{
+		Name:          "gpu-01",
+		Host:          "10.0.1.10",
+		AgentCLIPaths: map[string]string{"bad-adapter": "/bin/sh"},
+	})
+	if err == nil {
+		t.Fatal("ParseCreateMachine() expected agent_cli_paths validation error")
+	}
+}

--- a/internal/domain/machinechannel/contracts.go
+++ b/internal/domain/machinechannel/contracts.go
@@ -13,13 +13,13 @@ import (
 const (
 	TokenPrefix = "ase_machine_"
 
-	EnvMachineID                = "OPENASE_MACHINE_ID"
-	EnvMachineChannelToken      = "OPENASE_MACHINE_CHANNEL_TOKEN" // #nosec G101 -- environment variable key name, not a credential
-	EnvMachineControlPlaneURL   = "OPENASE_MACHINE_CONTROL_PLANE_URL"
-	EnvMachineHeartbeatInterval = "OPENASE_MACHINE_HEARTBEAT_INTERVAL"
-	EnvMachineAgentCLIPathsJSON = "OPENASE_MACHINE_AGENT_CLI_PATHS_JSON"
-	EnvMachineLocalRelayURL    = "OPENASE_MACHINE_LOCAL_RELAY_URL"
-	EnvMachineLocalRelayAddress = "OPENASE_MACHINE_LOCAL_RELAY_ADDRESS"
+	EnvMachineID                    = "OPENASE_MACHINE_ID"
+	EnvMachineChannelToken          = "OPENASE_MACHINE_CHANNEL_TOKEN" // #nosec G101 -- environment variable key name, not a credential
+	EnvMachineControlPlaneURL       = "OPENASE_MACHINE_CONTROL_PLANE_URL"
+	EnvMachineHeartbeatInterval     = "OPENASE_MACHINE_HEARTBEAT_INTERVAL"
+	EnvMachineAgentCLIPathsJSON     = "OPENASE_MACHINE_AGENT_CLI_PATHS_JSON"
+	EnvMachineLocalRelayURL         = "OPENASE_MACHINE_LOCAL_RELAY_URL"
+	EnvMachineLocalRelayAddress     = "OPENASE_MACHINE_LOCAL_RELAY_ADDRESS"
 	DefaultMachineLocalRelayAddress = "127.0.0.1:19839"
 )
 

--- a/internal/domain/machinechannel/contracts.go
+++ b/internal/domain/machinechannel/contracts.go
@@ -18,6 +18,9 @@ const (
 	EnvMachineControlPlaneURL   = "OPENASE_MACHINE_CONTROL_PLANE_URL"
 	EnvMachineHeartbeatInterval = "OPENASE_MACHINE_HEARTBEAT_INTERVAL"
 	EnvMachineAgentCLIPathsJSON = "OPENASE_MACHINE_AGENT_CLI_PATHS_JSON"
+	EnvMachineLocalRelayURL    = "OPENASE_MACHINE_LOCAL_RELAY_URL"
+	EnvMachineLocalRelayAddress = "OPENASE_MACHINE_LOCAL_RELAY_ADDRESS"
+	DefaultMachineLocalRelayAddress = "127.0.0.1:19839"
 )
 
 var (
@@ -151,6 +154,8 @@ const (
 	MessageTypeError         MessageType = "error"
 	MessageTypeRetryAfter    MessageType = "retry_after"
 	MessageTypeRuntime       MessageType = "runtime"
+	MessageTypeAPIRequest    MessageType = "api_request"
+	MessageTypeAPIResponse   MessageType = "api_response"
 )
 
 const ProtocolVersion = 1
@@ -292,6 +297,37 @@ type ResourceSnapshot struct {
 	FullAudit         *FullAudit `json:"full_audit,omitempty"`
 }
 
+type APIRelayRequest struct {
+	RequestID string              `json:"request_id"`
+	Method    string              `json:"method"`
+	URL       string              `json:"url"`
+	Headers   map[string][]string `json:"headers,omitempty"`
+	Body      []byte              `json:"body,omitempty"`
+}
+
+type APIRelayResponse struct {
+	RequestID  string              `json:"request_id"`
+	StatusCode int                 `json:"status_code"`
+	Status     string              `json:"status"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	Body       []byte              `json:"body,omitempty"`
+}
+
+type LocalRelayRequest struct {
+	Method  string              `json:"method"`
+	URL     string              `json:"url"`
+	Headers map[string][]string `json:"headers,omitempty"`
+	Body    []byte              `json:"body,omitempty"`
+}
+
+type LocalRelayResponse struct {
+	StatusCode int                 `json:"status_code,omitempty"`
+	Status     string              `json:"status,omitempty"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	Body       []byte              `json:"body,omitempty"`
+	Error      string              `json:"error,omitempty"`
+}
+
 func ParseToken(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" || !strings.HasPrefix(trimmed, TokenPrefix) {
@@ -320,7 +356,9 @@ func ParseEnvelope(raw []byte) (Envelope, error) {
 		MessageTypeToolInventory,
 		MessageTypeError,
 		MessageTypeRetryAfter,
-		MessageTypeRuntime:
+		MessageTypeRuntime,
+		MessageTypeAPIRequest,
+		MessageTypeAPIResponse:
 	default:
 		return Envelope{}, fmt.Errorf("%w: unsupported message type %q", ErrUnexpectedMessage, strings.TrimSpace(string(envelope.Type)))
 	}

--- a/internal/domain/machinechannel/contracts_test.go
+++ b/internal/domain/machinechannel/contracts_test.go
@@ -111,6 +111,9 @@ func TestParseDaemonAgentCLIPathsJSON(t *testing.T) {
 	} else if len(parsed) != 1 || parsed["codex-app-server"] != "/opt/codex/bin/codex" {
 		t.Fatalf("ParseDaemonAgentCLIPathsJSON(filtered) = %+v", parsed)
 	}
+	if cloned := cloneTrimmedStringMap(nil); cloned != nil {
+		t.Fatalf("cloneTrimmedStringMap(nil) = %+v, want nil", cloned)
+	}
 	if cloned := cloneTrimmedStringMap(map[string]string{"   ": "/ignored", "gemini-cli": "   "}); cloned != nil {
 		t.Fatalf("cloneTrimmedStringMap(all blank) = %+v, want nil", cloned)
 	}

--- a/internal/domain/websocketruntime/contracts.go
+++ b/internal/domain/websocketruntime/contracts.go
@@ -43,6 +43,7 @@ const (
 	OperationArtifactSync     Operation = "artifact_sync"
 	OperationCommandOpen      Operation = "command_open"
 	OperationSessionInput     Operation = "session_input"
+	OperationSessionResize    Operation = "session_resize"
 	OperationSessionSignal    Operation = "session_signal"
 	OperationSessionClose     Operation = "session_close"
 	OperationProcessStart     Operation = "process_start"
@@ -60,6 +61,7 @@ func (o Operation) IsValid() bool {
 		OperationArtifactSync,
 		OperationCommandOpen,
 		OperationSessionInput,
+		OperationSessionResize,
 		OperationSessionSignal,
 		OperationSessionClose,
 		OperationProcessStart,
@@ -258,6 +260,9 @@ type ArtifactSyncRequest struct {
 
 type CommandOpenRequest struct {
 	Command string `json:"command"`
+	PTY     bool   `json:"pty,omitempty"`
+	Cols    int    `json:"cols,omitempty"`
+	Rows    int    `json:"rows,omitempty"`
 }
 
 type ProcessStartRequest struct {
@@ -280,6 +285,12 @@ type SessionInputRequest struct {
 type SessionSignalRequest struct {
 	SessionID string `json:"session_id"`
 	Signal    string `json:"signal,omitempty"`
+}
+
+type SessionResizeRequest struct {
+	SessionID string `json:"session_id"`
+	Cols      int    `json:"cols"`
+	Rows      int    `json:"rows"`
 }
 
 type SessionCloseRequest struct {

--- a/internal/domain/websocketruntime/contracts.go
+++ b/internal/domain/websocketruntime/contracts.go
@@ -48,6 +48,7 @@ const (
 	OperationSessionClose     Operation = "session_close"
 	OperationProcessStart     Operation = "process_start"
 	OperationProcessStatus    Operation = "process_status"
+	OperationAPIRelay         Operation = "api_relay"
 	OperationSessionOutput    Operation = "session_output"
 	OperationSessionExit      Operation = "session_exit"
 )
@@ -66,6 +67,7 @@ func (o Operation) IsValid() bool {
 		OperationSessionClose,
 		OperationProcessStart,
 		OperationProcessStatus,
+		OperationAPIRelay,
 		OperationSessionOutput,
 		OperationSessionExit:
 		return true
@@ -305,6 +307,21 @@ type ProcessStatusResponse struct {
 	SessionID string `json:"session_id"`
 	Running   bool   `json:"running"`
 	ExitCode  *int   `json:"exit_code,omitempty"`
+}
+
+// APIRelayRequest forwards JSON-oriented OpenASE CLI requests over the websocket runtime channel.
+type APIRelayRequest struct {
+	Method  string              `json:"method"`
+	URL     string              `json:"url"`
+	Headers map[string][]string `json:"headers,omitempty"`
+	Body    []byte              `json:"body,omitempty"`
+}
+
+type APIRelayResponse struct {
+	StatusCode int                 `json:"status_code"`
+	Status     string              `json:"status"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	Body       []byte              `json:"body,omitempty"`
 }
 
 type SessionOutputEvent struct {

--- a/internal/httpapi/catalog_machines_ssh_bootstrap.go
+++ b/internal/httpapi/catalog_machines_ssh_bootstrap.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	controlplaneurl "github.com/BetterAndBetterII/openase/internal/controlplaneurl"
+	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/BetterAndBetterII/openase/internal/machinesetup"
 	"github.com/labstack/echo/v4"
 )
@@ -59,6 +61,18 @@ func (s *Server) sshBootstrapMachine(c echo.Context) error {
 		)
 		return c.JSON(http.StatusBadGateway, errorResponse(fmt.Sprintf("ssh bootstrap failed: %v", err)))
 	}
+	if remoteBinaryPath := strings.TrimSpace(result.RemoteBinaryPath); remoteBinaryPath != "" {
+		envVars := domain.UpsertMachineEnvironmentValue(machine.EnvVars, "OPENASE_REAL_BIN", remoteBinaryPath)
+		updateInput, err := parseMachinePatchRequest(machineID, machine, machinePatchRequest{EnvVars: &envVars})
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, errorResponse(err.Error()))
+		}
+		updatedMachine, err := s.catalog.UpdateMachine(c.Request().Context(), updateInput)
+		if err != nil {
+			return writeCatalogError(c, err)
+		}
+		machine = updatedMachine
+	}
 
 	s.logger.Info("ssh bootstrap completed",
 		"machine_id", machineID.String(),
@@ -75,19 +89,18 @@ func (s *Server) sshBootstrapMachine(c echo.Context) error {
 // caller hit round-trips correctly, falling back to the configured host and
 // port for bare localhost use.
 func (s *Server) resolveControlPlaneURL(c echo.Context) string {
-	if forwarded := strings.TrimSpace(c.Request().Header.Get("X-Forwarded-Host")); forwarded != "" {
-		scheme := strings.TrimSpace(c.Request().Header.Get("X-Forwarded-Proto"))
-		if scheme == "" {
-			scheme = "https"
+	if resolved, err := controlplaneurl.ResolveControlPlaneURL("", s.cfg.Host, s.cfg.Port); err == nil {
+		configured := strings.TrimSpace(resolved)
+		if configured != "" && !strings.Contains(configured, "://127.0.0.1") && !strings.Contains(configured, "://localhost") {
+			return configured
 		}
-		return fmt.Sprintf("%s://%s", scheme, forwarded)
 	}
-	if host := strings.TrimSpace(c.Request().Host); host != "" {
-		scheme := "http"
-		if c.IsTLS() {
-			scheme = "https"
-		}
-		return fmt.Sprintf("%s://%s", scheme, host)
+	if external := strings.TrimSpace(requestExternalBaseURL(c.Request())); external != "" {
+		return external
+	}
+	resolved, err := controlplaneurl.ResolveControlPlaneURL("", s.cfg.Host, s.cfg.Port)
+	if err == nil {
+		return resolved
 	}
 	host := strings.TrimSpace(s.cfg.Host)
 	if host == "" || host == "0.0.0.0" {

--- a/internal/httpapi/machine_channel_api.go
+++ b/internal/httpapi/machine_channel_api.go
@@ -1,11 +1,16 @@
 package httpapi
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"time"
 
@@ -209,6 +214,17 @@ func (s *Server) handleMachineConnect(c echo.Context) error {
 				s.failMachineConnection(ctx, conn, parsedMachineID, sessionID, "runtime_delivery_failed", err)
 				return nil
 			}
+		case domain.MessageTypeAPIRequest:
+			requestPayload, decodeErr := domain.DecodePayload[domain.APIRelayRequest](envelope)
+			if decodeErr != nil {
+				s.failMachineConnection(ctx, conn, parsedMachineID, sessionID, "invalid_api_request", decodeErr)
+				return nil
+			}
+			responsePayload := s.dispatchMachineAPIRequest(requestPayload)
+			if err := writeMachineEnvelope(conn, domain.MessageTypeAPIResponse, sessionID, responsePayload); err != nil {
+				s.failMachineConnection(ctx, conn, parsedMachineID, sessionID, "api_response_failed", err)
+				return nil
+			}
 		default:
 			s.failMachineConnection(ctx, conn, parsedMachineID, sessionID, "unexpected_message", domain.ErrUnexpectedMessage)
 			return nil
@@ -239,6 +255,62 @@ func runtimeEnvelopeFromMachineEnvelope(envelope domain.Envelope) (runtimecontra
 		return runtimecontract.Envelope{}, err
 	}
 	return runtimeEnvelope, nil
+}
+
+func (s *Server) dispatchMachineAPIRequest(request domain.APIRelayRequest) domain.APIRelayResponse {
+	response := domain.APIRelayResponse{RequestID: strings.TrimSpace(request.RequestID)}
+	method := strings.ToUpper(strings.TrimSpace(request.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	targetURL := strings.TrimSpace(request.URL)
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		response.StatusCode = http.StatusBadRequest
+		response.Status = http.StatusText(http.StatusBadRequest)
+		response.Headers = map[string][]string{"Content-Type": {"application/json"}}
+		response.Body = []byte(`{"error":"invalid relay url"}`)
+		return response
+	}
+	requestURI := parsedURL.RequestURI()
+	if requestURI == "" {
+		requestURI = parsedURL.Path
+	}
+	if requestURI == "" {
+		requestURI = "/"
+	}
+	httpRequest := httptest.NewRequest(method, requestURI, bytes.NewReader(request.Body))
+	httpRequest.Header = http.Header{}
+	for key, values := range request.Headers {
+		for _, value := range values {
+			httpRequest.Header.Add(key, value)
+		}
+	}
+	if parsedURL.Host != "" {
+		httpRequest.Host = parsedURL.Host
+	}
+	if parsedURL.Scheme == "https" {
+		httpRequest.TLS = &tls.ConnectionState{}
+		httpRequest.Header.Set("X-Forwarded-Proto", "https")
+	}
+	recorder := httptest.NewRecorder()
+	s.Handler().ServeHTTP(recorder, httpRequest)
+	result := recorder.Result()
+	defer func() {
+		_ = result.Body.Close()
+	}()
+	body, readErr := io.ReadAll(result.Body)
+	if readErr != nil {
+		body = []byte(`{"error":"read relay response failed"}`)
+		result.StatusCode = http.StatusInternalServerError
+		result.Status = fmt.Sprintf("%d %s", result.StatusCode, http.StatusText(result.StatusCode))
+		result.Header = http.Header{"Content-Type": {"application/json"}}
+	}
+	response.StatusCode = result.StatusCode
+	response.Status = result.Status
+	response.Headers = map[string][]string(result.Header.Clone())
+	response.Body = body
+	return response
 }
 
 func (s *Server) runMachineSessionExpiryLoop(ctx context.Context) {

--- a/internal/httpapi/machine_channel_api_test.go
+++ b/internal/httpapi/machine_channel_api_test.go
@@ -489,3 +489,68 @@ func dialMachineWebsocket(t *testing.T, serverURL string) *websocket.Conn {
 	}
 	return conn
 }
+
+func TestMachineConnectWebsocketRelaysAPIRequests(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	machineID := createReverseWebsocketMachine(t, client)
+	service := machinechannelservice.NewService(machinechannelrepo.NewEntRepository(client))
+	issued, err := service.IssueToken(ctx, domain.IssueInput{MachineID: machineID, TTL: time.Hour})
+	if err != nil {
+		t.Fatalf("IssueToken returned error: %v", err)
+	}
+
+	server := NewServer(
+		config.ServerConfig{Port: 40023},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		WithMachineChannel(service, machinechannelservice.NewSessionRegistry(machinechannelservice.DefaultHeartbeatTimeout)),
+	)
+	httpServer := httptest.NewServer(server.Handler())
+	defer httpServer.Close()
+
+	conn := dialMachineWebsocket(t, httpServer.URL)
+	defer func() { _ = conn.Close() }()
+	authenticateMachineWebsocket(t, conn, issued.Token, machineID)
+	registeredEnvelope, err := readMachineEnvelope(conn)
+	if err != nil {
+		t.Fatalf("read registered envelope: %v", err)
+	}
+	if registeredEnvelope.Type != domain.MessageTypeRegistered {
+		t.Fatalf("expected registered envelope, got %+v", registeredEnvelope)
+	}
+
+	if err := writeMachineEnvelope(conn, domain.MessageTypeAPIRequest, registeredEnvelope.SessionID, domain.APIRelayRequest{
+		RequestID: "req-1",
+		Method:    http.MethodGet,
+		URL:       httpServer.URL + "/api/v1/healthz",
+	}); err != nil {
+		t.Fatalf("write api relay request: %v", err)
+	}
+	responseEnvelope, err := readMachineEnvelope(conn)
+	if err != nil {
+		t.Fatalf("read api relay response: %v", err)
+	}
+	if responseEnvelope.Type != domain.MessageTypeAPIResponse {
+		t.Fatalf("expected api relay response envelope, got %+v", responseEnvelope)
+	}
+	responsePayload, err := domain.DecodePayload[domain.APIRelayResponse](responseEnvelope)
+	if err != nil {
+		t.Fatalf("decode api relay response: %v", err)
+	}
+	if responsePayload.RequestID != "req-1" {
+		t.Fatalf("response request_id = %q", responsePayload.RequestID)
+	}
+	if responsePayload.StatusCode != http.StatusOK {
+		t.Fatalf("response status code = %d, want %d", responsePayload.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(responsePayload.Body), `"service":"openase"`) {
+		t.Fatalf("unexpected relay body: %s", string(responsePayload.Body))
+	}
+}

--- a/internal/infra/hook/shell_executor_test.go
+++ b/internal/infra/hook/shell_executor_test.go
@@ -616,6 +616,12 @@ func (s *remoteHookTestSession) Start(cmd string) error {
 	return nil
 }
 
+func (s *remoteHookTestSession) StartPTY(cmd string, _ int, _ int) error {
+	return s.Start(cmd)
+}
+
+func (s *remoteHookTestSession) Resize(int, int) error { return nil }
+
 func (s *remoteHookTestSession) Signal(string) error { return nil }
 
 func (s *remoteHookTestSession) Wait() error { return <-s.done }

--- a/internal/infra/machinetransport/api_relay.go
+++ b/internal/infra/machinetransport/api_relay.go
@@ -15,10 +15,13 @@ import (
 
 	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
 	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
+	"github.com/BetterAndBetterII/openase/internal/logging"
 	"github.com/google/uuid"
 )
 
 const localRelayPath = "/__openase_cli_relay"
+
+var _ = logging.DeclareComponent("machine-transport-runtime-api-relay")
 
 var errRuntimeAPIRelayUnavailable = errors.New("runtime api relay is not connected")
 

--- a/internal/infra/machinetransport/api_relay.go
+++ b/internal/infra/machinetransport/api_relay.go
@@ -1,0 +1,232 @@
+package machinetransport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
+	"github.com/google/uuid"
+)
+
+const localRelayPath = "/__openase_cli_relay"
+
+var errRuntimeAPIRelayUnavailable = errors.New("runtime api relay is not connected")
+
+type runtimeAPIRelayManager struct {
+	mu      sync.RWMutex
+	session *runtimeAPIRelaySession
+}
+
+type runtimeAPIRelaySession struct {
+	mu      sync.Mutex
+	send    func(context.Context, string, runtimecontract.APIRelayRequest) error
+	pending map[string]chan runtimeAPIRelayResult
+	closed  error
+}
+
+type runtimeAPIRelayResult struct {
+	response runtimecontract.APIRelayResponse
+	err      error
+}
+
+func newRuntimeAPIRelayManager() *runtimeAPIRelayManager { return &runtimeAPIRelayManager{} }
+
+func (m *runtimeAPIRelayManager) SetSession(session *runtimeAPIRelaySession) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.session != nil && m.session != session {
+		m.session.close(errRuntimeAPIRelayUnavailable)
+	}
+	m.session = session
+	m.mu.Unlock()
+}
+
+func (m *runtimeAPIRelayManager) ClearSession(session *runtimeAPIRelaySession, err error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.session == session {
+		m.session = nil
+	}
+	m.mu.Unlock()
+	if session != nil {
+		session.close(err)
+	}
+}
+
+func (m *runtimeAPIRelayManager) RoundTrip(ctx context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
+	if m == nil {
+		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
+	}
+	m.mu.RLock()
+	session := m.session
+	m.mu.RUnlock()
+	if session == nil {
+		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
+	}
+	return session.Do(ctx, request)
+}
+
+func newRuntimeAPIRelaySession(send func(context.Context, string, runtimecontract.APIRelayRequest) error) *runtimeAPIRelaySession {
+	return &runtimeAPIRelaySession{send: send, pending: map[string]chan runtimeAPIRelayResult{}}
+}
+
+func (s *runtimeAPIRelaySession) Do(ctx context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
+	if s == nil || s.send == nil {
+		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
+	}
+	requestID := uuid.NewString()
+	responseCh := make(chan runtimeAPIRelayResult, 1)
+	s.mu.Lock()
+	if s.closed != nil {
+		err := s.closed
+		s.mu.Unlock()
+		return runtimecontract.APIRelayResponse{}, err
+	}
+	s.pending[requestID] = responseCh
+	s.mu.Unlock()
+	if err := s.send(ctx, requestID, request); err != nil {
+		s.mu.Lock()
+		delete(s.pending, requestID)
+		s.mu.Unlock()
+		return runtimecontract.APIRelayResponse{}, err
+	}
+	select {
+	case <-ctx.Done():
+		s.mu.Lock()
+		delete(s.pending, requestID)
+		s.mu.Unlock()
+		return runtimecontract.APIRelayResponse{}, ctx.Err()
+	case result := <-responseCh:
+		if result.err != nil {
+			return runtimecontract.APIRelayResponse{}, result.err
+		}
+		return result.response, nil
+	}
+}
+
+func (s *runtimeAPIRelaySession) HandleResponse(requestID string, response runtimecontract.APIRelayResponse) error {
+	if s == nil {
+		return errRuntimeAPIRelayUnavailable
+	}
+	s.mu.Lock()
+	ch, ok := s.pending[strings.TrimSpace(requestID)]
+	if ok {
+		delete(s.pending, strings.TrimSpace(requestID))
+	}
+	closed := s.closed
+	s.mu.Unlock()
+	if !ok {
+		if closed != nil {
+			return closed
+		}
+		return nil
+	}
+	ch <- runtimeAPIRelayResult{response: response}
+	return nil
+}
+
+func (s *runtimeAPIRelaySession) close(err error) {
+	if s == nil {
+		return
+	}
+	if err == nil {
+		err = errRuntimeAPIRelayUnavailable
+	}
+	s.mu.Lock()
+	if s.closed != nil {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = err
+	pending := s.pending
+	s.pending = map[string]chan runtimeAPIRelayResult{}
+	s.mu.Unlock()
+	for _, ch := range pending {
+		ch <- runtimeAPIRelayResult{err: err}
+	}
+}
+
+func startRuntimeLocalRelayServer(ctx context.Context, relay *runtimeAPIRelayManager, address string) (*http.Server, string, error) {
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		trimmed = machinechanneldomain.DefaultMachineLocalRelayAddress
+	}
+	listener, err := net.Listen("tcp", trimmed)
+	if err != nil {
+		return nil, "", fmt.Errorf("listen local runtime relay on %s: %w", trimmed, err)
+	}
+	relayURL := "http://" + listener.Addr().String()
+	if err := os.Setenv(machinechanneldomain.EnvMachineLocalRelayURL, relayURL); err != nil {
+		_ = listener.Close()
+		return nil, "", err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(localRelayPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		defer func() { _ = r.Body.Close() }()
+		var request machinechanneldomain.LocalRelayRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(machinechanneldomain.LocalRelayResponse{Error: err.Error()})
+			return
+		}
+		response, err := relay.RoundTrip(r.Context(), runtimecontract.APIRelayRequest{Method: request.Method, URL: request.URL, Headers: cloneStringHeaders(request.Headers), Body: append([]byte(nil), request.Body...)})
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(machinechanneldomain.LocalRelayResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(machinechanneldomain.LocalRelayResponse{StatusCode: response.StatusCode, Status: response.Status, Headers: cloneStringHeaders(response.Headers), Body: append([]byte(nil), response.Body...)})
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	go func() { _ = server.Serve(listener) }()
+	return server, relayURL, nil
+}
+
+func cloneStringHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		cloned[strings.TrimSpace(key)] = append([]string(nil), values...)
+	}
+	return cloned
+}
+
+func NewRuntimeLocalRelayManagerForCLI() *runtimeAPIRelayManager { return newRuntimeAPIRelayManager() }
+
+func StartRuntimeLocalRelayServerForCLI(ctx context.Context, relay *runtimeAPIRelayManager, address string) (*http.Server, string, error) {
+	return startRuntimeLocalRelayServer(ctx, relay, address)
+}

--- a/internal/infra/machinetransport/api_relay.go
+++ b/internal/infra/machinetransport/api_relay.go
@@ -206,7 +206,7 @@ func startRuntimeLocalRelayServer(ctx context.Context, relay *runtimeAPIRelayMan
 	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()
@@ -225,8 +225,12 @@ func cloneStringHeaders(headers map[string][]string) map[string][]string {
 	return cloned
 }
 
-func NewRuntimeLocalRelayManagerForCLI() *runtimeAPIRelayManager { return newRuntimeAPIRelayManager() }
+type RuntimeLocalRelayManager = runtimeAPIRelayManager
 
-func StartRuntimeLocalRelayServerForCLI(ctx context.Context, relay *runtimeAPIRelayManager, address string) (*http.Server, string, error) {
+func NewRuntimeLocalRelayManagerForCLI() *RuntimeLocalRelayManager {
+	return newRuntimeAPIRelayManager()
+}
+
+func StartRuntimeLocalRelayServerForCLI(ctx context.Context, relay *RuntimeLocalRelayManager, address string) (*http.Server, string, error) {
 	return startRuntimeLocalRelayServer(ctx, relay, address)
 }

--- a/internal/infra/machinetransport/api_relay.go
+++ b/internal/infra/machinetransport/api_relay.go
@@ -26,8 +26,66 @@ var _ = logging.DeclareComponent("machine-transport-runtime-api-relay")
 var errRuntimeAPIRelayUnavailable = errors.New("runtime api relay is not connected")
 
 type runtimeAPIRelayManager struct {
-	mu      sync.RWMutex
-	session *runtimeAPIRelaySession
+	mu       sync.RWMutex
+	sessions map[string]*runtimeAPIRelaySession
+	order    []string
+}
+
+func newRuntimeAPIRelayManager() *runtimeAPIRelayManager {
+	return &runtimeAPIRelayManager{sessions: map[string]*runtimeAPIRelaySession{}}
+}
+
+func (m *runtimeAPIRelayManager) SetSession(session *runtimeAPIRelaySession) string {
+	if m == nil || session == nil {
+		return ""
+	}
+	sessionID := uuid.NewString()
+	m.mu.Lock()
+	m.sessions[sessionID] = session
+	m.order = append(m.order, sessionID)
+	m.mu.Unlock()
+	return sessionID
+}
+
+func (m *runtimeAPIRelayManager) ClearSession(sessionID string, session *runtimeAPIRelaySession, err error) {
+	if m == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(sessionID)
+	m.mu.Lock()
+	if current, ok := m.sessions[trimmed]; ok && current == session {
+		delete(m.sessions, trimmed)
+	}
+	filtered := m.order[:0]
+	for _, item := range m.order {
+		if item != trimmed {
+			filtered = append(filtered, item)
+		}
+	}
+	m.order = filtered
+	m.mu.Unlock()
+	if session != nil {
+		session.close(err)
+	}
+}
+
+func (m *runtimeAPIRelayManager) RoundTrip(ctx context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
+	if m == nil {
+		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
+	}
+	m.mu.RLock()
+	var session *runtimeAPIRelaySession
+	for i := len(m.order) - 1; i >= 0; i-- {
+		if candidate := m.sessions[m.order[i]]; candidate != nil {
+			session = candidate
+			break
+		}
+	}
+	m.mu.RUnlock()
+	if session == nil {
+		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
+	}
+	return session.Do(ctx, request)
 }
 
 type runtimeAPIRelaySession struct {
@@ -40,47 +98,6 @@ type runtimeAPIRelaySession struct {
 type runtimeAPIRelayResult struct {
 	response runtimecontract.APIRelayResponse
 	err      error
-}
-
-func newRuntimeAPIRelayManager() *runtimeAPIRelayManager { return &runtimeAPIRelayManager{} }
-
-func (m *runtimeAPIRelayManager) SetSession(session *runtimeAPIRelaySession) {
-	if m == nil {
-		return
-	}
-	m.mu.Lock()
-	if m.session != nil && m.session != session {
-		m.session.close(errRuntimeAPIRelayUnavailable)
-	}
-	m.session = session
-	m.mu.Unlock()
-}
-
-func (m *runtimeAPIRelayManager) ClearSession(session *runtimeAPIRelaySession, err error) {
-	if m == nil {
-		return
-	}
-	m.mu.Lock()
-	if m.session == session {
-		m.session = nil
-	}
-	m.mu.Unlock()
-	if session != nil {
-		session.close(err)
-	}
-}
-
-func (m *runtimeAPIRelayManager) RoundTrip(ctx context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
-	if m == nil {
-		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
-	}
-	m.mu.RLock()
-	session := m.session
-	m.mu.RUnlock()
-	if session == nil {
-		return runtimecontract.APIRelayResponse{}, errRuntimeAPIRelayUnavailable
-	}
-	return session.Do(ctx, request)
 }
 
 func newRuntimeAPIRelaySession(send func(context.Context, string, runtimecontract.APIRelayRequest) error) *runtimeAPIRelaySession {

--- a/internal/infra/machinetransport/api_relay_test.go
+++ b/internal/infra/machinetransport/api_relay_test.go
@@ -125,3 +125,33 @@ func waitForRuntimeRelayHealth(t *testing.T, relayURL string) {
 	}
 	t.Fatalf("timed out waiting for relay %s", relayURL)
 }
+
+func TestRuntimeLocalRelayManagerKeepsOlderSessionWhenNewerSessionCloses(t *testing.T) {
+	t.Parallel()
+	manager := newRuntimeAPIRelayManager()
+	var first *runtimeAPIRelaySession
+	first = newRuntimeAPIRelaySession(func(_ context.Context, requestID string, _ runtimecontract.APIRelayRequest) error {
+		go func() {
+			_ = first.HandleResponse(requestID, runtimecontract.APIRelayResponse{StatusCode: http.StatusOK, Status: "200 OK", Body: []byte("first")})
+		}()
+		return nil
+	})
+	firstID := manager.SetSession(first)
+	var second *runtimeAPIRelaySession
+	second = newRuntimeAPIRelaySession(func(_ context.Context, requestID string, _ runtimecontract.APIRelayRequest) error {
+		go func() {
+			_ = second.HandleResponse(requestID, runtimecontract.APIRelayResponse{StatusCode: http.StatusOK, Status: "200 OK", Body: []byte("second")})
+		}()
+		return nil
+	})
+	secondID := manager.SetSession(second)
+	manager.ClearSession(secondID, second, context.Canceled)
+	response, err := manager.RoundTrip(context.Background(), runtimecontract.APIRelayRequest{Method: http.MethodGet, URL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if string(response.Body) != "first" {
+		t.Fatalf("RoundTrip() body = %s", string(response.Body))
+	}
+	manager.ClearSession(firstID, first, context.Canceled)
+}

--- a/internal/infra/machinetransport/api_relay_test.go
+++ b/internal/infra/machinetransport/api_relay_test.go
@@ -1,0 +1,127 @@
+package machinetransport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	machinechanneldomain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
+)
+
+func TestRuntimeProtocolClientHandlesAPIRelayRequest(t *testing.T) {
+	t.Parallel()
+
+	requestBody := []byte(`{"ok":true}`)
+	client := newRuntimeProtocolClient(func(context.Context, runtimecontract.Envelope) error { return nil })
+	client.apiRelay = func(_ context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
+		if request.Method != http.MethodGet {
+			t.Fatalf("api relay method = %q", request.Method)
+		}
+		if request.URL != "http://127.0.0.1:19836/api/v1/healthz" {
+			t.Fatalf("api relay url = %q", request.URL)
+		}
+		return runtimecontract.APIRelayResponse{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Headers:    map[string][]string{"Content-Type": {"application/json"}},
+			Body:       requestBody,
+		}, nil
+	}
+
+	responses := make([]runtimecontract.Envelope, 0, 1)
+	client.send = func(_ context.Context, envelope runtimecontract.Envelope) error {
+		responses = append(responses, envelope)
+		return nil
+	}
+
+	requestPayload, err := marshalRuntimePayload(runtimecontract.APIRelayRequest{Method: http.MethodGet, URL: "http://127.0.0.1:19836/api/v1/healthz"})
+	if err != nil {
+		t.Fatalf("marshal request payload: %v", err)
+	}
+	if err := client.HandleEnvelope(runtimecontract.Envelope{Version: runtimecontract.ProtocolVersion, Type: runtimecontract.MessageTypeRequest, RequestID: "req-1", Operation: runtimecontract.OperationAPIRelay, Payload: requestPayload}); err != nil {
+		t.Fatalf("HandleEnvelope() error = %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("responses len = %d", len(responses))
+	}
+	if responses[0].Type != runtimecontract.MessageTypeResponse || responses[0].RequestID != "req-1" || responses[0].Operation != runtimecontract.OperationAPIRelay {
+		t.Fatalf("unexpected response envelope: %+v", responses[0])
+	}
+	payload, err := runtimecontract.DecodePayload[runtimecontract.APIRelayResponse](responses[0])
+	if err != nil {
+		t.Fatalf("decode response payload: %v", err)
+	}
+	if payload.StatusCode != http.StatusOK || string(payload.Body) != string(requestBody) {
+		t.Fatalf("unexpected api relay response: %+v", payload)
+	}
+}
+
+func TestRuntimeLocalRelayServerBridgesConnectedSession(t *testing.T) {
+	t.Setenv(machinechanneldomain.EnvMachineLocalRelayURL, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	address := listener.Addr().String()
+	_ = listener.Close()
+
+	manager := newRuntimeAPIRelayManager()
+	var session *runtimeAPIRelaySession
+	session = newRuntimeAPIRelaySession(func(_ context.Context, requestID string, request runtimecontract.APIRelayRequest) error {
+		go func() {
+			_ = session.HandleResponse(requestID, runtimecontract.APIRelayResponse{StatusCode: http.StatusOK, Status: "200 OK", Headers: map[string][]string{"Content-Type": {"application/json"}}, Body: []byte(`{"path":"` + request.URL + `"}`)})
+		}()
+		return nil
+	})
+	manager.SetSession(session)
+
+	_, relayURL, err := startRuntimeLocalRelayServer(ctx, manager, address)
+	if err != nil {
+		t.Fatalf("startRuntimeLocalRelayServer() error = %v", err)
+	}
+	waitForRuntimeRelayHealth(t, relayURL)
+
+	body, err := json.Marshal(machinechanneldomain.LocalRelayRequest{Method: http.MethodGet, URL: "http://127.0.0.1:19836/api/v1/platform/projects/current"})
+	if err != nil {
+		t.Fatalf("marshal local relay request: %v", err)
+	}
+	response, err := http.Post(relayURL+localRelayPath, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST relay: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	var payload machinechanneldomain.LocalRelayResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode relay response: %v", err)
+	}
+	if payload.StatusCode != http.StatusOK {
+		t.Fatalf("relay status code = %d, want %d", payload.StatusCode, http.StatusOK)
+	}
+	if string(payload.Body) != `{"path":"http://127.0.0.1:19836/api/v1/platform/projects/current"}` {
+		t.Fatalf("relay body = %s", string(payload.Body))
+	}
+}
+
+func waitForRuntimeRelayHealth(t *testing.T, relayURL string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := http.Get(relayURL + "/healthz")
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for relay %s", relayURL)
+}

--- a/internal/infra/machinetransport/runtime_client_sessions.go
+++ b/internal/infra/machinetransport/runtime_client_sessions.go
@@ -339,6 +339,43 @@ func (s *runtimeCommandSession) Start(cmd string) error {
 	return nil
 }
 
+func (s *runtimeCommandSession) StartPTY(cmd string, cols int, rows int) error {
+	if s == nil || s.remote == nil || s.remote.client == nil {
+		return fmt.Errorf("runtime command session unavailable")
+	}
+	envelope, err := s.remote.client.request(s.remote.ctx, runtimecontract.OperationCommandOpen, runtimecontract.CommandOpenRequest{
+		Command: cmd,
+		PTY:     true,
+		Cols:    cols,
+		Rows:    rows,
+	})
+	if err != nil {
+		return err
+	}
+	payload, err := runtimecontract.DecodePayload[runtimecontract.SessionResponse](envelope)
+	if err != nil {
+		return err
+	}
+	s.remote.setSessionID(payload.SessionID)
+	s.remote.client.registerSession(payload.SessionID, s.remote)
+	return nil
+}
+
+func (s *runtimeCommandSession) Resize(cols int, rows int) error {
+	if s == nil || s.remote == nil || s.remote.client == nil {
+		return fmt.Errorf("runtime command session unavailable")
+	}
+	if cols <= 0 || rows <= 0 {
+		return fmt.Errorf("pty size must use positive cols and rows")
+	}
+	_, err := s.remote.client.request(s.remote.ctx, runtimecontract.OperationSessionResize, runtimecontract.SessionResizeRequest{
+		SessionID: s.remote.currentSessionID(),
+		Cols:      cols,
+		Rows:      rows,
+	})
+	return err
+}
+
 func (s *runtimeCommandSession) Signal(signal string) error { return s.remote.Signal(signal) }
 func (s *runtimeCommandSession) Wait() error                { return s.remote.Wait() }
 func (s *runtimeCommandSession) Close() error               { return s.remote.Close() }

--- a/internal/infra/machinetransport/runtime_protocol.go
+++ b/internal/infra/machinetransport/runtime_protocol.go
@@ -755,7 +755,8 @@ func (s shellCommandSpec) start(ctx context.Context, sessionID string, send runt
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		go runtimeCopyPTYOutput(sessionID, ptmx, send)
+		//nolint:gosec // PTY stream forwarding must continue asynchronously for the lifetime of the session.
+		go runtimeCopyPTYOutput(ctx, sessionID, ptmx, send)
 		return cmd, ptmx, ptmx, nil
 	}
 	stdin, err := cmd.StdinPipe()
@@ -965,15 +966,23 @@ func runtimePTYSize(cols int, rows int) (*pty.Winsize, error) {
 	if cols <= 0 || rows <= 0 {
 		return nil, fmt.Errorf("pty size must use positive cols and rows")
 	}
+	if cols > 65535 || rows > 65535 {
+		return nil, fmt.Errorf("pty size must not exceed 65535")
+	}
 	return &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}, nil
 }
 
-func runtimeCopyPTYOutput(sessionID string, ptmx *os.File, send runtimeEnvelopeSender) {
+func runtimeCopyPTYOutput(ctx context.Context, sessionID string, ptmx *os.File, send runtimeEnvelopeSender) {
 	if ptmx == nil || send == nil {
 		return
 	}
 	buffer := make([]byte, 4096)
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		count, err := ptmx.Read(buffer)
 		if count > 0 {
 			_ = send(context.Background(), runtimecontract.Envelope{

--- a/internal/infra/machinetransport/runtime_protocol.go
+++ b/internal/infra/machinetransport/runtime_protocol.go
@@ -1,12 +1,14 @@
 package machinetransport
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -54,7 +56,8 @@ func marshalRuntimePayload(value any) (json.RawMessage, error) {
 }
 
 type runtimeProtocolClient struct {
-	send runtimeEnvelopeSender
+	send     runtimeEnvelopeSender
+	apiRelay func(context.Context, runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error)
 
 	requestMu sync.Mutex
 	requests  map[string]chan runtimecontract.Envelope
@@ -75,6 +78,7 @@ type runtimeProtocolClient struct {
 func newRuntimeProtocolClient(send runtimeEnvelopeSender) *runtimeProtocolClient {
 	return &runtimeProtocolClient{
 		send:     send,
+		apiRelay: defaultRuntimeAPIRelayHandler,
 		requests: map[string]chan runtimecontract.Envelope{},
 		sessions: map[string]*runtimeManagedClientSession{},
 		pending:  map[string][]runtimecontract.Envelope{},
@@ -123,6 +127,8 @@ func (c *runtimeProtocolClient) HandleEnvelope(envelope runtimecontract.Envelope
 		default:
 		}
 		return nil
+	case runtimecontract.MessageTypeRequest:
+		return c.handleIncomingRequest(envelope)
 	case runtimecontract.MessageTypeEvent:
 		switch envelope.Operation {
 		case runtimecontract.OperationSessionOutput:
@@ -168,6 +174,7 @@ func (c *runtimeProtocolClient) ensureHello(ctx context.Context) error {
 			runtimecontract.OperationSessionClose,
 			runtimecontract.OperationProcessStart,
 			runtimecontract.OperationProcessStatus,
+			runtimecontract.OperationAPIRelay,
 		},
 	})
 	if err != nil {
@@ -258,6 +265,87 @@ func (c *runtimeProtocolClient) request(ctx context.Context, operation runtimeco
 		return runtimecontract.Envelope{}, err
 	}
 	return c.sendRequest(ctx, runtimecontract.MessageTypeRequest, operation, payload)
+}
+
+func (c *runtimeProtocolClient) handleIncomingRequest(envelope runtimecontract.Envelope) error {
+	if c == nil || c.send == nil {
+		return fmt.Errorf("runtime protocol client unavailable")
+	}
+	if envelope.Operation != runtimecontract.OperationAPIRelay {
+		return fmt.Errorf("runtime client request %q is not supported", envelope.Operation)
+	}
+	request, err := runtimecontract.DecodePayload[runtimecontract.APIRelayRequest](envelope)
+	if err != nil {
+		return c.send(context.Background(), runtimecontract.Envelope{
+			Version:   runtimecontract.ProtocolVersion,
+			Type:      runtimecontract.MessageTypeResponse,
+			RequestID: envelope.RequestID,
+			Operation: envelope.Operation,
+			Error: &runtimecontract.ErrorPayload{
+				Code:      runtimecontract.ErrorCodeInvalidRequest,
+				Class:     runtimecontract.ErrorClassMisconfiguration,
+				Message:   err.Error(),
+				Retryable: false,
+			},
+		})
+	}
+	handler := c.apiRelay
+	if handler == nil {
+		handler = defaultRuntimeAPIRelayHandler
+	}
+	response, err := handler(context.Background(), request)
+	if err != nil {
+		return c.send(context.Background(), runtimecontract.Envelope{
+			Version:   runtimecontract.ProtocolVersion,
+			Type:      runtimecontract.MessageTypeResponse,
+			RequestID: envelope.RequestID,
+			Operation: envelope.Operation,
+			Error: &runtimecontract.ErrorPayload{
+				Code:      runtimecontract.ErrorCodeTransportUnavailable,
+				Class:     runtimecontract.ErrorClassTransient,
+				Message:   err.Error(),
+				Retryable: true,
+			},
+		})
+	}
+	payload, err := marshalRuntimePayload(response)
+	if err != nil {
+		return err
+	}
+	return c.send(context.Background(), runtimecontract.Envelope{
+		Version:   runtimecontract.ProtocolVersion,
+		Type:      runtimecontract.MessageTypeResponse,
+		RequestID: envelope.RequestID,
+		Operation: envelope.Operation,
+		Payload:   payload,
+	})
+}
+
+func defaultRuntimeAPIRelayHandler(ctx context.Context, request runtimecontract.APIRelayRequest) (runtimecontract.APIRelayResponse, error) {
+	httpRequest, err := http.NewRequestWithContext(ctx, strings.ToUpper(strings.TrimSpace(request.Method)), strings.TrimSpace(request.URL), bytes.NewReader(request.Body))
+	if err != nil {
+		return runtimecontract.APIRelayResponse{}, fmt.Errorf("build runtime api relay request: %w", err)
+	}
+	for key, values := range request.Headers {
+		for _, value := range values {
+			httpRequest.Header.Add(key, value)
+		}
+	}
+	response, err := http.DefaultClient.Do(httpRequest)
+	if err != nil {
+		return runtimecontract.APIRelayResponse{}, fmt.Errorf("perform runtime api relay request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return runtimecontract.APIRelayResponse{}, fmt.Errorf("read runtime api relay response: %w", err)
+	}
+	return runtimecontract.APIRelayResponse{
+		StatusCode: response.StatusCode,
+		Status:     response.Status,
+		Headers:    map[string][]string(response.Header.Clone()),
+		Body:       body,
+	}, nil
 }
 
 func (c *runtimeProtocolClient) registerSession(sessionID string, session *runtimeManagedClientSession) {
@@ -745,8 +833,11 @@ func (s shellCommandSpec) start(ctx context.Context, sessionID string, send runt
 	}
 	shell, args := listenerShellCommand(command)
 	cmd := exec.CommandContext(ctx, shell, args...) // #nosec G204 -- runtime contract intentionally runs orchestrator-provided shell commands.
-	cmd.SysProcAttr = runtimeProcessSysProcAttr()
 	if s.pty {
+		// Let creack/pty own Setsid/Setctty for terminal shells. Reusing the
+		// non-PTY Setpgid path can make fork/exec fail with EPERM on listener
+		// hosts even though PTYs are otherwise available.
+		cmd.SysProcAttr = nil
 		size, err := runtimePTYSize(s.cols, s.rows)
 		if err != nil {
 			return nil, nil, nil, err
@@ -759,6 +850,7 @@ func (s shellCommandSpec) start(ctx context.Context, sessionID string, send runt
 		go runtimeCopyPTYOutput(ctx, sessionID, ptmx, send)
 		return cmd, ptmx, ptmx, nil
 	}
+	cmd.SysProcAttr = runtimeProcessSysProcAttr()
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/infra/machinetransport/runtime_protocol.go
+++ b/internal/infra/machinetransport/runtime_protocol.go
@@ -22,6 +22,7 @@ import (
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
 	"github.com/BetterAndBetterII/openase/internal/logging"
 	"github.com/BetterAndBetterII/openase/internal/provider"
+	"github.com/creack/pty"
 	"github.com/google/uuid"
 )
 
@@ -436,6 +437,8 @@ func (s *runtimeProtocolServer) handleRequest(ctx context.Context, envelope runt
 		return s.handleArtifactSync(ctx, envelope)
 	case runtimecontract.OperationCommandOpen:
 		return s.handleCommandOpen(ctx, envelope)
+	case runtimecontract.OperationSessionResize:
+		return s.handleSessionResize(ctx, envelope)
 	case runtimecontract.OperationProcessStart:
 		return s.handleProcessStart(ctx, envelope)
 	case runtimecontract.OperationSessionInput:
@@ -586,7 +589,13 @@ func (s *runtimeProtocolServer) handleCommandOpen(ctx context.Context, envelope 
 	if err != nil {
 		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeInvalidRequest, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
 	}
-	sessionID, err := s.startSession(shellCommandSpec(payload.Command), "")
+	commandSpec := shellCommandSpec{
+		command: payload.Command,
+		pty:     payload.PTY,
+		cols:    payload.Cols,
+		rows:    payload.Rows,
+	}
+	sessionID, err := s.startSession(commandSpec, "")
 	if err != nil {
 		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeProcessStart, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
 	}
@@ -622,6 +631,21 @@ func (s *runtimeProtocolServer) handleSessionInput(ctx context.Context, envelope
 	}
 	if err := session.writeInput(payload); err != nil {
 		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeSessionNotFound, runtimecontract.ErrorClassTransient, err, true, nil))
+	}
+	return s.sendResponse(ctx, envelope, map[string]any{"ok": true})
+}
+
+func (s *runtimeProtocolServer) handleSessionResize(ctx context.Context, envelope runtimecontract.Envelope) error {
+	payload, err := runtimecontract.DecodePayload[runtimecontract.SessionResizeRequest](envelope)
+	if err != nil {
+		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeInvalidRequest, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
+	}
+	session, ok := s.session(payload.SessionID)
+	if !ok {
+		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeSessionNotFound, runtimecontract.ErrorClassMisconfiguration, fmt.Errorf("runtime session %s is not active", payload.SessionID), false, nil))
+	}
+	if err := session.resize(payload.Cols, payload.Rows); err != nil {
+		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeProcessSignal, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
 	}
 	return s.sendResponse(ctx, envelope, map[string]any{"ok": true})
 }
@@ -704,29 +728,46 @@ func (s *runtimeProtocolServer) deleteSession(sessionID string) {
 }
 
 type commandSpec interface {
-	start(context.Context, string, runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, error)
+	start(context.Context, string, runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, *os.File, error)
 }
 
-type shellCommandSpec string
+type shellCommandSpec struct {
+	command string
+	pty     bool
+	cols    int
+	rows    int
+}
 
-func (s shellCommandSpec) start(ctx context.Context, sessionID string, send runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, error) {
-	command := strings.TrimSpace(string(s))
+func (s shellCommandSpec) start(ctx context.Context, sessionID string, send runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, *os.File, error) {
+	command := strings.TrimSpace(s.command)
 	if command == "" {
-		return nil, nil, fmt.Errorf("remote command must not be empty")
+		return nil, nil, nil, fmt.Errorf("remote command must not be empty")
 	}
 	shell, args := listenerShellCommand(command)
 	cmd := exec.CommandContext(ctx, shell, args...) // #nosec G204 -- runtime contract intentionally runs orchestrator-provided shell commands.
 	cmd.SysProcAttr = runtimeProcessSysProcAttr()
+	if s.pty {
+		size, err := runtimePTYSize(s.cols, s.rows)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		ptmx, err := pty.StartWithSize(cmd, size)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		go runtimeCopyPTYOutput(sessionID, ptmx, send)
+		return cmd, ptmx, ptmx, nil
+	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	cmd.Stdout = runtimeProcessStreamWriter{sessionID: sessionID, stream: "stdout", send: send}
 	cmd.Stderr = runtimeProcessStreamWriter{sessionID: sessionID, stream: "stderr", send: send}
 	if err := cmd.Start(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return cmd, stdin, nil
+	return cmd, stdin, nil, nil
 }
 
 type processCommandSpec struct {
@@ -736,10 +777,10 @@ type processCommandSpec struct {
 	cwd     string
 }
 
-func (s processCommandSpec) start(ctx context.Context, sessionID string, send runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, error) {
+func (s processCommandSpec) start(ctx context.Context, sessionID string, send runtimeEnvelopeSender) (*exec.Cmd, io.WriteCloser, *os.File, error) {
 	command := strings.TrimSpace(s.command)
 	if command == "" {
-		return nil, nil, fmt.Errorf("agent cli command must not be empty")
+		return nil, nil, nil, fmt.Errorf("agent cli command must not be empty")
 	}
 	cmd := exec.CommandContext(ctx, command, append([]string(nil), s.args...)...) // #nosec G204 -- runtime contract intentionally runs orchestrator-provided processes.
 	cmd.SysProcAttr = runtimeProcessSysProcAttr()
@@ -751,20 +792,20 @@ func (s processCommandSpec) start(ctx context.Context, sessionID string, send ru
 	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	cmd.Stdout = runtimeProcessStreamWriter{sessionID: sessionID, stream: "stdout", send: send}
 	cmd.Stderr = runtimeProcessStreamWriter{sessionID: sessionID, stream: "stderr", send: send}
 	if err := cmd.Start(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return cmd, stdin, nil
+	return cmd, stdin, nil, nil
 }
 
 func (s *runtimeProtocolServer) startSession(spec commandSpec, workingDirectory string) (string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	sessionID := uuid.NewString()
-	cmd, stdin, err := spec.start(ctx, sessionID, s.send)
+	cmd, stdin, ptyFile, err := spec.start(ctx, sessionID, s.send)
 	if err != nil {
 		cancel()
 		return "", err
@@ -773,6 +814,7 @@ func (s *runtimeProtocolServer) startSession(spec commandSpec, workingDirectory 
 		id:       sessionID,
 		cmd:      cmd,
 		stdin:    stdin,
+		ptyFile:  ptyFile,
 		cancel:   cancel,
 		send:     s.send,
 		onFinish: s.deleteSession,
@@ -790,6 +832,7 @@ type runtimeProcessSession struct {
 
 	cmd      *exec.Cmd
 	stdin    io.WriteCloser
+	ptyFile  *os.File
 	cancel   context.CancelFunc
 	send     runtimeEnvelopeSender
 	onFinish func(string)
@@ -862,6 +905,17 @@ func (s *runtimeProcessSession) writeInput(payload runtimecontract.SessionInputR
 	return err
 }
 
+func (s *runtimeProcessSession) resize(cols int, rows int) error {
+	if s.ptyFile == nil {
+		return fmt.Errorf("runtime session does not support pty resize")
+	}
+	size, err := runtimePTYSize(cols, rows)
+	if err != nil {
+		return err
+	}
+	return pty.Setsize(s.ptyFile, size)
+}
+
 func (s *runtimeProcessSession) signal(raw string) error {
 	if s.cmd == nil || s.cmd.Process == nil {
 		return fmt.Errorf("runtime session process is not running")
@@ -895,12 +949,47 @@ func (s *runtimeProcessSession) stop() {
 	if s.stdin != nil {
 		_ = s.stdin.Close()
 	}
+	if s.ptyFile != nil {
+		_ = s.ptyFile.Close()
+	}
 	if s.cmd != nil && s.cmd.Process != nil {
 		if runtime.GOOS == "windows" {
 			_ = s.cmd.Process.Kill()
 			return
 		}
 		_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
+	}
+}
+
+func runtimePTYSize(cols int, rows int) (*pty.Winsize, error) {
+	if cols <= 0 || rows <= 0 {
+		return nil, fmt.Errorf("pty size must use positive cols and rows")
+	}
+	return &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}, nil
+}
+
+func runtimeCopyPTYOutput(sessionID string, ptmx *os.File, send runtimeEnvelopeSender) {
+	if ptmx == nil || send == nil {
+		return
+	}
+	buffer := make([]byte, 4096)
+	for {
+		count, err := ptmx.Read(buffer)
+		if count > 0 {
+			_ = send(context.Background(), runtimecontract.Envelope{
+				Version:   runtimecontract.ProtocolVersion,
+				Type:      runtimecontract.MessageTypeEvent,
+				Operation: runtimecontract.OperationSessionOutput,
+				Payload: mustRuntimePayload(runtimecontract.SessionOutputEvent{
+					SessionID:  sessionID,
+					Stream:     "stdout",
+					DataBase64: base64.StdEncoding.EncodeToString(append([]byte(nil), buffer[:count]...)),
+				}),
+			})
+		}
+		if err != nil {
+			return
+		}
 	}
 }
 

--- a/internal/infra/machinetransport/transport.go
+++ b/internal/infra/machinetransport/transport.go
@@ -31,6 +31,8 @@ type CommandSession interface {
 	StdoutPipe() (io.Reader, error)
 	StderrPipe() (io.Reader, error)
 	Start(cmd string) error
+	StartPTY(cmd string, cols int, rows int) error
+	Resize(cols int, rows int) error
 	Signal(signal string) error
 	Wait() error
 	Close() error

--- a/internal/infra/machinetransport/websocket_session.go
+++ b/internal/infra/machinetransport/websocket_session.go
@@ -108,11 +108,13 @@ func dialWebsocketRuntimeClient(
 
 type ListenerHandlerOptions struct {
 	BearerToken string
+	APIRelay    *runtimeAPIRelayManager
 }
 
 func NewWebsocketListenerHandler(options ListenerHandlerOptions) http.Handler {
 	return &websocketListenerHandler{
 		bearerToken: strings.TrimSpace(options.BearerToken),
+		apiRelay:    options.APIRelay,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(*http.Request) bool { return true },
 		},
@@ -121,6 +123,7 @@ func NewWebsocketListenerHandler(options ListenerHandlerOptions) http.Handler {
 
 type websocketListenerHandler struct {
 	bearerToken string
+	apiRelay    *runtimeAPIRelayManager
 	upgrader    websocket.Upgrader
 }
 
@@ -147,23 +150,46 @@ func (h *websocketListenerHandler) ServeHTTP(writer http.ResponseWriter, request
 	}
 	defer func() { _ = conn.Close() }()
 
-	runWebsocketListenerSession(request.Context(), conn)
+	runWebsocketListenerSession(request.Context(), conn, h.apiRelay)
 }
 
-func runWebsocketListenerSession(parent context.Context, conn *websocket.Conn) {
+func runWebsocketListenerSession(parent context.Context, conn *websocket.Conn, relay *runtimeAPIRelayManager) {
 	var writeMu sync.Mutex
-	server := newRuntimeProtocolServer(func(ctx context.Context, envelope runtimecontract.Envelope) error {
+	sendEnvelope := func(ctx context.Context, envelope runtimecontract.Envelope) error {
 		writeMu.Lock()
 		defer writeMu.Unlock()
 		_ = conn.SetWriteDeadline(time.Now().Add(websocketWriteTimeout))
 		return conn.WriteJSON(envelope)
-	})
+	}
+	server := newRuntimeProtocolServer(sendEnvelope)
 	defer server.Close()
+	var relaySession *runtimeAPIRelaySession
+	if relay != nil {
+		relaySession = newRuntimeAPIRelaySession(func(ctx context.Context, requestID string, request runtimecontract.APIRelayRequest) error {
+			payload, err := marshalRuntimePayload(request)
+			if err != nil {
+				return err
+			}
+			return sendEnvelope(ctx, runtimecontract.Envelope{Version: runtimecontract.ProtocolVersion, Type: runtimecontract.MessageTypeRequest, RequestID: requestID, Operation: runtimecontract.OperationAPIRelay, Payload: payload})
+		})
+		relay.SetSession(relaySession)
+		defer relay.ClearSession(relaySession, context.Canceled)
+	}
 
 	for {
 		var envelope runtimecontract.Envelope
 		if err := conn.ReadJSON(&envelope); err != nil {
 			return
+		}
+		if relaySession != nil && envelope.Type == runtimecontract.MessageTypeResponse && envelope.Operation == runtimecontract.OperationAPIRelay {
+			response, err := runtimecontract.DecodePayload[runtimecontract.APIRelayResponse](envelope)
+			if err != nil {
+				return
+			}
+			if err := relaySession.HandleResponse(envelope.RequestID, response); err != nil {
+				return
+			}
+			continue
 		}
 		if err := server.HandleEnvelope(parent, envelope); err != nil {
 			return

--- a/internal/infra/machinetransport/websocket_session.go
+++ b/internal/infra/machinetransport/websocket_session.go
@@ -155,7 +155,7 @@ func (h *websocketListenerHandler) ServeHTTP(writer http.ResponseWriter, request
 
 func runWebsocketListenerSession(parent context.Context, conn *websocket.Conn, relay *runtimeAPIRelayManager) {
 	var writeMu sync.Mutex
-	sendEnvelope := func(ctx context.Context, envelope runtimecontract.Envelope) error {
+	sendEnvelope := func(_ context.Context, envelope runtimecontract.Envelope) error {
 		writeMu.Lock()
 		defer writeMu.Unlock()
 		_ = conn.SetWriteDeadline(time.Now().Add(websocketWriteTimeout))

--- a/internal/infra/machinetransport/websocket_session.go
+++ b/internal/infra/machinetransport/websocket_session.go
@@ -172,8 +172,8 @@ func runWebsocketListenerSession(parent context.Context, conn *websocket.Conn, r
 			}
 			return sendEnvelope(ctx, runtimecontract.Envelope{Version: runtimecontract.ProtocolVersion, Type: runtimecontract.MessageTypeRequest, RequestID: requestID, Operation: runtimecontract.OperationAPIRelay, Payload: payload})
 		})
-		relay.SetSession(relaySession)
-		defer relay.ClearSession(relaySession, context.Canceled)
+		relaySessionID := relay.SetSession(relaySession)
+		defer relay.ClearSession(relaySessionID, relaySession, context.Canceled)
 	}
 
 	for {

--- a/internal/infra/machinetransport/websocket_transport_test.go
+++ b/internal/infra/machinetransport/websocket_transport_test.go
@@ -275,6 +275,81 @@ func TestWebsocketListenerTransportStartProcess(t *testing.T) {
 	}
 }
 
+func TestWebsocketListenerTransportCommandSessionPTYResize(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(NewWebsocketListenerHandler(ListenerHandlerOptions{}))
+	defer server.Close()
+
+	machine := testListenerMachine(websocketURL(server.URL), "")
+	transport := websocketTransport{mode: domain.MachineConnectionModeWSListener}
+
+	session, err := transport.OpenCommandSession(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("OpenCommandSession() error = %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe() error = %v", err)
+	}
+	if _, err := session.StderrPipe(); err != nil {
+		t.Fatalf("StderrPipe() error = %v", err)
+	}
+	if _, err := session.StdinPipe(); err != nil {
+		t.Fatalf("StdinPipe() error = %v", err)
+	}
+	if err := session.StartPTY("stty size", 120, 32); err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
+		t.Fatalf("StartPTY() error = %v", err)
+	}
+	output, err := io.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("ReadAll(stdout) error = %v", err)
+	}
+	if err := session.Wait(); err != nil {
+		t.Fatalf("session.Wait() error = %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != "32 120" {
+		t.Fatalf("initial PTY size output = %q, want %q", got, "32 120")
+	}
+
+	session, err = transport.OpenCommandSession(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("OpenCommandSession(second) error = %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	stdout, err = session.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe(second) error = %v", err)
+	}
+	if _, err := session.StdinPipe(); err != nil {
+		t.Fatalf("StdinPipe(second) error = %v", err)
+	}
+	if err := session.StartPTY("sleep 0.05; stty size", 80, 24); err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("pty unsupported in this test environment: %v", err)
+		}
+		t.Fatalf("StartPTY(second) error = %v", err)
+	}
+	if err := session.Resize(100, 40); err != nil {
+		t.Fatalf("Resize() error = %v", err)
+	}
+	output, err = io.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("ReadAll(stdout second) error = %v", err)
+	}
+	if err := session.Wait(); err != nil {
+		t.Fatalf("session.Wait(second) error = %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != "40 100" {
+		t.Fatalf("resized PTY output = %q, want %q", got, "40 100")
+	}
+}
+
 func TestWebsocketListenerTransportDialErrorClassification(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/ssh/pool.go
+++ b/internal/infra/ssh/pool.go
@@ -29,6 +29,8 @@ type Session interface {
 	StdoutPipe() (io.Reader, error)
 	StderrPipe() (io.Reader, error)
 	Start(cmd string) error
+	StartPTY(cmd string, cols int, rows int) error
+	Resize(cols int, rows int) error
 	Signal(signal string) error
 	Wait() error
 	Close() error
@@ -383,6 +385,23 @@ func (s *realSession) StderrPipe() (io.Reader, error) {
 
 func (s *realSession) Start(cmd string) error {
 	return s.session.Start(cmd)
+}
+
+func (s *realSession) StartPTY(cmd string, cols int, rows int) error {
+	if cols <= 0 || rows <= 0 {
+		return fmt.Errorf("pty size must use positive cols and rows")
+	}
+	if err := s.session.RequestPty("xterm-256color", rows, cols, gossh.TerminalModes{}); err != nil {
+		return err
+	}
+	return s.session.Start(cmd)
+}
+
+func (s *realSession) Resize(cols int, rows int) error {
+	if cols <= 0 || rows <= 0 {
+		return fmt.Errorf("pty size must use positive cols and rows")
+	}
+	return s.session.WindowChange(rows, cols)
 }
 
 func (s *realSession) Signal(signal string) error {

--- a/internal/infra/ssh/pool_test.go
+++ b/internal/infra/ssh/pool_test.go
@@ -180,6 +180,8 @@ type fakeSession struct {
 	waitCh   chan error
 
 	startedCommand string
+	startedPTY     [2]int
+	resized        [2]int
 	signal         string
 }
 
@@ -213,6 +215,17 @@ func (s *fakeSession) StderrPipe() (io.Reader, error) {
 
 func (s *fakeSession) Start(cmd string) error {
 	s.startedCommand = cmd
+	return nil
+}
+
+func (s *fakeSession) StartPTY(cmd string, cols int, rows int) error {
+	s.startedCommand = cmd
+	s.startedPTY = [2]int{cols, rows}
+	return nil
+}
+
+func (s *fakeSession) Resize(cols int, rows int) error {
+	s.resized = [2]int{cols, rows}
 	return nil
 }
 

--- a/internal/infra/workspace/remote_manager_test.go
+++ b/internal/infra/workspace/remote_manager_test.go
@@ -292,6 +292,10 @@ func (s *remoteTestSession) StderrPipe() (io.Reader, error) { return strings.New
 
 func (s *remoteTestSession) Start(string) error { return nil }
 
+func (s *remoteTestSession) StartPTY(string, int, int) error { return nil }
+
+func (s *remoteTestSession) Resize(int, int) error { return nil }
+
 func (s *remoteTestSession) Signal(string) error { return nil }
 
 func (s *remoteTestSession) Wait() error { return nil }

--- a/internal/machinechannel/api_relay.go
+++ b/internal/machinechannel/api_relay.go
@@ -1,7 +1,6 @@
 package machinechannel
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -239,7 +238,7 @@ func startDaemonLocalRelayServer(ctx context.Context, relay *apiRelayManager, ad
 	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()
@@ -259,27 +258,10 @@ func cloneRelayHeaders(headers map[string][]string) map[string][]string {
 		if trimmedKey == "" {
 			continue
 		}
-		copied := make([]string, 0, len(values))
-		for _, value := range values {
-			copied = append(copied, value)
-		}
-		cloned[trimmedKey] = copied
+		cloned[trimmedKey] = append([]string(nil), values...)
 	}
 	if len(cloned) == 0 {
 		return nil
 	}
 	return cloned
-}
-
-func localRelayRoundTrip(ctx context.Context, relayURL string, request domain.LocalRelayRequest) (*http.Response, error) {
-	body, err := json.Marshal(request)
-	if err != nil {
-		return nil, fmt.Errorf("marshal local relay request: %w", err)
-	}
-	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(strings.TrimSpace(relayURL), "/")+machineLocalRelayPath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("build local relay request: %w", err)
-	}
-	httpRequest.Header.Set("Content-Type", "application/json")
-	return http.DefaultClient.Do(httpRequest)
 }

--- a/internal/machinechannel/api_relay.go
+++ b/internal/machinechannel/api_relay.go
@@ -1,0 +1,285 @@
+package machinechannel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	domain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+	"github.com/google/uuid"
+)
+
+const machineLocalRelayPath = "/__openase_cli_relay"
+
+var errAPIRelayUnavailable = errors.New("machine api relay is not connected")
+
+type apiRelayManager struct {
+	mu      sync.RWMutex
+	session *apiRelaySession
+}
+
+type apiRelaySession struct {
+	sessionID string
+	send      func(context.Context, domain.APIRelayRequest) error
+
+	mu      sync.Mutex
+	pending map[string]chan apiRelayResult
+	closed  error
+}
+
+type apiRelayResult struct {
+	response domain.APIRelayResponse
+	err      error
+}
+
+func newAPIRelayManager() *apiRelayManager {
+	return &apiRelayManager{}
+}
+
+func (m *apiRelayManager) SetSession(session *apiRelaySession) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.session != nil && m.session != session {
+		m.session.close(errAPIRelayUnavailable)
+	}
+	m.session = session
+	m.mu.Unlock()
+}
+
+func (m *apiRelayManager) ClearSession(session *apiRelaySession, err error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.session == session {
+		m.session = nil
+	}
+	m.mu.Unlock()
+	if session != nil {
+		session.close(err)
+	}
+}
+
+func (m *apiRelayManager) RoundTrip(ctx context.Context, request domain.APIRelayRequest) (domain.APIRelayResponse, error) {
+	if m == nil {
+		return domain.APIRelayResponse{}, errAPIRelayUnavailable
+	}
+	m.mu.RLock()
+	session := m.session
+	m.mu.RUnlock()
+	if session == nil {
+		return domain.APIRelayResponse{}, errAPIRelayUnavailable
+	}
+	return session.Do(ctx, request)
+}
+
+func newAPIRelaySession(sessionID string, send func(context.Context, domain.APIRelayRequest) error) *apiRelaySession {
+	return &apiRelaySession{
+		sessionID: strings.TrimSpace(sessionID),
+		send:      send,
+		pending:   map[string]chan apiRelayResult{},
+	}
+}
+
+func (s *apiRelaySession) Do(ctx context.Context, request domain.APIRelayRequest) (domain.APIRelayResponse, error) {
+	if s == nil || s.send == nil {
+		return domain.APIRelayResponse{}, errAPIRelayUnavailable
+	}
+	requestID := strings.TrimSpace(request.RequestID)
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
+	request.RequestID = requestID
+	responseCh := make(chan apiRelayResult, 1)
+
+	s.mu.Lock()
+	if s.closed != nil {
+		closedErr := s.closed
+		s.mu.Unlock()
+		return domain.APIRelayResponse{}, closedErr
+	}
+	s.pending[requestID] = responseCh
+	s.mu.Unlock()
+
+	if err := s.send(ctx, request); err != nil {
+		s.mu.Lock()
+		delete(s.pending, requestID)
+		s.mu.Unlock()
+		return domain.APIRelayResponse{}, err
+	}
+
+	select {
+	case <-ctx.Done():
+		s.mu.Lock()
+		delete(s.pending, requestID)
+		s.mu.Unlock()
+		return domain.APIRelayResponse{}, ctx.Err()
+	case result := <-responseCh:
+		if result.err != nil {
+			return domain.APIRelayResponse{}, result.err
+		}
+		return result.response, nil
+	}
+}
+
+func (s *apiRelaySession) HandleResponse(response domain.APIRelayResponse) error {
+	if s == nil {
+		return errAPIRelayUnavailable
+	}
+	requestID := strings.TrimSpace(response.RequestID)
+	if requestID == "" {
+		return fmt.Errorf("api relay response is missing request_id")
+	}
+	s.mu.Lock()
+	responseCh, ok := s.pending[requestID]
+	if ok {
+		delete(s.pending, requestID)
+	}
+	closedErr := s.closed
+	s.mu.Unlock()
+	if !ok {
+		if closedErr != nil {
+			return closedErr
+		}
+		return nil
+	}
+	responseCh <- apiRelayResult{response: response}
+	return nil
+}
+
+func (s *apiRelaySession) close(err error) {
+	if s == nil {
+		return
+	}
+	if err == nil {
+		err = errAPIRelayUnavailable
+	}
+	s.mu.Lock()
+	if s.closed != nil {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = err
+	pending := s.pending
+	s.pending = map[string]chan apiRelayResult{}
+	s.mu.Unlock()
+	for _, responseCh := range pending {
+		responseCh <- apiRelayResult{err: err}
+	}
+}
+
+func startDaemonLocalRelayServer(ctx context.Context, relay *apiRelayManager, address string) (*http.Server, string, error) {
+	trimmedAddress := strings.TrimSpace(address)
+	if trimmedAddress == "" {
+		trimmedAddress = domain.DefaultMachineLocalRelayAddress
+	}
+	listener, err := net.Listen("tcp", trimmedAddress)
+	if err != nil {
+		return nil, "", fmt.Errorf("listen local machine relay on %s: %w", trimmedAddress, err)
+	}
+	relayURL := "http://" + listener.Addr().String()
+	if envErr := os.Setenv(domain.EnvMachineLocalRelayURL, relayURL); envErr != nil {
+		_ = listener.Close()
+		return nil, "", fmt.Errorf("set %s: %w", domain.EnvMachineLocalRelayURL, envErr)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(machineLocalRelayPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		var request domain.LocalRelayRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(domain.LocalRelayResponse{Error: "decode relay request: " + err.Error()})
+			return
+		}
+		response, err := relay.RoundTrip(r.Context(), domain.APIRelayRequest{
+			Method:  request.Method,
+			URL:     request.URL,
+			Headers: cloneRelayHeaders(request.Headers),
+			Body:    append([]byte(nil), request.Body...),
+		})
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(domain.LocalRelayResponse{Error: err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(domain.LocalRelayResponse{
+			StatusCode: response.StatusCode,
+			Status:     response.Status,
+			Headers:    cloneRelayHeaders(response.Headers),
+			Body:       append([]byte(nil), response.Body...),
+		})
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	return server, relayURL, nil
+}
+
+func cloneRelayHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		copied := make([]string, 0, len(values))
+		for _, value := range values {
+			copied = append(copied, value)
+		}
+		cloned[trimmedKey] = copied
+	}
+	if len(cloned) == 0 {
+		return nil
+	}
+	return cloned
+}
+
+func localRelayRoundTrip(ctx context.Context, relayURL string, request domain.LocalRelayRequest) (*http.Response, error) {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal local relay request: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(strings.TrimSpace(relayURL), "/")+machineLocalRelayPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build local relay request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(httpRequest)
+}

--- a/internal/machinechannel/daemon.go
+++ b/internal/machinechannel/daemon.go
@@ -50,13 +50,20 @@ func (d *Daemon) Run(ctx context.Context, config domain.DaemonConfig) error {
 		return fmt.Errorf("machine daemon unavailable")
 	}
 
+	relayManager := newAPIRelayManager()
+	_, relayURL, err := startDaemonLocalRelayServer(ctx, relayManager, os.Getenv(domain.EnvMachineLocalRelayAddress))
+	if err != nil {
+		return err
+	}
+	d.logger.Info("machine local api relay ready", "relay_url", relayURL)
+
 	backoff := config.ReconnectBackoff
 	if backoff <= 0 {
 		backoff = DefaultReconnectBackoff
 	}
 
 	for {
-		err := d.runSession(ctx, config)
+		err := d.runSession(ctx, config, relayManager)
 		if err == nil || errors.Is(err, context.Canceled) {
 			return nil
 		}
@@ -79,7 +86,7 @@ func (d *Daemon) Run(ctx context.Context, config domain.DaemonConfig) error {
 	}
 }
 
-func (d *Daemon) runSession(ctx context.Context, config domain.DaemonConfig) error {
+func (d *Daemon) runSession(ctx context.Context, config domain.DaemonConfig, relayManager *apiRelayManager) error {
 	connectURL, err := machineConnectURL(config.ControlPlaneURL)
 	if err != nil {
 		return err
@@ -173,6 +180,21 @@ func (d *Daemon) runSession(ctx context.Context, config domain.DaemonConfig) err
 	})
 	defer runtimeServer.Close()
 
+	apiRelaySession := newAPIRelaySession(registered.SessionID, func(ctx context.Context, request domain.APIRelayRequest) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return writeJSONEnvelope(conn, domain.Envelope{
+			Version:   domain.ProtocolVersion,
+			Type:      domain.MessageTypeAPIRequest,
+			SessionID: registered.SessionID,
+			Payload:   mustMarshalJSON(request),
+		})
+	})
+	if relayManager != nil {
+		relayManager.SetSession(apiRelaySession)
+		defer relayManager.ClearSession(apiRelaySession, context.Canceled)
+	}
+
 	incomingCh := make(chan domain.Envelope, 1)
 	readErrCh := make(chan error, 1)
 	go func() {
@@ -213,6 +235,14 @@ func (d *Daemon) runSession(ctx context.Context, config domain.DaemonConfig) err
 					return fmt.Errorf("decode runtime envelope: %w", err)
 				}
 				if err := runtimeServer.HandleEnvelope(ctx, runtimeEnvelope); err != nil {
+					return err
+				}
+			case domain.MessageTypeAPIResponse:
+				response, err := domain.DecodePayload[domain.APIRelayResponse](incoming)
+				if err != nil {
+					return fmt.Errorf("decode api relay response: %w", err)
+				}
+				if err := apiRelaySession.HandleResponse(response); err != nil {
 					return err
 				}
 			}

--- a/internal/machinechannel/daemon_test.go
+++ b/internal/machinechannel/daemon_test.go
@@ -1,11 +1,20 @@
 package machinechannel
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	domain "github.com/BetterAndBetterII/openase/internal/domain/machinechannel"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 )
 
 func TestDaemonToolInventoryUsesScopedAgentCLIPaths(t *testing.T) {
@@ -67,4 +76,162 @@ func writeExecutable(t *testing.T, path string) string {
 		t.Fatalf("chmod executable %s: %v", path, err)
 	}
 	return path
+}
+
+func TestDaemonLocalRelayBridgesAPIRequestsOverMachineWebsocket(t *testing.T) {
+	machineID := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/machines/connect" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, err := readJSONEnvelope(conn); err != nil {
+			t.Errorf("read hello: %v", err)
+			return
+		}
+		authEnvelope, err := readJSONEnvelope(conn)
+		if err != nil {
+			t.Errorf("read authenticate: %v", err)
+			return
+		}
+		authenticate, err := domain.DecodePayload[domain.Authenticate](authEnvelope)
+		if err != nil {
+			t.Errorf("decode authenticate: %v", err)
+			return
+		}
+		if authenticate.MachineID != machineID.String() {
+			t.Errorf("authenticate machine_id = %q", authenticate.MachineID)
+			return
+		}
+		if err := writeJSONEnvelope(conn, domain.Envelope{
+			Version: domain.ProtocolVersion,
+			Type:    domain.MessageTypeRegistered,
+			Payload: mustMarshalJSON(domain.Registered{MachineID: machineID.String(), SessionID: "session-1", HeartbeatIntervalSeconds: 60}),
+		}); err != nil {
+			t.Errorf("write registered: %v", err)
+			return
+		}
+
+		for {
+			envelope, err := readJSONEnvelope(conn)
+			if err != nil {
+				return
+			}
+			if envelope.Type != domain.MessageTypeAPIRequest {
+				continue
+			}
+			request, err := domain.DecodePayload[domain.APIRelayRequest](envelope)
+			if err != nil {
+				t.Errorf("decode api request: %v", err)
+				return
+			}
+			if err := writeJSONEnvelope(conn, domain.Envelope{
+				Version:   domain.ProtocolVersion,
+				Type:      domain.MessageTypeAPIResponse,
+				SessionID: "session-1",
+				Payload: mustMarshalJSON(domain.APIRelayResponse{
+					RequestID:  request.RequestID,
+					StatusCode: http.StatusCreated,
+					Status:     "201 Created",
+					Headers:    map[string][]string{"Content-Type": {"application/json"}},
+					Body:       []byte(`{"ok":true}`),
+				}),
+			}); err != nil {
+				t.Errorf("write api response: %v", err)
+			}
+			return
+		}
+	}))
+	defer server.Close()
+
+	relayAddress := freeLocalRelayAddress(t)
+	t.Setenv(domain.EnvMachineLocalRelayAddress, relayAddress)
+
+	daemon := NewDaemon(nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- daemon.Run(ctx, domain.DaemonConfig{
+			MachineID:         machineID,
+			Token:             "ase_machine_test",
+			ControlPlaneURL:   server.URL,
+			HeartbeatInterval: time.Minute,
+			ReconnectBackoff:  10 * time.Millisecond,
+		})
+	}()
+
+	relayURL := waitForLocalRelay(t, "http://"+relayAddress)
+	body, err := json.Marshal(domain.LocalRelayRequest{Method: http.MethodGet, URL: "https://control.example.com/api/v1/healthz"})
+	if err != nil {
+		t.Fatalf("marshal local relay request: %v", err)
+	}
+	var relayResponse domain.LocalRelayResponse
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := http.Post(relayURL+"/__openase_cli_relay", "application/json", bytes.NewReader(body))
+		if err == nil {
+			func() {
+				defer func() { _ = response.Body.Close() }()
+				relayResponse = domain.LocalRelayResponse{}
+				_ = json.NewDecoder(response.Body).Decode(&relayResponse)
+			}()
+			if relayResponse.StatusCode == http.StatusCreated {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if relayResponse.StatusCode != http.StatusCreated {
+		t.Fatalf("relay status code = %d, want %d (error=%q)", relayResponse.StatusCode, http.StatusCreated, relayResponse.Error)
+	}
+	if string(relayResponse.Body) != `{"ok":true}` {
+		t.Fatalf("relay body = %s", string(relayResponse.Body))
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("daemon.Run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for daemon shutdown")
+	}
+}
+
+func freeLocalRelayAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for relay address: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	return listener.Addr().String()
+}
+
+func waitForLocalRelay(t *testing.T, relayURL string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := http.Get(relayURL + "/healthz")
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return relayURL
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for local relay %s", relayURL)
+	return ""
 }

--- a/internal/orchestrator/run_completion_summary.go
+++ b/internal/orchestrator/run_completion_summary.go
@@ -439,6 +439,9 @@ func (c *runtimeCompletionSummaryCoordinator) generateRunCompletionSummary(ctx c
 	if err != nil {
 		return err
 	}
+	if resolved := catalogdomain.ResolveMachineOpenASEBinaryPath(summaryCtx.machine); resolved != nil {
+		environment = catalogdomain.UpsertMachineEnvironmentValue(environment, "OPENASE_REAL_BIN", *resolved)
+	}
 	processSpec, err := provider.NewAgentCLIProcessSpec(
 		command,
 		append([]string(nil), summaryCtx.provider.CliArgs...),

--- a/internal/orchestrator/runtime_execution_slice.go
+++ b/internal/orchestrator/runtime_execution_slice.go
@@ -73,8 +73,12 @@ func (s runtimeExecutionSlice) startReadyExecutions(ctx context.Context) error {
 			executingAt,
 		)
 
+		executionCtx := context.Background()
+		if ctx != nil {
+			executionCtx = context.WithoutCancel(ctx)
+		}
 		//nolint:gosec // runtime executions intentionally continue asynchronously after the launcher tick claims the run.
-		go s.runReadyExecution(ctx, assignment.run.ID)
+		go s.runReadyExecution(executionCtx, assignment.run.ID)
 	}
 
 	return nil

--- a/internal/orchestrator/runtime_launcher.go
+++ b/internal/orchestrator/runtime_launcher.go
@@ -412,7 +412,6 @@ func (l *RuntimeLauncher) startAgentSessionWithTimeout(
 	}
 
 	startCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	type startResult struct {
 		session agentSession
@@ -556,12 +555,9 @@ func (l *RuntimeLauncher) startRuntimeSessionOnMachine(
 		return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
 	}
 	environment = append(environment, githubEnvironment...)
-	if !remote {
-		launcherEnvironment, err := buildLocalOpenASEEnvironment()
-		if err != nil {
-			return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
-		}
-		environment = append(environment, launcherEnvironment...)
+	environment, err = buildMachineOpenASEEnvironment(machine, remote, environment)
+	if err != nil {
+		return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
 	}
 	if requiresMachineCodexReady(command, environment) {
 		if ready, reason, ok := machineCodexReady(machine.Resources); ok && !ready {
@@ -699,6 +695,22 @@ func buildLocalOpenASEEnvironment() ([]string, error) {
 	}
 
 	return []string{"OPENASE_REAL_BIN=" + executable}, nil
+}
+
+func buildMachineOpenASEEnvironment(machine catalogdomain.Machine, remote bool, environment []string) ([]string, error) {
+	if !remote {
+		launcherEnvironment, err := buildLocalOpenASEEnvironment()
+		if err != nil {
+			return nil, err
+		}
+		return append(environment, launcherEnvironment...), nil
+	}
+
+	resolved := catalogdomain.ResolveMachineOpenASEBinaryPath(machine)
+	if resolved == nil || strings.TrimSpace(*resolved) == "" {
+		return environment, nil
+	}
+	return catalogdomain.UpsertMachineEnvironmentValue(environment, "OPENASE_REAL_BIN", *resolved), nil
 }
 
 func uuidPointer(id uuid.UUID) *uuid.UUID {

--- a/internal/orchestrator/runtime_launcher_split_timeout_test.go
+++ b/internal/orchestrator/runtime_launcher_split_timeout_test.go
@@ -186,3 +186,30 @@ func (runtimeImmediateAgentAdapter) Start(context.Context, agentSessionStartSpec
 func (runtimeImmediateAgentAdapter) Resume(context.Context, agentSessionResumeSpec) (agentSession, error) {
 	return runtimeStaticAgentSession{sessionID: uuid.NewString()}, nil
 }
+
+func TestRuntimeLauncherStartAgentSessionWithTimeoutDoesNotCancelSuccessfulSessionContext(t *testing.T) {
+	t.Parallel()
+
+	launcher := NewRuntimeLauncher(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, nil)
+	launcher.agentSessionStartTimeout = 100 * time.Millisecond
+
+	var startCtx context.Context
+	session, err := launcher.startAgentSessionWithTimeout(context.Background(), func(ctx context.Context) (agentSession, error) {
+		startCtx = ctx
+		return runtimeStaticAgentSession{sessionID: uuid.NewString()}, nil
+	})
+	if err != nil {
+		t.Fatalf("startAgentSessionWithTimeout() error = %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected session")
+	}
+	if startCtx == nil {
+		t.Fatal("expected start context")
+	}
+	select {
+	case <-startCtx.Done():
+		t.Fatal("expected successful session start context to remain active")
+	default:
+	}
+}

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -1588,6 +1588,60 @@ func TestRuntimeLauncherHandleExecutionFailureIgnoresTerminalRun(t *testing.T) {
 	}
 }
 
+func TestRuntimeLauncherHandleExecutionFailurePersistsAfterContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	fixture := seedProjectFixture(ctx, t, client)
+	now := time.Date(2026, 3, 22, 10, 35, 0, 0, time.UTC)
+
+	workflowItem, err := client.Workflow.Create().
+		SetProjectID(fixture.projectID).
+		SetName("Coding").
+		SetType(entworkflow.TypeCoding).
+		SetHarnessPath(".openase/harnesses/coding.md").
+		SetMaxConcurrent(1).
+		AddPickupStatusIDs(fixture.statusIDs["Todo"]).
+		AddFinishStatusIDs(fixture.statusIDs["Done"]).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	agentItem := fixture.createAgent(ctx, t, "coding-cancelled-01", 0)
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(fixture.projectID).
+		SetIdentifier("ASE-91C").
+		SetTitle("Persist failure after cancellation").
+		SetStatusID(fixture.statusIDs["Todo"]).
+		SetWorkflowID(workflowItem.ID).
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	runItem := mustCreateCurrentRun(ctx, t, client, agentItem, workflowItem.ID, ticketItem.ID, entagentrun.StatusExecuting, now)
+
+	launcher := NewRuntimeLauncher(client, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, nil)
+	launcher.now = func() time.Time { return now }
+
+	failureCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	launcher.handleExecutionFailure(failureCtx, runItem.ID, agentItem.ID, ticketItem.ID, fmt.Errorf("context-canceled failure"))
+
+	runAfter, err := client.AgentRun.Get(ctx, runItem.ID)
+	if err != nil {
+		t.Fatalf("reload run: %v", err)
+	}
+	if runAfter.Status != entagentrun.StatusErrored {
+		t.Fatalf("expected errored run after canceled context, got %+v", runAfter)
+	}
+	if strings.TrimSpace(runAfter.LastError) != "context-canceled failure" {
+		t.Fatalf("expected persisted last_error, got %q", runAfter.LastError)
+	}
+	if runAfter.TerminalAt == nil || !runAfter.TerminalAt.Equal(now) {
+		t.Fatalf("expected persisted terminal_at %v, got %+v", now, runAfter.TerminalAt)
+	}
+}
+
 func TestRuntimeLauncherFinishResolvedExecutionRequiresExplicitFinishChoiceWhenMultipleAllowed(t *testing.T) {
 	ctx := context.Background()
 	client := openTestEntClient(t)

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -6469,7 +6469,9 @@ func (s *runtimeSSHPrepareSession) StderrPipe() (io.Reader, error) { return stri
 
 func (s *runtimeSSHPrepareSession) Start(string) error { return fmt.Errorf("not supported") }
 
-func (s *runtimeSSHPrepareSession) StartPTY(string, int, int) error { return fmt.Errorf("not supported") }
+func (s *runtimeSSHPrepareSession) StartPTY(string, int, int) error {
+	return fmt.Errorf("not supported")
+}
 
 func (s *runtimeSSHPrepareSession) Resize(int, int) error { return nil }
 

--- a/internal/orchestrator/runtime_launcher_test.go
+++ b/internal/orchestrator/runtime_launcher_test.go
@@ -6469,6 +6469,10 @@ func (s *runtimeSSHPrepareSession) StderrPipe() (io.Reader, error) { return stri
 
 func (s *runtimeSSHPrepareSession) Start(string) error { return fmt.Errorf("not supported") }
 
+func (s *runtimeSSHPrepareSession) StartPTY(string, int, int) error { return fmt.Errorf("not supported") }
+
+func (s *runtimeSSHPrepareSession) Resize(int, int) error { return nil }
+
 func (s *runtimeSSHPrepareSession) Signal(string) error { return nil }
 
 func (s *runtimeSSHPrepareSession) Wait() error { return nil }
@@ -6557,6 +6561,12 @@ func (s *runtimeSSHProcessSession) Start(cmd string) error {
 	}()
 	return nil
 }
+
+func (s *runtimeSSHProcessSession) StartPTY(cmd string, _ int, _ int) error {
+	return s.Start(cmd)
+}
+
+func (s *runtimeSSHProcessSession) Resize(int, int) error { return nil }
 
 func (s *runtimeSSHProcessSession) Signal(string) error {
 	return s.Close()

--- a/internal/orchestrator/runtime_openase_environment_test.go
+++ b/internal/orchestrator/runtime_openase_environment_test.go
@@ -1,0 +1,23 @@
+package orchestrator
+
+import (
+	"testing"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+)
+
+func TestBuildMachineOpenASEEnvironmentRemoteFallback(t *testing.T) {
+	t.Parallel()
+
+	sshUser := "agentuser"
+	environment, err := buildMachineOpenASEEnvironment(catalogdomain.Machine{
+		Host:    "listener.internal",
+		SSHUser: &sshUser,
+	}, true, []string{"PATH=/usr/bin"})
+	if err != nil {
+		t.Fatalf("buildMachineOpenASEEnvironment() error = %v", err)
+	}
+	if !containsEnvironmentPrefix(environment, "OPENASE_REAL_BIN=/home/agentuser/.openase/bin/openase") {
+		t.Fatalf("expected remote OPENASE_REAL_BIN in environment, got %+v", environment)
+	}
+}

--- a/internal/orchestrator/runtime_process_lifecycle_slice.go
+++ b/internal/orchestrator/runtime_process_lifecycle_slice.go
@@ -190,7 +190,6 @@ func (s runtimeProcessLifecycleSlice) startAgentSessionWithTimeout(
 	}
 
 	startCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	type startResult struct {
 		session agentSession
@@ -522,12 +521,9 @@ func (s runtimeProcessLifecycleSlice) startRuntimeSessionOnMachine(
 		return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
 	}
 	environment = append(environment, githubEnvironment...)
-	if !remote {
-		launcherEnvironment, err := buildLocalOpenASEEnvironment()
-		if err != nil {
-			return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
-		}
-		environment = append(environment, launcherEnvironment...)
+	environment, err = buildMachineOpenASEEnvironment(machine, remote, environment)
+	if err != nil {
+		return nil, wrapRuntimeLaunchFailure(machine, workspaceRoot, runtimeLaunchStageContext, err)
 	}
 	if requiresMachineCodexReady(command, environment) {
 		if ready, reason, ok := machineCodexReady(machine.Resources); ok && !ready {

--- a/internal/orchestrator/runtime_runner.go
+++ b/internal/orchestrator/runtime_runner.go
@@ -1457,7 +1457,12 @@ func (l *RuntimeLauncher) handleExecutionFailure(ctx context.Context, runID uuid
 	l.deleteSession(runID)
 	l.runtime.delete(runID)
 
-	suppressFailure, err := l.shouldSuppressExecutionFailure(ctx, runID, ticketID)
+	persistCtx := context.Background()
+	if ctx != nil {
+		persistCtx = context.WithoutCancel(ctx)
+	}
+
+	suppressFailure, err := l.shouldSuppressExecutionFailure(persistCtx, runID, ticketID)
 	if err != nil {
 		l.logger.Warn("check execution failure suppression", "run_id", runID, "ticket_id", ticketID, "error", err)
 	} else if suppressFailure {
@@ -1470,16 +1475,16 @@ func (l *RuntimeLauncher) handleExecutionFailure(ctx context.Context, runID uuid
 		SetStatus(entagentrun.StatusErrored).
 		SetTerminalAt(now).
 		SetLastError(strings.TrimSpace(failure.Error())).
-		Save(ctx); err == nil {
-		_ = catalogrepo.MaterializeAgentRunDailyUsage(ctx, l.client, runID, now)
-		l.tickets.RunLifecycleHookBestEffort(ctx, ticketservice.RunLifecycleHookInput{
+		Save(persistCtx); err == nil {
+		_ = catalogrepo.MaterializeAgentRunDailyUsage(persistCtx, l.client, runID, now)
+		l.tickets.RunLifecycleHookBestEffort(persistCtx, ticketservice.RunLifecycleHookInput{
 			TicketID: ticketID,
 			RunID:    runID,
 			HookName: infrahook.TicketHookOnError,
 		})
-		if failedAgent, err := loadAgentLifecycleState(ctx, l.client, agentID, &runID); err == nil {
+		if failedAgent, err := loadAgentLifecycleState(persistCtx, l.client, agentID, &runID); err == nil {
 			l.publishLifecycleEvent(
-				ctx,
+				persistCtx,
 				agentFailedType,
 				failedAgent,
 				lifecycleMessage(agentFailedType, failedAgent.agent.Name),
@@ -1487,8 +1492,10 @@ func (l *RuntimeLauncher) handleExecutionFailure(ctx context.Context, runID uuid
 				now,
 			)
 		}
+	} else {
+		l.logger.Warn("persist execution failure state", "run_id", runID, "agent_id", agentID, "ticket_id", ticketID, "error", err)
 	}
-	l.prepareRunCompletionSummaryBestEffort(ctx, runID)
+	l.prepareRunCompletionSummaryBestEffort(persistCtx, runID)
 	l.scheduleRunCompletionSummary(runID)
 
 	retrySvc := NewRetryService(l.client, l.logger, l.events)


### PR DESCRIPTION
## Summary
- harden remote websocket runtime startup so remote Codex sessions survive launch and execution context transitions
- inject stable remote `OPENASE_REAL_BIN` paths into websocket runtimes, summaries, and ssh bootstrap updates
- add PTY-aware remote terminal command sessions with resize support while keeping terminal shells separate from agent stdio processes
- include the current branch's related control-plane URL, CLI relay, and machine-channel helper changes already present in the workspace

## Validation
- `go test ./internal/orchestrator ./internal/chat ./internal/httpapi ./internal/cli ./internal/domain/catalog`
- `go test ./internal/infra/ssh ./internal/infra/machinetransport ./internal/chat ./internal/httpapi`
- `.codex/skills/push/scripts/openase_ci_gate.sh` *(fails on domain/core coverage gate: 99.8% < required 100.0%)*

## Risks / Follow-up
- current working tree still has additional uncommitted local changes that are not part of this PR
- remote PTY behavior is exercised in tests, but some PTY cases are skipped in restricted local environments where PTY creation is not permitted
