### PR TITLE
refactor: replace machine frontend budget bypasses

### DIFF
--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -1,18 +1,3 @@
-const machineContainerBudgetOverrides = {
-  'src/lib/features/machines/components/machine-create-wizard.svelte': {
-    soft: 750,
-    hard: 900,
-  },
-  'src/lib/features/machines/components/machine-editor-guidance.svelte': {
-    soft: 550,
-    hard: 700,
-  },
-  'src/lib/features/machines/components/machine-health-panel.svelte': {
-    soft: 550,
-    hard: 700,
-  },
-}
-
 export const fileBudgetLimits = {
   routePage: { soft: 150, hard: 250 },
   routeLayout: { soft: 180, hard: 300 },
@@ -61,17 +46,7 @@ function isUiPrimitive(filePath) {
   return /^src\/lib\/components\/ui\/.+\.svelte$/.test(filePath)
 }
 
-const machineContainerBudgetRules = Object.entries(machineContainerBudgetOverrides).map(
-  ([filePath, budget]) => ({
-    name: `Machine container budget override (${filePath})`,
-    match: (candidatePath) => candidatePath === filePath,
-    softLimit: budget.soft,
-    hardLimit: budget.hard,
-  }),
-)
-
 export const fileBudgetRules = [
-  ...machineContainerBudgetRules,
   {
     name: 'Route pages',
     match: isRoutePage,

--- a/web/src/lib/features/agents/components/agents-page.test.ts
+++ b/web/src/lib/features/agents/components/agents-page.test.ts
@@ -21,9 +21,10 @@ vi.mock('$lib/api/sse', () => ({
 
 vi.mock('$lib/features/project-events', () => ({
   createProjectReconnectRecoveryTask: vi.fn(
-    (recover: (recovery: { sequence: number }) => Promise<void> | void) => (recovery: { sequence: number }) => {
-      void recover(recovery)
-    },
+    (recover: (recovery: { sequence: number }) => Promise<void> | void) =>
+      (recovery: { sequence: number }) => {
+        void recover(recovery)
+      },
   ),
   isProjectDashboardRefreshEvent: vi.fn(() => false),
   readProjectDashboardRefreshSections: vi.fn(() => []),

--- a/web/src/lib/features/machines/components/machine-create-wizard-footer.svelte
+++ b/web/src/lib/features/machines/components/machine-create-wizard-footer.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { ArrowLeft, ArrowRight } from '@lucide/svelte'
+  import { Button } from '$ui/button'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+
+  let {
+    currentStepIndex,
+    canAdvance,
+    isLastStep,
+    saving = false,
+    bootstrapping = false,
+    hasTerminalState = false,
+    onBack,
+    onNext,
+    onCreate,
+  }: {
+    currentStepIndex: number
+    canAdvance: boolean
+    isLastStep: boolean
+    saving?: boolean
+    bootstrapping?: boolean
+    hasTerminalState?: boolean
+    onBack?: () => void
+    onNext?: () => void
+    onCreate?: () => void
+  } = $props()
+</script>
+
+<div class="flex items-center justify-between gap-2">
+  <Button
+    variant="ghost"
+    size="sm"
+    onclick={onBack}
+    disabled={currentStepIndex === 0 || saving || bootstrapping}
+    data-testid="machine-wizard-back"
+  >
+    <ArrowLeft class="size-3.5" />
+    {i18nStore.t('machines.machineCreateWizard.actions.back')}
+  </Button>
+
+  {#if isLastStep}
+    {#if !hasTerminalState}
+      <Button
+        size="sm"
+        onclick={onCreate}
+        disabled={saving || bootstrapping}
+        data-testid="machine-wizard-create"
+      >
+        {saving || bootstrapping
+          ? i18nStore.t('machines.machineCreateWizard.actions.creating')
+          : i18nStore.t('machines.machineCreateWizard.actions.create')}
+      </Button>
+    {/if}
+  {:else}
+    <Button size="sm" onclick={onNext} disabled={!canAdvance} data-testid="machine-wizard-next">
+      {i18nStore.t('machines.machineCreateWizard.actions.next')}
+      <ArrowRight class="size-3.5" />
+    </Button>
+  {/if}
+</div>

--- a/web/src/lib/features/machines/components/machine-create-wizard-options.ts
+++ b/web/src/lib/features/machines/components/machine-create-wizard-options.ts
@@ -1,0 +1,43 @@
+import { ArrowLeftRight, ArrowRight, Monitor, Radio, Sparkles } from '@lucide/svelte'
+import type {
+  MachineWizardLocationAnswer,
+  MachineWizardOptionCard,
+  MachineWizardStrategy,
+} from './machine-create-wizard-types'
+
+export const machineWizardLocationOptions: MachineWizardOptionCard<MachineWizardLocationAnswer>[] =
+  [
+    {
+      value: 'local',
+      icon: Monitor,
+      titleKey: 'machines.machineCreateWizard.location.local.title',
+      descKey: 'machines.machineCreateWizard.location.local.desc',
+    },
+    {
+      value: 'remote',
+      icon: ArrowRight,
+      titleKey: 'machines.machineCreateWizard.location.remote.title',
+      descKey: 'machines.machineCreateWizard.location.remote.desc',
+    },
+  ]
+
+export const machineWizardStrategyOptions: MachineWizardOptionCard<MachineWizardStrategy>[] = [
+  {
+    value: 'ssh-install-listener',
+    icon: Sparkles,
+    titleKey: 'machines.machineCreateWizard.strategy.sshInstall.title',
+    descKey: 'machines.machineCreateWizard.strategy.sshInstall.desc',
+  },
+  {
+    value: 'reverse',
+    icon: ArrowLeftRight,
+    titleKey: 'machines.machineCreateWizard.strategy.reverse.title',
+    descKey: 'machines.machineCreateWizard.strategy.reverse.desc',
+  },
+  {
+    value: 'direct-open',
+    icon: Radio,
+    titleKey: 'machines.machineCreateWizard.strategy.directOpen.title',
+    descKey: 'machines.machineCreateWizard.strategy.directOpen.desc',
+  },
+]

--- a/web/src/lib/features/machines/components/machine-create-wizard-review.svelte
+++ b/web/src/lib/features/machines/components/machine-create-wizard-review.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { Loader2 } from '@lucide/svelte'
+  import { fly } from 'svelte/transition'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import { Button } from '$ui/button'
+  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import type {
+    MachineWizardLocationAnswer,
+    MachineWizardStrategy,
+  } from './machine-create-wizard-types'
+
+  let {
+    location,
+    name,
+    host,
+    strategy,
+    sshUser,
+    advertisedEndpoint,
+    strategyNeedsSSH,
+    saving = false,
+    bootstrapping = false,
+    bootstrapResult = null,
+    errorMessage = '',
+    onClose,
+  }: {
+    location: MachineWizardLocationAnswer | null
+    name: string
+    host: string
+    strategy: MachineWizardStrategy | null
+    sshUser: string
+    advertisedEndpoint: string
+    strategyNeedsSSH: boolean
+    saving?: boolean
+    bootstrapping?: boolean
+    bootstrapResult?: MachineSSHBootstrapResult | null
+    errorMessage?: string
+    onClose?: () => void
+  } = $props()
+
+  function strategyLabel(value: MachineWizardStrategy | null): string {
+    switch (value) {
+      case 'ssh-install-listener':
+        return i18nStore.t('machines.machineCreateWizard.strategy.sshInstall.title')
+      case 'reverse':
+        return i18nStore.t('machines.machineCreateWizard.strategy.reverse.title')
+      case 'direct-open':
+        return i18nStore.t('machines.machineCreateWizard.strategy.directOpen.title')
+      default:
+        return ''
+    }
+  }
+</script>
+
+<div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
+  <div class="space-y-1">
+    <p class="text-foreground text-sm font-medium">
+      {i18nStore.t('machines.machineCreateWizard.review.question')}
+    </p>
+    <p class="text-muted-foreground text-xs">
+      {i18nStore.t('machines.machineCreateWizard.review.helper')}
+    </p>
+  </div>
+
+  {#if !bootstrapResult && !errorMessage}
+    <dl class="border-border bg-card divide-border divide-y rounded-lg border text-xs">
+      <div class="flex items-center justify-between gap-3 px-3 py-2">
+        <dt class="text-muted-foreground">
+          {i18nStore.t('machines.machineCreateWizard.review.nameLabel')}
+        </dt>
+        <dd class="text-foreground font-medium">{name || '—'}</dd>
+      </div>
+      {#if location === 'remote'}
+        <div class="flex items-center justify-between gap-3 px-3 py-2">
+          <dt class="text-muted-foreground">
+            {i18nStore.t('machines.machineCreateWizard.review.hostLabel')}
+          </dt>
+          <dd class="text-foreground font-medium">{host || '—'}</dd>
+        </div>
+        <div class="flex items-center justify-between gap-3 px-3 py-2">
+          <dt class="text-muted-foreground">
+            {i18nStore.t('machines.machineCreateWizard.review.strategyLabel')}
+          </dt>
+          <dd class="text-foreground font-medium">{strategyLabel(strategy)}</dd>
+        </div>
+        {#if strategyNeedsSSH}
+          <div class="flex items-center justify-between gap-3 px-3 py-2">
+            <dt class="text-muted-foreground">
+              {i18nStore.t('machines.machineCreateWizard.review.sshLabel')}
+            </dt>
+            <dd class="text-foreground font-medium">{sshUser || '—'}@{host || '—'}</dd>
+          </div>
+        {/if}
+        {#if strategy === 'direct-open'}
+          <div class="flex items-center justify-between gap-3 px-3 py-2">
+            <dt class="text-muted-foreground">
+              {i18nStore.t('machines.machineCreateWizard.review.endpointLabel')}
+            </dt>
+            <dd class="text-foreground font-medium break-all">{advertisedEndpoint || '—'}</dd>
+          </div>
+        {/if}
+      {/if}
+    </dl>
+  {/if}
+
+  {#if saving || bootstrapping}
+    <div
+      class="border-primary/30 bg-primary/5 flex items-center gap-2 rounded-lg border px-3 py-2.5 text-xs"
+    >
+      <Loader2 class="text-primary size-3.5 animate-spin" />
+      <span class="text-foreground">
+        {bootstrapping
+          ? i18nStore.t('machines.machineCreateWizard.review.bootstrapProgress')
+          : i18nStore.t('machines.machineCreateWizard.review.saveProgress')}
+      </span>
+    </div>
+  {/if}
+
+  {#if bootstrapResult}
+    <div class="border-primary/30 bg-primary/5 space-y-1 rounded-lg border px-3 py-2.5 text-[11px]">
+      <p class="text-foreground text-xs font-medium">
+        {i18nStore.t('machines.machineCreateWizard.review.bootstrapDone')}
+      </p>
+      <p class="text-muted-foreground">{bootstrapResult.summary}</p>
+      <div class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+        <span>
+          <span class="text-muted-foreground"
+            >{i18nStore.t('machines.machineCreateWizard.review.serviceStatus')}</span
+          >
+          <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
+        </span>
+        <span>
+          <span class="text-muted-foreground"
+            >{i18nStore.t('machines.machineCreateWizard.review.connectionTarget')}</span
+          >
+          <span class="text-foreground ml-1 break-all">{bootstrapResult.connection_target}</span>
+        </span>
+      </div>
+    </div>
+  {/if}
+
+  {#if errorMessage}
+    <div class="border-destructive/40 bg-destructive/10 rounded-lg border px-3 py-2.5 text-xs">
+      <p class="text-destructive">{errorMessage}</p>
+    </div>
+  {/if}
+
+  {#if bootstrapResult || (!saving && !bootstrapping && errorMessage)}
+    <Button size="sm" onclick={onClose} data-testid="machine-wizard-done">
+      {i18nStore.t('machines.machineCreateWizard.actions.done')}
+    </Button>
+  {/if}
+</div>

--- a/web/src/lib/features/machines/components/machine-create-wizard-steps.svelte
+++ b/web/src/lib/features/machines/components/machine-create-wizard-steps.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { Check } from '@lucide/svelte'
+  import { fly } from 'svelte/transition'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import { Input } from '$ui/input'
+  import { Label } from '$ui/label'
+  import { cn } from '$lib/utils'
+  import type {
+    MachineWizardLocationAnswer,
+    MachineWizardOptionCard,
+    MachineWizardStep,
+    MachineWizardStrategy,
+  } from './machine-create-wizard-types'
+
+  let {
+    step,
+    location,
+    name = $bindable(''),
+    host = $bindable(''),
+    strategy,
+    sshUser = $bindable(''),
+    sshKeyPath = $bindable(''),
+    advertisedEndpoint = $bindable(''),
+    locationOptions,
+    strategyOptions,
+    onPickLocation,
+    onPickStrategy,
+  }: {
+    step: MachineWizardStep
+    location: MachineWizardLocationAnswer | null
+    name: string
+    host: string
+    strategy: MachineWizardStrategy | null
+    sshUser: string
+    sshKeyPath: string
+    advertisedEndpoint: string
+    locationOptions: MachineWizardOptionCard<MachineWizardLocationAnswer>[]
+    strategyOptions: MachineWizardOptionCard<MachineWizardStrategy>[]
+    onPickLocation?: (value: MachineWizardLocationAnswer) => void
+    onPickStrategy?: (value: MachineWizardStrategy) => void
+  } = $props()
+</script>
+
+{#if step === 'location'}
+  <div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
+    <div class="space-y-1">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineCreateWizard.location.question')}
+      </p>
+      <p class="text-muted-foreground text-xs">
+        {i18nStore.t('machines.machineCreateWizard.location.helper')}
+      </p>
+    </div>
+    <div class="grid gap-2 sm:grid-cols-2">
+      {#each locationOptions as option (option.value)}
+        {@const Icon = option.icon}
+        {@const selected = location === option.value}
+        <button
+          type="button"
+          class={cn(
+            'border-border bg-card hover:bg-muted/50 rounded-lg border px-3 py-3 text-left transition-all',
+            selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
+          )}
+          onclick={() => onPickLocation?.(option.value)}
+          data-testid={`machine-wizard-location-${option.value}`}
+        >
+          <div class="flex items-center gap-2">
+            <Icon class={cn('size-4', selected ? 'text-primary' : 'text-muted-foreground')} />
+            <span class="text-foreground text-sm font-medium">
+              {i18nStore.t(option.titleKey)}
+            </span>
+            {#if selected}
+              <Check class="text-primary ml-auto size-3.5" />
+            {/if}
+          </div>
+          <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+            {i18nStore.t(option.descKey)}
+          </p>
+        </button>
+      {/each}
+    </div>
+  </div>
+{:else if step === 'identity'}
+  <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
+    <div class="space-y-1">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineCreateWizard.identity.question')}
+      </p>
+      <p class="text-muted-foreground text-xs">
+        {i18nStore.t('machines.machineCreateWizard.identity.helper')}
+      </p>
+    </div>
+    <div class="space-y-3">
+      <div class="space-y-1.5">
+        <Label for="wizard-name" class="text-xs">
+          {i18nStore.t('machines.machineCreateWizard.identity.nameLabel')}
+        </Label>
+        <Input
+          id="wizard-name"
+          bind:value={name}
+          placeholder={i18nStore.t('machines.machineCreateWizard.identity.namePlaceholder')}
+          autocomplete="off"
+          data-testid="machine-wizard-name"
+        />
+      </div>
+      {#if location === 'remote'}
+        <div class="space-y-1.5">
+          <Label for="wizard-host" class="text-xs">
+            {i18nStore.t('machines.machineCreateWizard.identity.hostLabel')}
+          </Label>
+          <Input
+            id="wizard-host"
+            bind:value={host}
+            placeholder={i18nStore.t('machines.machineCreateWizard.identity.hostPlaceholder')}
+            autocomplete="off"
+            data-testid="machine-wizard-host"
+          />
+          <p class="text-muted-foreground text-[11px] leading-relaxed">
+            {i18nStore.t('machines.machineCreateWizard.identity.hostHint')}
+          </p>
+        </div>
+      {/if}
+    </div>
+  </div>
+{:else if step === 'strategy'}
+  <div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
+    <div class="space-y-1">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineCreateWizard.strategy.question')}
+      </p>
+      <p class="text-muted-foreground text-xs">
+        {i18nStore.t('machines.machineCreateWizard.strategy.helper')}
+      </p>
+    </div>
+    <div class="grid gap-2">
+      {#each strategyOptions as option (option.value)}
+        {@const Icon = option.icon}
+        {@const selected = strategy === option.value}
+        <button
+          type="button"
+          class={cn(
+            'border-border bg-card hover:bg-muted/50 rounded-lg border px-3 py-3 text-left transition-all',
+            selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
+          )}
+          onclick={() => onPickStrategy?.(option.value)}
+          data-testid={`machine-wizard-strategy-${option.value}`}
+        >
+          <div class="flex items-start gap-2.5">
+            <div
+              class={cn(
+                'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md',
+                selected ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
+              )}
+            >
+              <Icon class="size-3.5" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <span class="text-foreground text-sm font-medium">
+                  {i18nStore.t(option.titleKey)}
+                </span>
+                {#if option.value === 'ssh-install-listener'}
+                  <span
+                    class="bg-primary/10 text-primary rounded-full px-1.5 py-px text-[10px] font-medium"
+                  >
+                    {i18nStore.t('machines.machineCreateWizard.strategy.recommendedBadge')}
+                  </span>
+                {/if}
+                {#if selected}
+                  <Check class="text-primary ml-auto size-3.5" />
+                {/if}
+              </div>
+              <p class="text-muted-foreground mt-1 text-[11px] leading-relaxed">
+                {i18nStore.t(option.descKey)}
+              </p>
+            </div>
+          </div>
+        </button>
+      {/each}
+    </div>
+  </div>
+{:else if step === 'credentials'}
+  <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
+    <div class="space-y-1">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineCreateWizard.credentials.question')}
+      </p>
+      <p class="text-muted-foreground text-xs leading-relaxed">
+        {i18nStore.t('machines.machineCreateWizard.credentials.helper')}
+      </p>
+    </div>
+    <div class="space-y-3">
+      <div class="space-y-1.5">
+        <Label for="wizard-ssh-user" class="text-xs">
+          {i18nStore.t('machines.machineCreateWizard.credentials.userLabel')}
+        </Label>
+        <Input
+          id="wizard-ssh-user"
+          bind:value={sshUser}
+          placeholder={i18nStore.t('machines.machineCreateWizard.credentials.userPlaceholder')}
+          autocomplete="off"
+          data-testid="machine-wizard-ssh-user"
+        />
+      </div>
+      <div class="space-y-1.5">
+        <Label for="wizard-ssh-key" class="text-xs">
+          {i18nStore.t('machines.machineCreateWizard.credentials.keyLabel')}
+        </Label>
+        <Input
+          id="wizard-ssh-key"
+          bind:value={sshKeyPath}
+          placeholder={i18nStore.t('machines.machineCreateWizard.credentials.keyPlaceholder')}
+          autocomplete="off"
+          data-testid="machine-wizard-ssh-key"
+        />
+        <p class="text-muted-foreground text-[11px] leading-relaxed">
+          {i18nStore.t('machines.machineCreateWizard.credentials.keyHint')}
+        </p>
+      </div>
+    </div>
+  </div>
+{:else if step === 'advertised-endpoint'}
+  <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
+    <div class="space-y-1">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineCreateWizard.endpoint.question')}
+      </p>
+      <p class="text-muted-foreground text-xs leading-relaxed">
+        {i18nStore.t('machines.machineCreateWizard.endpoint.helper')}
+      </p>
+    </div>
+    <div class="space-y-1.5">
+      <Label for="wizard-endpoint" class="text-xs">
+        {i18nStore.t('machines.machineCreateWizard.endpoint.label')}
+      </Label>
+      <Input
+        id="wizard-endpoint"
+        bind:value={advertisedEndpoint}
+        placeholder="wss://machine.example.com/openase/runtime"
+        autocomplete="off"
+        data-testid="machine-wizard-endpoint"
+      />
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/features/machines/components/machine-create-wizard-types.ts
+++ b/web/src/lib/features/machines/components/machine-create-wizard-types.ts
@@ -1,0 +1,20 @@
+import type { TranslationKey } from '$lib/i18n'
+import type { Component } from 'svelte'
+
+export type MachineWizardStrategy = 'direct-open' | 'ssh-install-listener' | 'reverse'
+export type MachineWizardLocationAnswer = 'local' | 'remote'
+export type MachineWizardStep =
+  | 'location'
+  | 'identity'
+  | 'strategy'
+  | 'credentials'
+  | 'advertised-endpoint'
+  | 'review'
+
+export type MachineWizardOptionCard<T> = {
+  value: T
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: Component<any>
+  titleKey: TranslationKey
+  descKey: TranslationKey
+}

--- a/web/src/lib/features/machines/components/machine-create-wizard.svelte
+++ b/web/src/lib/features/machines/components/machine-create-wizard.svelte
@@ -1,37 +1,23 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
   import * as Dialog from '$ui/dialog'
-  import { Button } from '$ui/button'
-  import { Input } from '$ui/input'
-  import { Label } from '$ui/label'
   import { cn } from '$lib/utils'
-  import { fly } from 'svelte/transition'
-  import {
-    ArrowLeftRight,
-    ArrowRight,
-    ArrowLeft,
-    Check,
-    Loader2,
-    Monitor,
-    Radio,
-    Sparkles,
-  } from '@lucide/svelte'
   import { i18nStore } from '$lib/i18n/store.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
-  import type { TranslationKey } from '$lib/i18n'
   import type { Machine, MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import MachineCreateWizardFooter from './machine-create-wizard-footer.svelte'
+  import {
+    machineWizardLocationOptions,
+    machineWizardStrategyOptions,
+  } from './machine-create-wizard-options'
+  import MachineCreateWizardReview from './machine-create-wizard-review.svelte'
   import { machineErrorMessage, runMachineSSHBootstrap, saveMachine } from './machines-page-api'
+  import MachineCreateWizardSteps from './machine-create-wizard-steps.svelte'
   import type { MachineMutationInput } from '../types'
-
-  type Strategy = 'direct-open' | 'ssh-install-listener' | 'reverse'
-  type LocationAnswer = 'local' | 'remote'
-  type Step =
-    | 'location'
-    | 'identity'
-    | 'strategy'
-    | 'credentials'
-    | 'advertised-endpoint'
-    | 'review'
+  import type {
+    MachineWizardLocationAnswer,
+    MachineWizardStep,
+    MachineWizardStrategy,
+  } from './machine-create-wizard-types'
 
   let {
     open = $bindable(false),
@@ -43,13 +29,11 @@
     onCreated?: (machine: Machine) => void
   } = $props()
 
-  // Wizard state — only the fields the user can actually answer. Ports, topology
-  // envs, and binary paths fall back to sensible server defaults.
-  let step = $state<Step>('location')
-  let location = $state<LocationAnswer | null>(null)
+  let step = $state<MachineWizardStep>('location')
+  let location = $state<MachineWizardLocationAnswer | null>(null)
   let name = $state('')
   let host = $state('')
-  let strategy = $state<Strategy | null>(null)
+  let strategy = $state<MachineWizardStrategy | null>(null)
   let sshUser = $state('')
   let sshKeyPath = $state('~/.ssh/id_ed25519')
   let advertisedEndpoint = $state('')
@@ -59,7 +43,6 @@
   let bootstrapResult = $state<MachineSSHBootstrapResult | null>(null)
   let errorMessage = $state('')
 
-  // Reset wizard every time the dialog opens.
   $effect(() => {
     if (open) {
       step = 'location'
@@ -83,9 +66,12 @@
   const totalSteps = $derived(stepOrder.length)
   const isLastStep = $derived(step === 'review')
 
-  function computeStepOrder(loc: LocationAnswer | null, strat: Strategy | null): Step[] {
+  function computeStepOrder(
+    loc: MachineWizardLocationAnswer | null,
+    strat: MachineWizardStrategy | null,
+  ): MachineWizardStep[] {
     if (loc === 'local') return ['location', 'identity', 'review']
-    const order: Step[] = ['location', 'identity', 'strategy']
+    const order: MachineWizardStep[] = ['location', 'identity', 'strategy']
     if (strat === 'direct-open') order.push('advertised-endpoint')
     if (strat === 'ssh-install-listener' || strat === 'reverse') {
       order.push('credentials')
@@ -127,7 +113,7 @@
     }
   }
 
-  function pickLocation(value: LocationAnswer) {
+  function pickLocation(value: MachineWizardLocationAnswer) {
     location = value
     if (value === 'local') {
       strategy = null
@@ -135,11 +121,10 @@
     } else if (!strategy) {
       strategy = 'ssh-install-listener'
     }
-    // Auto-advance for a snappy feel.
     setTimeout(() => goNext(), 120)
   }
 
-  function pickStrategy(value: Strategy) {
+  function pickStrategy(value: MachineWizardStrategy) {
     strategy = value
     setTimeout(() => goNext(), 120)
   }
@@ -163,6 +148,7 @@
         env_vars: [],
       }
     }
+
     const hostValue = host.trim()
     if (strategy === 'reverse') {
       return {
@@ -182,7 +168,7 @@
         env_vars: [],
       }
     }
-    // direct-open and ssh-install-listener both target direct_connect / ws_listener.
+
     const endpoint =
       strategy === 'direct-open'
         ? advertisedEndpoint.trim()
@@ -210,6 +196,7 @@
       toastStore.error(i18nStore.t('machines.machineCreateWizard.errors.noOrg'))
       return
     }
+
     errorMessage = ''
     saving = true
     try {
@@ -217,9 +204,6 @@
       const created = await saveMachine(organizationId, null, 'create', mutation)
       onCreated?.(created.machine)
 
-      // Auto-bootstrap when the strategy maps to a CLI topology the backend
-      // can drive in-process. direct-open skips this because the user manages
-      // the listener themselves.
       if (strategy === 'ssh-install-listener' || strategy === 'reverse') {
         bootstrapping = true
         try {
@@ -246,7 +230,7 @@
       } else {
         toastStore.success(i18nStore.t('machines.machineCreateWizard.successes.created'))
       }
-      // Keep the dialog open only when the user can read the bootstrap result.
+
       if (!bootstrapResult && !errorMessage) {
         open = false
       }
@@ -264,63 +248,17 @@
   function closeWizard() {
     open = false
   }
-
-  type OptionCard<T> = {
-    value: T
-    icon: typeof Monitor
-    titleKey: TranslationKey
-    descKey: TranslationKey
-  }
-
-  const locationOptions: OptionCard<LocationAnswer>[] = [
-    {
-      value: 'local',
-      icon: Monitor,
-      titleKey: 'machines.machineCreateWizard.location.local.title',
-      descKey: 'machines.machineCreateWizard.location.local.desc',
-    },
-    {
-      value: 'remote',
-      icon: ArrowRight,
-      titleKey: 'machines.machineCreateWizard.location.remote.title',
-      descKey: 'machines.machineCreateWizard.location.remote.desc',
-    },
-  ]
-
-  const strategyOptions: OptionCard<Strategy>[] = [
-    {
-      value: 'ssh-install-listener',
-      icon: Sparkles,
-      titleKey: 'machines.machineCreateWizard.strategy.sshInstall.title',
-      descKey: 'machines.machineCreateWizard.strategy.sshInstall.desc',
-    },
-    {
-      value: 'reverse',
-      icon: ArrowLeftRight,
-      titleKey: 'machines.machineCreateWizard.strategy.reverse.title',
-      descKey: 'machines.machineCreateWizard.strategy.reverse.desc',
-    },
-    {
-      value: 'direct-open',
-      icon: Radio,
-      titleKey: 'machines.machineCreateWizard.strategy.directOpen.title',
-      descKey: 'machines.machineCreateWizard.strategy.directOpen.desc',
-    },
-  ]
 </script>
 
 <Dialog.Root bind:open>
   <Dialog.Content class="sm:max-w-lg" data-testid="machine-create-wizard">
     <Dialog.Header>
-      <Dialog.Title>
-        {i18nStore.t('machines.machineCreateWizard.title')}
-      </Dialog.Title>
+      <Dialog.Title>{i18nStore.t('machines.machineCreateWizard.title')}</Dialog.Title>
       <Dialog.Description class="text-xs">
         {i18nStore.t('machines.machineCreateWizard.description')}
       </Dialog.Description>
     </Dialog.Header>
 
-    <!-- Progress bar: simple dots, no chapter labels so it stays out of the way. -->
     <div class="flex items-center justify-between gap-1 px-1 pt-1">
       <div class="flex flex-1 gap-1">
         {#each Array(totalSteps) as _, idx (idx)}
@@ -338,366 +276,51 @@
     </div>
 
     <Dialog.Body class="min-h-[220px] py-4">
-      {#if step === 'location'}
-        <div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.location.question')}
-            </p>
-            <p class="text-muted-foreground text-xs">
-              {i18nStore.t('machines.machineCreateWizard.location.helper')}
-            </p>
-          </div>
-          <div class="grid gap-2 sm:grid-cols-2">
-            {#each locationOptions as option (option.value)}
-              {@const Icon = option.icon}
-              {@const selected = location === option.value}
-              <button
-                type="button"
-                class={cn(
-                  'border-border bg-card hover:bg-muted/50 rounded-lg border px-3 py-3 text-left transition-all',
-                  selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
-                )}
-                onclick={() => pickLocation(option.value)}
-                data-testid={`machine-wizard-location-${option.value}`}
-              >
-                <div class="flex items-center gap-2">
-                  <Icon class={cn('size-4', selected ? 'text-primary' : 'text-muted-foreground')} />
-                  <span class="text-foreground text-sm font-medium">
-                    {i18nStore.t(option.titleKey)}
-                  </span>
-                  {#if selected}
-                    <Check class="text-primary ml-auto size-3.5" />
-                  {/if}
-                </div>
-                <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
-                  {i18nStore.t(option.descKey)}
-                </p>
-              </button>
-            {/each}
-          </div>
-        </div>
-      {:else if step === 'identity'}
-        <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.identity.question')}
-            </p>
-            <p class="text-muted-foreground text-xs">
-              {i18nStore.t('machines.machineCreateWizard.identity.helper')}
-            </p>
-          </div>
-          <div class="space-y-3">
-            <div class="space-y-1.5">
-              <Label for="wizard-name" class="text-xs">
-                {i18nStore.t('machines.machineCreateWizard.identity.nameLabel')}
-              </Label>
-              <Input
-                id="wizard-name"
-                bind:value={name}
-                placeholder={i18nStore.t('machines.machineCreateWizard.identity.namePlaceholder')}
-                autocomplete="off"
-                data-testid="machine-wizard-name"
-              />
-            </div>
-            {#if location === 'remote'}
-              <div class="space-y-1.5">
-                <Label for="wizard-host" class="text-xs">
-                  {i18nStore.t('machines.machineCreateWizard.identity.hostLabel')}
-                </Label>
-                <Input
-                  id="wizard-host"
-                  bind:value={host}
-                  placeholder={i18nStore.t('machines.machineCreateWizard.identity.hostPlaceholder')}
-                  autocomplete="off"
-                  data-testid="machine-wizard-host"
-                />
-                <p class="text-muted-foreground text-[11px] leading-relaxed">
-                  {i18nStore.t('machines.machineCreateWizard.identity.hostHint')}
-                </p>
-              </div>
-            {/if}
-          </div>
-        </div>
-      {:else if step === 'strategy'}
-        <div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.strategy.question')}
-            </p>
-            <p class="text-muted-foreground text-xs">
-              {i18nStore.t('machines.machineCreateWizard.strategy.helper')}
-            </p>
-          </div>
-          <div class="grid gap-2">
-            {#each strategyOptions as option (option.value)}
-              {@const Icon = option.icon}
-              {@const selected = strategy === option.value}
-              <button
-                type="button"
-                class={cn(
-                  'border-border bg-card hover:bg-muted/50 rounded-lg border px-3 py-3 text-left transition-all',
-                  selected && 'border-primary bg-primary/5 ring-primary/20 ring-1',
-                )}
-                onclick={() => pickStrategy(option.value)}
-                data-testid={`machine-wizard-strategy-${option.value}`}
-              >
-                <div class="flex items-start gap-2.5">
-                  <div
-                    class={cn(
-                      'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md',
-                      selected ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
-                    )}
-                  >
-                    <Icon class="size-3.5" />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <div class="flex items-center gap-2">
-                      <span class="text-foreground text-sm font-medium">
-                        {i18nStore.t(option.titleKey)}
-                      </span>
-                      {#if option.value === 'ssh-install-listener'}
-                        <span
-                          class="bg-primary/10 text-primary rounded-full px-1.5 py-px text-[10px] font-medium"
-                        >
-                          {i18nStore.t('machines.machineCreateWizard.strategy.recommendedBadge')}
-                        </span>
-                      {/if}
-                      {#if selected}
-                        <Check class="text-primary ml-auto size-3.5" />
-                      {/if}
-                    </div>
-                    <p class="text-muted-foreground mt-1 text-[11px] leading-relaxed">
-                      {i18nStore.t(option.descKey)}
-                    </p>
-                  </div>
-                </div>
-              </button>
-            {/each}
-          </div>
-        </div>
-      {:else if step === 'credentials'}
-        <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.credentials.question')}
-            </p>
-            <p class="text-muted-foreground text-xs leading-relaxed">
-              {i18nStore.t('machines.machineCreateWizard.credentials.helper')}
-            </p>
-          </div>
-          <div class="space-y-3">
-            <div class="space-y-1.5">
-              <Label for="wizard-ssh-user" class="text-xs">
-                {i18nStore.t('machines.machineCreateWizard.credentials.userLabel')}
-              </Label>
-              <Input
-                id="wizard-ssh-user"
-                bind:value={sshUser}
-                placeholder={i18nStore.t(
-                  'machines.machineCreateWizard.credentials.userPlaceholder',
-                )}
-                autocomplete="off"
-                data-testid="machine-wizard-ssh-user"
-              />
-            </div>
-            <div class="space-y-1.5">
-              <Label for="wizard-ssh-key" class="text-xs">
-                {i18nStore.t('machines.machineCreateWizard.credentials.keyLabel')}
-              </Label>
-              <Input
-                id="wizard-ssh-key"
-                bind:value={sshKeyPath}
-                placeholder={i18nStore.t('machines.machineCreateWizard.credentials.keyPlaceholder')}
-                autocomplete="off"
-                data-testid="machine-wizard-ssh-key"
-              />
-              <p class="text-muted-foreground text-[11px] leading-relaxed">
-                {i18nStore.t('machines.machineCreateWizard.credentials.keyHint')}
-              </p>
-            </div>
-          </div>
-        </div>
-      {:else if step === 'advertised-endpoint'}
-        <div class="space-y-4" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.endpoint.question')}
-            </p>
-            <p class="text-muted-foreground text-xs leading-relaxed">
-              {i18nStore.t('machines.machineCreateWizard.endpoint.helper')}
-            </p>
-          </div>
-          <div class="space-y-1.5">
-            <Label for="wizard-endpoint" class="text-xs">
-              {i18nStore.t('machines.machineCreateWizard.endpoint.label')}
-            </Label>
-            <Input
-              id="wizard-endpoint"
-              bind:value={advertisedEndpoint}
-              placeholder="wss://machine.example.com/openase/runtime"
-              autocomplete="off"
-              data-testid="machine-wizard-endpoint"
-            />
-          </div>
-        </div>
-      {:else if step === 'review'}
-        <div class="space-y-3" in:fly={{ y: 6, duration: 180 }}>
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">
-              {i18nStore.t('machines.machineCreateWizard.review.question')}
-            </p>
-            <p class="text-muted-foreground text-xs">
-              {i18nStore.t('machines.machineCreateWizard.review.helper')}
-            </p>
-          </div>
-
-          {#if !bootstrapResult && !errorMessage}
-            <dl class="border-border bg-card divide-border divide-y rounded-lg border text-xs">
-              <div class="flex items-center justify-between gap-3 px-3 py-2">
-                <dt class="text-muted-foreground">
-                  {i18nStore.t('machines.machineCreateWizard.review.nameLabel')}
-                </dt>
-                <dd class="text-foreground font-medium">{name || '—'}</dd>
-              </div>
-              {#if location === 'remote'}
-                <div class="flex items-center justify-between gap-3 px-3 py-2">
-                  <dt class="text-muted-foreground">
-                    {i18nStore.t('machines.machineCreateWizard.review.hostLabel')}
-                  </dt>
-                  <dd class="text-foreground font-medium">{host || '—'}</dd>
-                </div>
-                <div class="flex items-center justify-between gap-3 px-3 py-2">
-                  <dt class="text-muted-foreground">
-                    {i18nStore.t('machines.machineCreateWizard.review.strategyLabel')}
-                  </dt>
-                  <dd class="text-foreground font-medium">
-                    {#if strategy === 'ssh-install-listener'}
-                      {i18nStore.t('machines.machineCreateWizard.strategy.sshInstall.title')}
-                    {:else if strategy === 'reverse'}
-                      {i18nStore.t('machines.machineCreateWizard.strategy.reverse.title')}
-                    {:else if strategy === 'direct-open'}
-                      {i18nStore.t('machines.machineCreateWizard.strategy.directOpen.title')}
-                    {/if}
-                  </dd>
-                </div>
-                {#if strategyNeedsSSH}
-                  <div class="flex items-center justify-between gap-3 px-3 py-2">
-                    <dt class="text-muted-foreground">
-                      {i18nStore.t('machines.machineCreateWizard.review.sshLabel')}
-                    </dt>
-                    <dd class="text-foreground font-medium">
-                      {sshUser || '—'}@{host || '—'}
-                    </dd>
-                  </div>
-                {/if}
-                {#if strategy === 'direct-open'}
-                  <div class="flex items-center justify-between gap-3 px-3 py-2">
-                    <dt class="text-muted-foreground">
-                      {i18nStore.t('machines.machineCreateWizard.review.endpointLabel')}
-                    </dt>
-                    <dd class="text-foreground font-medium break-all">
-                      {advertisedEndpoint || '—'}
-                    </dd>
-                  </div>
-                {/if}
-              {/if}
-            </dl>
-          {/if}
-
-          {#if saving || bootstrapping}
-            <div
-              class="border-primary/30 bg-primary/5 flex items-center gap-2 rounded-lg border px-3 py-2.5 text-xs"
-            >
-              <Loader2 class="text-primary size-3.5 animate-spin" />
-              <span class="text-foreground">
-                {bootstrapping
-                  ? i18nStore.t('machines.machineCreateWizard.review.bootstrapProgress')
-                  : i18nStore.t('machines.machineCreateWizard.review.saveProgress')}
-              </span>
-            </div>
-          {/if}
-
-          {#if bootstrapResult}
-            <div
-              class="border-primary/30 bg-primary/5 space-y-1 rounded-lg border px-3 py-2.5 text-[11px]"
-            >
-              <p class="text-foreground text-xs font-medium">
-                {i18nStore.t('machines.machineCreateWizard.review.bootstrapDone')}
-              </p>
-              <p class="text-muted-foreground">
-                {bootstrapResult.summary}
-              </p>
-              <div class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
-                <span>
-                  <span class="text-muted-foreground">
-                    {i18nStore.t('machines.machineCreateWizard.review.serviceStatus')}
-                  </span>
-                  <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
-                </span>
-                <span>
-                  <span class="text-muted-foreground">
-                    {i18nStore.t('machines.machineCreateWizard.review.connectionTarget')}
-                  </span>
-                  <span class="text-foreground ml-1 break-all"
-                    >{bootstrapResult.connection_target}</span
-                  >
-                </span>
-              </div>
-            </div>
-          {/if}
-
-          {#if errorMessage}
-            <div
-              class="border-destructive/40 bg-destructive/10 rounded-lg border px-3 py-2.5 text-xs"
-            >
-              <p class="text-destructive">{errorMessage}</p>
-            </div>
-          {/if}
-        </div>
+      {#if step === 'review'}
+        <MachineCreateWizardReview
+          {location}
+          {name}
+          {host}
+          {strategy}
+          {sshUser}
+          {advertisedEndpoint}
+          {strategyNeedsSSH}
+          {saving}
+          {bootstrapping}
+          {bootstrapResult}
+          {errorMessage}
+          onClose={closeWizard}
+        />
+      {:else}
+        <MachineCreateWizardSteps
+          {step}
+          {location}
+          bind:name
+          bind:host
+          {strategy}
+          bind:sshUser
+          bind:sshKeyPath
+          bind:advertisedEndpoint
+          locationOptions={machineWizardLocationOptions}
+          strategyOptions={machineWizardStrategyOptions}
+          onPickLocation={pickLocation}
+          onPickStrategy={pickStrategy}
+        />
       {/if}
     </Dialog.Body>
 
-    <Dialog.Footer class="flex items-center justify-between gap-2">
-      <Button
-        variant="ghost"
-        size="sm"
-        onclick={goBack}
-        disabled={currentStepIndex === 0 || saving || bootstrapping}
-        data-testid="machine-wizard-back"
-      >
-        <ArrowLeft class="size-3.5" />
-        {i18nStore.t('machines.machineCreateWizard.actions.back')}
-      </Button>
-
-      {#if isLastStep}
-        {#if bootstrapResult || (!saving && !bootstrapping && errorMessage)}
-          <Button size="sm" onclick={closeWizard} data-testid="machine-wizard-done">
-            {i18nStore.t('machines.machineCreateWizard.actions.done')}
-          </Button>
-        {:else}
-          <Button
-            size="sm"
-            onclick={handleCreate}
-            disabled={saving || bootstrapping}
-            data-testid="machine-wizard-create"
-          >
-            {saving || bootstrapping
-              ? i18nStore.t('machines.machineCreateWizard.actions.creating')
-              : i18nStore.t('machines.machineCreateWizard.actions.create')}
-          </Button>
-        {/if}
-      {:else}
-        <Button
-          size="sm"
-          onclick={goNext}
-          disabled={!canAdvance()}
-          data-testid="machine-wizard-next"
-        >
-          {i18nStore.t('machines.machineCreateWizard.actions.next')}
-          <ArrowRight class="size-3.5" />
-        </Button>
-      {/if}
+    <Dialog.Footer>
+      <MachineCreateWizardFooter
+        {currentStepIndex}
+        canAdvance={canAdvance()}
+        {isLastStep}
+        {saving}
+        {bootstrapping}
+        hasTerminalState={Boolean(bootstrapResult || (!saving && !bootstrapping && errorMessage))}
+        onBack={goBack}
+        onNext={goNext}
+        onCreate={handleCreate}
+      />
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/web/src/lib/features/machines/components/machine-editor-guidance-setup.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-guidance-setup.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { Loader2, Play } from '@lucide/svelte'
+  import { slide } from 'svelte/transition'
+  import { Badge } from '$ui/badge'
+  import { Button } from '$ui/button'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import MachineSetupCommandList from './machine-setup-command-list.svelte'
+  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import type { MachineSetupGuide } from '../machine-setup'
+  import type { MachineModeGuide } from '../types'
+
+  let {
+    reachabilityGuide,
+    setupGuide,
+    detectionBadgeClass,
+    detectionStatusLabel,
+    detectedOSLabel,
+    detectedArchLabel,
+    detectionSummary,
+    canRunBootstrap = false,
+    bootstrapRunning = false,
+    bootstrapResult = null,
+    bootstrapError = '',
+    onRunBootstrap,
+  }: {
+    reachabilityGuide: MachineModeGuide
+    setupGuide: MachineSetupGuide
+    detectionBadgeClass: string
+    detectionStatusLabel: string
+    detectedOSLabel: string
+    detectedArchLabel: string
+    detectionSummary: string
+    canRunBootstrap?: boolean
+    bootstrapRunning?: boolean
+    bootstrapResult?: MachineSSHBootstrapResult | null
+    bootstrapError?: string
+    onRunBootstrap?: () => void
+  } = $props()
+</script>
+
+<div
+  class="border-border bg-card rounded-lg border px-3.5 py-3"
+  transition:slide={{ duration: 220 }}
+>
+  <div class="flex items-center gap-2">
+    <span
+      class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
+    >
+      3
+    </span>
+    <p class="text-foreground text-sm font-medium">
+      {i18nStore.t('machines.machineEditorGuidance.progressive.step3.title')}
+    </p>
+  </div>
+  <div class="mt-2.5 flex flex-wrap items-center gap-2">
+    <Badge variant="outline" class="text-[10px]">{reachabilityGuide.label}</Badge>
+    <Badge variant="outline" class="text-[10px]">{setupGuide.runtimeLabel}</Badge>
+    <Badge variant="outline" class="text-[10px]">{setupGuide.helperLabel}</Badge>
+    <Badge variant="outline" class={`text-[10px] ${detectionBadgeClass}`}
+      >{detectionStatusLabel}</Badge
+    >
+    <Badge variant="secondary" class="text-[10px]">{detectedOSLabel}</Badge>
+    <Badge variant="secondary" class="text-[10px]">{detectedArchLabel}</Badge>
+  </div>
+  <p class="text-muted-foreground mt-2 text-xs leading-relaxed">{detectionSummary}</p>
+  <div class="mt-2 grid gap-x-6 gap-y-1 text-xs sm:grid-cols-2">
+    <div>
+      <span class="text-muted-foreground">
+        {i18nStore.t('machines.machineEditorGuidance.labels.required')}
+      </span>
+      <span class="text-foreground ml-1">{reachabilityGuide.requiredFields}</span>
+    </div>
+    <div>
+      <span class="text-muted-foreground">
+        {i18nStore.t('machines.machineEditorGuidance.labels.state')}
+      </span>
+      <span class="text-foreground ml-1">{setupGuide.stateSummary}</span>
+    </div>
+  </div>
+</div>
+
+<div transition:slide={{ duration: 260, delay: 80 }}>
+  <div class="mb-2 flex items-center gap-2">
+    <span
+      class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
+    >
+      4
+    </span>
+    <p class="text-foreground text-sm font-medium">
+      {i18nStore.t('machines.machineEditorGuidance.progressive.step4.title')}
+    </p>
+  </div>
+  <div class="grid gap-3 lg:grid-cols-2">
+    <div class="border-border bg-card rounded-lg border px-3.5 py-3">
+      <div class="space-y-1">
+        <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
+        <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.runtimeSummary}</p>
+      </div>
+      <div class="mt-3 space-y-1">
+        <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
+        <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.helperSummary}</p>
+      </div>
+    </div>
+
+    <div class="border-border bg-card rounded-lg border px-3.5 py-3">
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineEditorGuidance.heading.nextStep')}
+      </p>
+      <ul class="text-muted-foreground mt-2 space-y-1.5 text-xs leading-relaxed">
+        {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
+          <li>{step}</li>
+        {/each}
+      </ul>
+    </div>
+  </div>
+</div>
+
+{#if setupGuide.commands.length > 0 || canRunBootstrap}
+  <div transition:slide={{ duration: 300, delay: 160 }}>
+    <div class="mb-2 flex items-center gap-2">
+      <span
+        class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
+      >
+        5
+      </span>
+      <p class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineEditorGuidance.progressive.step5.title')}
+      </p>
+    </div>
+
+    {#if canRunBootstrap}
+      <div class="border-primary/30 bg-primary/5 mb-3 rounded-lg border px-3.5 py-3">
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            <p class="text-foreground text-sm font-medium">
+              {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.title')}
+            </p>
+            <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+              {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.description')}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            disabled={bootstrapRunning}
+            onclick={onRunBootstrap}
+            data-testid="machine-ssh-bootstrap-run"
+          >
+            {#if bootstrapRunning}
+              <Loader2 class="size-3.5 animate-spin" />
+              {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.running')}
+            {:else}
+              <Play class="size-3.5" />
+              {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.action')}
+            {/if}
+          </Button>
+        </div>
+        {#if bootstrapError}
+          <div
+            class="border-destructive/20 bg-destructive/5 text-destructive mt-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
+          >
+            {bootstrapError}
+          </div>
+        {/if}
+        {#if bootstrapResult}
+          <div class="border-primary/20 mt-3 space-y-1 border-t pt-3 text-[11px]">
+            <div class="flex flex-wrap gap-x-4 gap-y-1">
+              <span>
+                <span class="text-muted-foreground">
+                  {i18nStore.t(
+                    'machines.machineEditorGuidance.progressive.bootstrap.serviceManager',
+                  )}
+                </span>
+                <span class="text-foreground ml-1">{bootstrapResult.service_manager}</span>
+              </span>
+              <span>
+                <span class="text-muted-foreground">
+                  {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.serviceName')}
+                </span>
+                <span class="text-foreground ml-1">{bootstrapResult.service_name}</span>
+              </span>
+              <span>
+                <span class="text-muted-foreground">
+                  {i18nStore.t(
+                    'machines.machineEditorGuidance.progressive.bootstrap.serviceStatus',
+                  )}
+                </span>
+                <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
+              </span>
+            </div>
+            {#if bootstrapResult.connection_target}
+              <p class="text-muted-foreground">
+                <span>
+                  {i18nStore.t(
+                    'machines.machineEditorGuidance.progressive.bootstrap.connectionTarget',
+                  )}
+                </span>
+                <span class="text-foreground ml-1">{bootstrapResult.connection_target}</span>
+              </p>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    {#if setupGuide.commands.length > 0}
+      <MachineSetupCommandList commands={setupGuide.commands} className="grid gap-3" />
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/features/machines/components/machine-editor-guidance.svelte
+++ b/web/src/lib/features/machines/components/machine-editor-guidance.svelte
@@ -1,7 +1,19 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
-  import { Badge } from '$ui/badge'
+  import { ArrowLeftRight, ArrowRight, Check, KeyRound, Monitor, Radio } from '@lucide/svelte'
+  import { slide } from 'svelte/transition'
+  import type { Component } from 'svelte'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import { toastStore } from '$lib/stores/toast.svelte'
   import { cn } from '$lib/utils'
+  import type { TranslationKey } from '$lib/i18n'
+  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import { buildMachineSetupGuide } from '../machine-setup'
+  import type {
+    MachineDraft,
+    MachineItem,
+    MachineModeGuide,
+    MachineReachabilityMode,
+  } from '../types'
   import {
     detectedPlatformFromSnapshot,
     machineDetectedArchLabel,
@@ -10,35 +22,19 @@
     machineDetectionMessage,
     machineDetectionStatusLabel,
     machineModeGuide,
-    parseMachineSnapshot,
     machineReachabilityLabel,
     normalizeReachabilityMode,
+    parseMachineSnapshot,
   } from '../model'
-  import { buildMachineSetupGuide } from '../machine-setup'
-  import type { MachineDraft, MachineItem, MachineReachabilityMode } from '../types'
-  import {
-    Monitor,
-    ArrowLeftRight,
-    Radio,
-    Check,
-    ArrowRight,
-    KeyRound,
-    Loader2,
-    Play,
-  } from '@lucide/svelte'
-  import type { TranslationKey } from '$lib/i18n'
-  import { i18nStore } from '$lib/i18n/store.svelte'
-  import { slide } from 'svelte/transition'
-  import { Button } from '$ui/button'
-  import { toastStore } from '$lib/stores/toast.svelte'
-  import { runMachineSSHBootstrap, machineErrorMessage } from './machines-page-api'
-  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import { machineErrorMessage, runMachineSSHBootstrap } from './machines-page-api'
+  import MachineEditorGuidanceSetup from './machine-editor-guidance-setup.svelte'
 
   type WsStrategy = 'direct-open' | 'ssh-install-listener' | 'reverse'
   type WsOption = {
     strategy: WsStrategy
     mode: MachineReachabilityMode
-    icon: typeof Monitor
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    icon: Component<any>
     titleKey: TranslationKey
     descKey: TranslationKey
   }
@@ -78,19 +74,12 @@
   } = $props()
 
   const reachabilityMode = $derived(normalizeReachabilityMode(draft.reachabilityMode, draft.host))
-  const reachabilityGuide = $derived(machineModeGuide(reachabilityMode))
+  const reachabilityGuide = $derived<MachineModeGuide>(machineModeGuide(reachabilityMode))
 
-  // Progressive flow state. Starts null, synced from current reachability so
-  // existing machines land in the correct step without user interaction.
   type LocationAnswer = 'local' | 'remote' | null
   let locationAnswer = $state<LocationAnswer>(null)
   let wsStrategy = $state<WsStrategy | null>(null)
 
-  // Only pre-fill answers for an existing machine; for new machines let the
-  // user click through the guided flow from step 1. The 'direct-open' vs
-  // 'ssh-install-listener' distinction can't be inferred from reachability
-  // alone, so existing direct_connect machines default to 'direct-open' —
-  // the user can re-pick if they used the SSH-installed listener path.
   $effect(() => {
     if (!machine) return
     if (locationAnswer === null) {
@@ -123,6 +112,7 @@
     locationAnswer = null
     wsStrategy = null
   }
+
   const flowComplete = $derived(locationAnswer === 'local' || wsStrategy !== null)
   const detectionStatusLabel = $derived(machineDetectionStatusLabel(machine?.detection_status))
   const detectionBadgeClass = $derived(machineDetectionBadgeClass(machine?.detection_status))
@@ -137,12 +127,6 @@
   )
   const detectionSummary = $derived(machineDetectionMessage(machine, draft))
   const setupGuide = $derived(buildMachineSetupGuide({ machine, draft }))
-
-  const allCommands = $derived(setupGuide.commands)
-
-  // Map the user's chosen WS strategy onto the CLI topology flag so the
-  // in-process ssh-bootstrap handler picks the same service manifest the CLI
-  // would.
   const bootstrapTopology = $derived(
     wsStrategy === 'ssh-install-listener'
       ? 'remote-listener'
@@ -151,6 +135,7 @@
         : null,
   )
   const canRunBootstrap = $derived(Boolean(machine?.id && bootstrapTopology))
+
   let bootstrapRunning = $state(false)
   let bootstrapResult = $state<MachineSSHBootstrapResult | null>(null)
   let bootstrapError = $state('')
@@ -188,7 +173,6 @@
     </p>
   </div>
 
-  <!-- Step 1: where is the machine -->
   <div class="border-border bg-card rounded-lg border px-3.5 py-3">
     <div class="flex items-center gap-2">
       <span
@@ -215,9 +199,7 @@
         >
           <div class="flex items-center gap-2">
             <Icon class={cn('size-4', selected ? 'text-primary' : 'text-muted-foreground')} />
-            <span class="text-foreground text-sm font-medium">
-              {i18nStore.t(option.descKey)}
-            </span>
+            <span class="text-foreground text-sm font-medium">{i18nStore.t(option.descKey)}</span>
             {#if selected}
               <Check class="text-primary ml-auto size-3.5" />
             {/if}
@@ -232,7 +214,6 @@
     </div>
   </div>
 
-  <!-- Step 2: only shown for remote -->
   {#if locationAnswer === 'remote'}
     <div
       class="border-border bg-card rounded-lg border px-3.5 py-3"
@@ -299,192 +280,20 @@
     </div>
   {/if}
 
-  <!-- Step 3: topology summary, revealed once the flow is answered -->
   {#if flowComplete}
-    <div
-      class="border-border bg-card rounded-lg border px-3.5 py-3"
-      transition:slide={{ duration: 220 }}
-    >
-      <div class="flex items-center gap-2">
-        <span
-          class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
-        >
-          3
-        </span>
-        <p class="text-foreground text-sm font-medium">
-          {i18nStore.t('machines.machineEditorGuidance.progressive.step3.title')}
-        </p>
-      </div>
-      <div class="mt-2.5 flex flex-wrap items-center gap-2">
-        <Badge variant="outline" class="text-[10px]">{reachabilityGuide.label}</Badge>
-        <Badge variant="outline" class="text-[10px]">{setupGuide.runtimeLabel}</Badge>
-        <Badge variant="outline" class="text-[10px]">{setupGuide.helperLabel}</Badge>
-        <Badge variant="outline" class={cn('text-[10px]', detectionBadgeClass)}>
-          {detectionStatusLabel}
-        </Badge>
-        <Badge variant="secondary" class="text-[10px]">{detectedOSLabel}</Badge>
-        <Badge variant="secondary" class="text-[10px]">{detectedArchLabel}</Badge>
-      </div>
-      <p class="text-muted-foreground mt-2 text-xs leading-relaxed">{detectionSummary}</p>
-      <div class="mt-2 grid gap-x-6 gap-y-1 text-xs sm:grid-cols-2">
-        <div>
-          <span class="text-muted-foreground">
-            {i18nStore.t('machines.machineEditorGuidance.labels.required')}
-          </span>
-          <span class="text-foreground ml-1">{reachabilityGuide.requiredFields}</span>
-        </div>
-        <div>
-          <span class="text-muted-foreground">
-            {i18nStore.t('machines.machineEditorGuidance.labels.state')}
-          </span>
-          <span class="text-foreground ml-1">{setupGuide.stateSummary}</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Step 4: runtime + next steps -->
-    <div transition:slide={{ duration: 260, delay: 80 }}>
-      <div class="mb-2 flex items-center gap-2">
-        <span
-          class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
-        >
-          4
-        </span>
-        <p class="text-foreground text-sm font-medium">
-          {i18nStore.t('machines.machineEditorGuidance.progressive.step4.title')}
-        </p>
-      </div>
-      <div class="grid gap-3 lg:grid-cols-2">
-        <div class="border-border bg-card rounded-lg border px-3.5 py-3">
-          <div class="space-y-1">
-            <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
-            <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.runtimeSummary}</p>
-          </div>
-          <div class="mt-3 space-y-1">
-            <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
-            <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.helperSummary}</p>
-          </div>
-        </div>
-
-        <div class="border-border bg-card rounded-lg border px-3.5 py-3">
-          <p class="text-foreground text-sm font-medium">
-            {i18nStore.t('machines.machineEditorGuidance.heading.nextStep')}
-          </p>
-          <ul class="text-muted-foreground mt-2 space-y-1.5 text-xs leading-relaxed">
-            {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
-              <li>{step}</li>
-            {/each}
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <!-- Step 5: concrete commands + one-click bootstrap (if applicable) -->
-    {#if allCommands.length > 0 || canRunBootstrap}
-      <div transition:slide={{ duration: 300, delay: 160 }}>
-        <div class="mb-2 flex items-center gap-2">
-          <span
-            class="bg-primary/10 text-primary flex size-5 items-center justify-center rounded-full text-[10px] font-semibold"
-          >
-            5
-          </span>
-          <p class="text-foreground text-sm font-medium">
-            {i18nStore.t('machines.machineEditorGuidance.progressive.step5.title')}
-          </p>
-        </div>
-
-        {#if canRunBootstrap}
-          <div class="border-primary/30 bg-primary/5 mb-3 rounded-lg border px-3.5 py-3">
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0 flex-1">
-                <p class="text-foreground text-sm font-medium">
-                  {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.title')}
-                </p>
-                <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
-                  {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.description')}
-                </p>
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                disabled={bootstrapRunning}
-                onclick={handleRunBootstrap}
-                data-testid="machine-ssh-bootstrap-run"
-              >
-                {#if bootstrapRunning}
-                  <Loader2 class="size-3.5 animate-spin" />
-                  {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.running')}
-                {:else}
-                  <Play class="size-3.5" />
-                  {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.action')}
-                {/if}
-              </Button>
-            </div>
-            {#if bootstrapError}
-              <div
-                class="border-destructive/20 bg-destructive/5 text-destructive mt-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
-              >
-                {bootstrapError}
-              </div>
-            {/if}
-            {#if bootstrapResult}
-              <div class="border-primary/20 mt-3 space-y-1 border-t pt-3 text-[11px]">
-                <div class="flex flex-wrap gap-x-4 gap-y-1">
-                  <span>
-                    <span class="text-muted-foreground">
-                      {i18nStore.t(
-                        'machines.machineEditorGuidance.progressive.bootstrap.serviceManager',
-                      )}
-                    </span>
-                    <span class="text-foreground ml-1">{bootstrapResult.service_manager}</span>
-                  </span>
-                  <span>
-                    <span class="text-muted-foreground">
-                      {i18nStore.t(
-                        'machines.machineEditorGuidance.progressive.bootstrap.serviceName',
-                      )}
-                    </span>
-                    <span class="text-foreground ml-1">{bootstrapResult.service_name}</span>
-                  </span>
-                  <span>
-                    <span class="text-muted-foreground">
-                      {i18nStore.t(
-                        'machines.machineEditorGuidance.progressive.bootstrap.serviceStatus',
-                      )}
-                    </span>
-                    <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
-                  </span>
-                </div>
-                {#if bootstrapResult.connection_target}
-                  <p class="text-muted-foreground">
-                    <span>
-                      {i18nStore.t(
-                        'machines.machineEditorGuidance.progressive.bootstrap.connectionTarget',
-                      )}
-                    </span>
-                    <span class="text-foreground ml-1">{bootstrapResult.connection_target}</span>
-                  </p>
-                {/if}
-              </div>
-            {/if}
-          </div>
-        {/if}
-
-        {#if allCommands.length > 0}
-          <div class="grid gap-3">
-            {#each allCommands as command (command.title)}
-              <div class="border-border bg-card rounded-lg border px-3.5 py-3">
-                <p class="text-foreground text-sm font-medium">{command.title}</p>
-                <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
-                  {command.description}
-                </p>
-                <pre
-                  class="bg-muted/60 text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 text-xs whitespace-pre-wrap">{command.command}</pre>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    {/if}
+    <MachineEditorGuidanceSetup
+      {reachabilityGuide}
+      {setupGuide}
+      {detectionBadgeClass}
+      {detectionStatusLabel}
+      {detectedOSLabel}
+      {detectedArchLabel}
+      {detectionSummary}
+      {canRunBootstrap}
+      {bootstrapRunning}
+      {bootstrapResult}
+      {bootstrapError}
+      onRunBootstrap={handleRunBootstrap}
+    />
   {/if}
 </section>

--- a/web/src/lib/features/machines/components/machine-health-audit-panel.svelte
+++ b/web/src/lib/features/machines/components/machine-health-audit-panel.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { Badge } from '$ui/badge'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import { formatMachineRelativeTime } from '../machine-i18n'
+  import type { HealthAuditRow, TruthyState } from './machine-health-panel-view'
+
+  let {
+    auditRows,
+    checkedLabel,
+    badgeVariant,
+    badgeLabel,
+    truthyIcon,
+    truthyColorClass,
+    auditRowIcons,
+  }: {
+    auditRows: HealthAuditRow[]
+    checkedLabel: string
+    badgeVariant: 'default' | 'secondary' | 'outline' | 'destructive'
+    badgeLabel: string
+    truthyIcon: Record<TruthyState, typeof import('@lucide/svelte').CircleCheck>
+    truthyColorClass: Record<TruthyState, string>
+    auditRowIcons: {
+      git: typeof import('@lucide/svelte').GitBranch
+      'gh-cli': typeof import('@lucide/svelte').Terminal
+      network: typeof import('@lucide/svelte').Globe
+    }
+  } = $props()
+</script>
+
+<div class="border-border bg-card rounded-xl border">
+  <div
+    class="border-border flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+  >
+    <div class="flex items-center gap-2">
+      <h4 class="text-foreground text-sm font-semibold">
+        {i18nStore.t('machines.machineHealthPanel.heading.toolingAudit')}
+      </h4>
+      <Badge variant={badgeVariant}>{badgeLabel}</Badge>
+    </div>
+    <span class="text-muted-foreground text-xs">{checkedLabel}</span>
+  </div>
+  <div class="divide-border divide-y">
+    {#each auditRows as row (row.kind)}
+      {@const RowIcon = auditRowIcons[row.kind]}
+      <div class="flex items-start gap-3 px-4 py-3">
+        <div class="bg-muted mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md">
+          <RowIcon class="text-muted-foreground size-3.5" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="text-foreground text-sm font-medium">{row.label}</span>
+            {#if row.kind === 'git' || row.kind === 'gh-cli'}
+              {@const Icon = truthyIcon[row.installed]}
+              <div class={`flex items-center gap-1 ${truthyColorClass[row.installed]}`}>
+                <Icon class="size-3.5" />
+                <span class="text-xs font-medium">
+                  {row.installed === 'yes'
+                    ? i18nStore.t('machines.machineHealthPanel.status.installed')
+                    : row.installed === 'no'
+                      ? i18nStore.t('machines.machineHealthPanel.status.missing')
+                      : i18nStore.t('machines.machineHealthPanel.status.unknown')}
+                </span>
+              </div>
+              {#if row.kind === 'gh-cli'}
+                <Badge variant="outline" class="text-[10px]">
+                  {i18nStore.t('machines.machineHealthPanel.badge.observational')}
+                </Badge>
+              {/if}
+            {/if}
+          </div>
+          <div class="text-muted-foreground mt-1 text-xs">
+            {#if row.kind === 'git'}
+              {row.identity ?? i18nStore.t('machines.machineHealthPanel.hint.noGitIdentity')}
+            {:else if row.kind === 'gh-cli'}
+              {row.authStatus ?? i18nStore.t('machines.machineHealthPanel.hint.noAuthStatus')}
+            {:else if row.kind === 'network'}
+              <div class="mt-1 flex items-center gap-3">
+                {#each row.endpoints as endpoint (endpoint.name)}
+                  {@const EpIcon = truthyIcon[endpoint.reachable]}
+                  <div class="flex items-center gap-1">
+                    <EpIcon class={`size-3 ${truthyColorClass[endpoint.reachable]}`} />
+                    <span>{endpoint.name}</span>
+                  </div>
+                {/each}
+              </div>
+              {#if row.auditTimestamp}
+                <div class="mt-1 text-[11px]">
+                  {i18nStore.t('machines.machineHealthPanel.hint.capturedAt', {
+                    time: formatMachineRelativeTime(row.auditTimestamp),
+                  })}
+                </div>
+              {/if}
+            {/if}
+          </div>
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/web/src/lib/features/machines/components/machine-health-panel.svelte
+++ b/web/src/lib/features/machines/components/machine-health-panel.svelte
@@ -1,47 +1,35 @@
 <script lang="ts">
-  /* eslint-disable max-lines */
-  import {
-    CircleCheck,
-    CircleX,
-    CircleHelp,
-    GitBranch,
-    Terminal,
-    Globe,
-    ChevronDown,
-    ChevronUp,
-    Loader2,
-    Wrench,
-  } from '@lucide/svelte'
-  import { slide } from 'svelte/transition'
-  import { formatMachineRelativeTime } from '../machine-i18n'
+  import { CircleCheck, CircleHelp, CircleX, GitBranch, Globe, Terminal } from '@lucide/svelte'
   import { Badge } from '$ui/badge'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import { toastStore } from '$lib/stores/toast.svelte'
+  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import { buildMachineSetupGuide } from '../machine-setup'
   import type {
     MachineItem,
     MachineProbeResult,
     MachineReachabilityMode,
     MachineSnapshot,
   } from '../types'
-  import { buildMachineSetupGuide } from '../machine-setup'
-  import type { TruthyState } from './machine-health-panel-view'
   import {
     buildAuditRows,
     buildLevelCards,
     buildStatCards,
     checkedAtLabel,
+    levelState,
     runtimeLabel,
     stateBadgeVariant,
     stateLabel,
     toTruthyState,
-    levelState,
+    type TruthyState,
   } from './machine-health-panel-view'
   import MachineGpuTable from './machine-gpu-table.svelte'
+  import MachineHealthAuditPanel from './machine-health-audit-panel.svelte'
   import MachineHealthHeader from './machine-health-header.svelte'
+  import MachineHealthRuntimeTable from './machine-health-runtime-table.svelte'
+  import MachineHealthSetupPanel from './machine-health-setup-panel.svelte'
   import MachineProbeCard from './machine-probe-card.svelte'
-  import { i18nStore } from '$lib/i18n/store.svelte'
-  import { Button } from '$ui/button'
-  import { toastStore } from '$lib/stores/toast.svelte'
-  import { runMachineSSHBootstrap, machineErrorMessage } from './machines-page-api'
-  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import { machineErrorMessage, runMachineSSHBootstrap } from './machines-page-api'
 
   const truthyIcon: Record<TruthyState, typeof CircleCheck> = {
     yes: CircleCheck,
@@ -86,11 +74,6 @@
   const runtimeRows = $derived(snapshot?.agentEnvironment ?? [])
   const auditRows = $derived(snapshot ? buildAuditRows(snapshot) : [])
   const setupGuide = $derived(buildMachineSetupGuide({ machine, snapshot }))
-
-  // When the machine is healthy we don't want the wall of setup commands and
-  // topology prose in the user's face — that content is only useful as a
-  // recovery aid. Auto-expand on signs of trouble; otherwise keep it tucked
-  // behind a disclosure the user can open on demand.
   const hasTrouble = $derived(
     (snapshot?.monitorErrors?.length ?? 0) > 0 ||
       levelCards.some((card) => card.state === 'error') ||
@@ -98,6 +81,7 @@
         Boolean(machine?.daemon_status) &&
         machine?.daemon_status?.session_state !== 'connected'),
   )
+
   let setupExpanded = $state(false)
   $effect(() => {
     if (hasTrouble) setupExpanded = true
@@ -114,6 +98,7 @@
     return null
   })
   const showBootstrapRepair = $derived(Boolean(hasTrouble && repairBootstrapTopology))
+
   let bootstrapRunning = $state(false)
   let bootstrapResult = $state<MachineSSHBootstrapResult | null>(null)
   let bootstrapError = $state('')
@@ -154,156 +139,17 @@
       {i18nStore.t('machines.machineHealthPanel.emptyState')}
     </div>
   {:else}
-    <!-- Collapsed disclosure: one-line row showing topology + a toggle.
-         Auto-expands when hasTrouble is true so problems are never hidden. -->
-    <div class="border-border bg-card rounded-xl border">
-      <button
-        type="button"
-        class="hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-xl px-4 py-2.5 text-left transition-colors"
-        onclick={() => (setupExpanded = !setupExpanded)}
-        aria-expanded={setupExpanded}
-        data-testid="machine-health-setup-toggle"
-      >
-        <div class="flex min-w-0 items-center gap-2">
-          <span class="text-foreground text-sm font-medium">
-            {i18nStore.t('machines.machineHealthPanel.heading.setupGuidance')}
-          </span>
-          <Badge variant="outline" class="text-[10px]">{setupGuide.topologyLabel}</Badge>
-          {#if hasTrouble}
-            <Badge variant="destructive" class="text-[10px]">
-              {i18nStore.t('machines.machineHealthPanel.status.needsAttention')}
-            </Badge>
-          {/if}
-        </div>
-        {#if setupExpanded}
-          <ChevronUp class="text-muted-foreground size-4" />
-        {:else}
-          <ChevronDown class="text-muted-foreground size-4" />
-        {/if}
-      </button>
-
-      {#if setupExpanded}
-        <div class="border-border border-t" transition:slide={{ duration: 200 }}>
-          <div class="flex flex-wrap items-center justify-between gap-2 px-4 py-3">
-            <Badge variant="outline">{setupGuide.stateLabel}</Badge>
-            {#if showBootstrapRepair}
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={bootstrapRunning}
-                onclick={handleBootstrapRepair}
-                data-testid="machine-health-bootstrap-repair"
-              >
-                {#if bootstrapRunning}
-                  <Loader2 class="size-3.5 animate-spin" />
-                  {i18nStore.t('machines.machineHealthPanel.bootstrapRepair.running')}
-                {:else}
-                  <Wrench class="size-3.5" />
-                  {i18nStore.t('machines.machineHealthPanel.bootstrapRepair.action')}
-                {/if}
-              </Button>
-            {/if}
-          </div>
-          <p class="text-muted-foreground px-4 pb-3 text-xs leading-relaxed">
-            {hasTrouble && showBootstrapRepair
-              ? i18nStore.t('machines.machineHealthPanel.bootstrapRepair.description')
-              : setupGuide.topologySummary}
-          </p>
-
-          {#if bootstrapError}
-            <div
-              class="border-destructive/20 bg-destructive/5 text-destructive mx-4 mb-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
-            >
-              {bootstrapError}
-            </div>
-          {/if}
-
-          {#if bootstrapResult}
-            <div
-              class="border-primary/20 bg-primary/5 mx-4 mb-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
-            >
-              <div class="flex flex-wrap gap-x-4 gap-y-1">
-                <span>
-                  <span class="text-muted-foreground">
-                    {i18nStore.t(
-                      'machines.machineEditorGuidance.progressive.bootstrap.serviceManager',
-                    )}
-                  </span>
-                  <span class="text-foreground ml-1">{bootstrapResult.service_manager}</span>
-                </span>
-                <span>
-                  <span class="text-muted-foreground">
-                    {i18nStore.t(
-                      'machines.machineEditorGuidance.progressive.bootstrap.serviceName',
-                    )}
-                  </span>
-                  <span class="text-foreground ml-1">{bootstrapResult.service_name}</span>
-                </span>
-                <span>
-                  <span class="text-muted-foreground">
-                    {i18nStore.t(
-                      'machines.machineEditorGuidance.progressive.bootstrap.serviceStatus',
-                    )}
-                  </span>
-                  <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
-                </span>
-              </div>
-              {#if bootstrapResult.connection_target}
-                <p class="text-muted-foreground mt-1">
-                  <span>
-                    {i18nStore.t(
-                      'machines.machineEditorGuidance.progressive.bootstrap.connectionTarget',
-                    )}
-                  </span>
-                  <span class="text-foreground ml-1">{bootstrapResult.connection_target}</span>
-                </p>
-              {/if}
-            </div>
-          {/if}
-
-          <div class="grid gap-3 px-4 py-3 lg:grid-cols-3">
-            <div class="space-y-1.5">
-              <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
-              <p class="text-muted-foreground text-xs leading-relaxed">
-                {setupGuide.runtimeSummary}
-              </p>
-            </div>
-            <div class="space-y-1.5">
-              <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
-              <p class="text-muted-foreground text-xs leading-relaxed">
-                {setupGuide.helperSummary}
-              </p>
-            </div>
-            <div class="space-y-1.5">
-              <p class="text-foreground text-sm font-medium">
-                {i18nStore.t('machines.machineHealthPanel.heading.nextSteps')}
-              </p>
-              <ul class="text-muted-foreground space-y-1.5 text-xs leading-relaxed">
-                {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
-                  <li>{step}</li>
-                {/each}
-              </ul>
-            </div>
-          </div>
-
-          {#if setupGuide.commands.length > 0}
-            <div class="border-border grid gap-3 border-t px-4 py-4">
-              {#each setupGuide.commands as command (command.title)}
-                <div class="rounded-lg border border-dashed px-3.5 py-3">
-                  <p class="text-foreground text-sm font-medium">{command.title}</p>
-                  <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
-                    {command.description}
-                  </p>
-                  <pre
-                    class="bg-muted/60 text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 text-xs whitespace-pre-wrap">{command.command}</pre>
-                </div>
-              {/each}
-            </div>
-          {/if}
-        </div>
-      {/if}
-    </div>
+    <MachineHealthSetupPanel
+      {setupGuide}
+      {hasTrouble}
+      {setupExpanded}
+      {showBootstrapRepair}
+      {bootstrapRunning}
+      {bootstrapResult}
+      {bootstrapError}
+      onToggle={() => (setupExpanded = !setupExpanded)}
+      onBootstrapRepair={handleBootstrapRepair}
+    />
 
     <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
       {#each statCards as card (card.label)}
@@ -343,68 +189,16 @@
 
     {#if runtimeRows.length > 0}
       {@const l4State = levelState(snapshot.monitor.l4)}
-      <div class="border-border bg-card rounded-xl border">
-        <div
-          class="border-border flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-        >
-          <div class="flex items-center gap-2">
-            <h4 class="text-foreground text-sm font-semibold">
-              {i18nStore.t('machines.machineHealthPanel.heading.runtimeProviders')}
-            </h4>
-            <Badge variant={stateBadgeVariant(l4State)}>{stateLabel(l4State)}</Badge>
-          </div>
-          <span class="text-muted-foreground text-xs">
-            {checkedAtLabel(snapshot.agentEnvironmentCheckedAt)}
-          </span>
-        </div>
-        <div class="overflow-x-auto">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-border text-muted-foreground border-b text-left text-xs">
-                <th class="px-4 py-2 font-medium">
-                  {i18nStore.t('machines.machineHealthPanel.tableColumns.runtime')}
-                </th>
-                <th class="px-4 py-2 font-medium">
-                  {i18nStore.t('machines.machineHealthPanel.tableColumns.installed')}
-                </th>
-                <th class="px-4 py-2 font-medium">
-                  {i18nStore.t('machines.machineHealthPanel.tableColumns.auth')}
-                </th>
-                <th class="px-4 py-2 font-medium">
-                  {i18nStore.t('machines.machineHealthPanel.tableColumns.ready')}
-                </th>
-                <th class="px-4 py-2 font-medium">
-                  {i18nStore.t('machines.machineHealthPanel.tableColumns.version')}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each runtimeRows as runtime (runtime.name)}
-                {@const installedState = toTruthyState(runtime.installed)}
-                {@const readyState = toTruthyState(runtime.ready)}
-                {@const InstalledIcon = truthyIcon[installedState]}
-                {@const ReadyIcon = truthyIcon[readyState]}
-                <tr class="border-border/60 border-b last:border-0">
-                  <td class="px-4 py-3 font-medium">{runtimeLabel(runtime)}</td>
-                  <td class="px-4 py-3">
-                    <InstalledIcon class="size-4 {truthyColorClass[installedState]}" />
-                  </td>
-                  <td class="px-4 py-3 text-xs">
-                    {[runtime.authStatus, runtime.authMode].filter(Boolean).join(' · ') ||
-                      i18nStore.t('machines.machineHealthPanel.status.unknown')}
-                  </td>
-                  <td class="px-4 py-3">
-                    <ReadyIcon class="size-4 {truthyColorClass[readyState]}" />
-                  </td>
-                  <td class="text-muted-foreground px-4 py-3 text-xs">
-                    {runtime.version ?? i18nStore.t('machines.machineHealthPanel.status.unknown')}
-                  </td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <MachineHealthRuntimeTable
+        {runtimeRows}
+        checkedLabel={checkedAtLabel(snapshot.agentEnvironmentCheckedAt)}
+        badgeVariant={stateBadgeVariant(l4State)}
+        badgeLabel={stateLabel(l4State)}
+        {truthyIcon}
+        {truthyColorClass}
+        {runtimeLabel}
+        {toTruthyState}
+      />
     {/if}
 
     {#if snapshot.gpus.length > 0}
@@ -413,90 +207,15 @@
 
     {#if snapshot.fullAudit}
       {@const l5State = levelState(snapshot.monitor.l5)}
-      <div class="border-border bg-card rounded-xl border">
-        <div
-          class="border-border flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-        >
-          <div class="flex items-center gap-2">
-            <h4 class="text-foreground text-sm font-semibold">
-              {i18nStore.t('machines.machineHealthPanel.heading.toolingAudit')}
-            </h4>
-            <Badge variant={stateBadgeVariant(l5State)}>{stateLabel(l5State)}</Badge>
-          </div>
-          <span class="text-muted-foreground text-xs">
-            {checkedAtLabel(snapshot.fullAudit.checkedAt)}
-          </span>
-        </div>
-        <div class="divide-border divide-y">
-          {#each auditRows as row (row.kind)}
-            {@const RowIcon = auditRowIcons[row.kind]}
-            <div class="flex items-start gap-3 px-4 py-3">
-              <div
-                class="bg-muted mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md"
-              >
-                <RowIcon class="text-muted-foreground size-3.5" />
-              </div>
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-2">
-                  <span class="text-foreground text-sm font-medium">{row.label}</span>
-                  {#if row.kind === 'git'}
-                    {@const Icon = truthyIcon[row.installed]}
-                    <div class="flex items-center gap-1 {truthyColorClass[row.installed]}">
-                      <Icon class="size-3.5" />
-                      <span class="text-xs font-medium">
-                        {row.installed === 'yes'
-                          ? i18nStore.t('machines.machineHealthPanel.status.installed')
-                          : row.installed === 'no'
-                            ? i18nStore.t('machines.machineHealthPanel.status.missing')
-                            : i18nStore.t('machines.machineHealthPanel.status.unknown')}
-                      </span>
-                    </div>
-                  {:else if row.kind === 'gh-cli'}
-                    {@const Icon = truthyIcon[row.installed]}
-                    <div class="flex items-center gap-1 {truthyColorClass[row.installed]}">
-                      <Icon class="size-3.5" />
-                      <span class="text-xs font-medium">
-                        {row.installed === 'yes'
-                          ? i18nStore.t('machines.machineHealthPanel.status.installed')
-                          : row.installed === 'no'
-                            ? i18nStore.t('machines.machineHealthPanel.status.missing')
-                            : i18nStore.t('machines.machineHealthPanel.status.unknown')}
-                      </span>
-                    </div>
-                    <Badge variant="outline" class="text-[10px]">
-                      {i18nStore.t('machines.machineHealthPanel.badge.observational')}
-                    </Badge>
-                  {/if}
-                </div>
-                <div class="text-muted-foreground mt-1 text-xs">
-                  {#if row.kind === 'git'}
-                    {row.identity ?? i18nStore.t('machines.machineHealthPanel.hint.noGitIdentity')}
-                  {:else if row.kind === 'gh-cli'}
-                    {row.authStatus ?? i18nStore.t('machines.machineHealthPanel.hint.noAuthStatus')}
-                  {:else if row.kind === 'network'}
-                    <div class="mt-1 flex items-center gap-3">
-                      {#each row.endpoints as endpoint (endpoint.name)}
-                        {@const EpIcon = truthyIcon[endpoint.reachable]}
-                        <div class="flex items-center gap-1">
-                          <EpIcon class="size-3 {truthyColorClass[endpoint.reachable]}" />
-                          <span>{endpoint.name}</span>
-                        </div>
-                      {/each}
-                    </div>
-                    {#if row.auditTimestamp}
-                      <div class="mt-1 text-[11px]">
-                        {i18nStore.t('machines.machineHealthPanel.hint.capturedAt', {
-                          time: formatMachineRelativeTime(row.auditTimestamp),
-                        })}
-                      </div>
-                    {/if}
-                  {/if}
-                </div>
-              </div>
-            </div>
-          {/each}
-        </div>
-      </div>
+      <MachineHealthAuditPanel
+        {auditRows}
+        checkedLabel={checkedAtLabel(snapshot.fullAudit.checkedAt)}
+        badgeVariant={stateBadgeVariant(l5State)}
+        badgeLabel={stateLabel(l5State)}
+        {truthyIcon}
+        {truthyColorClass}
+        {auditRowIcons}
+      />
     {/if}
   {/if}
 

--- a/web/src/lib/features/machines/components/machine-health-runtime-table.svelte
+++ b/web/src/lib/features/machines/components/machine-health-runtime-table.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { Badge } from '$ui/badge'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import type { MachineCLIStatus } from '../types'
+  import type { TruthyState } from './machine-health-panel-view'
+
+  let {
+    runtimeRows,
+    checkedLabel,
+    badgeVariant,
+    badgeLabel,
+    truthyIcon,
+    truthyColorClass,
+    runtimeLabel,
+    toTruthyState,
+  }: {
+    runtimeRows: MachineCLIStatus[]
+    checkedLabel: string
+    badgeVariant: 'default' | 'secondary' | 'outline' | 'destructive'
+    badgeLabel: string
+    truthyIcon: Record<TruthyState, typeof import('@lucide/svelte').CircleCheck>
+    truthyColorClass: Record<TruthyState, string>
+    runtimeLabel: (runtime: MachineCLIStatus) => string
+    toTruthyState: (value: boolean | undefined) => TruthyState
+  } = $props()
+</script>
+
+<div class="border-border bg-card rounded-xl border">
+  <div
+    class="border-border flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+  >
+    <div class="flex items-center gap-2">
+      <h4 class="text-foreground text-sm font-semibold">
+        {i18nStore.t('machines.machineHealthPanel.heading.runtimeProviders')}
+      </h4>
+      <Badge variant={badgeVariant}>{badgeLabel}</Badge>
+    </div>
+    <span class="text-muted-foreground text-xs">{checkedLabel}</span>
+  </div>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-border text-muted-foreground border-b text-left text-xs">
+          <th class="px-4 py-2 font-medium">
+            {i18nStore.t('machines.machineHealthPanel.tableColumns.runtime')}
+          </th>
+          <th class="px-4 py-2 font-medium">
+            {i18nStore.t('machines.machineHealthPanel.tableColumns.installed')}
+          </th>
+          <th class="px-4 py-2 font-medium">
+            {i18nStore.t('machines.machineHealthPanel.tableColumns.auth')}
+          </th>
+          <th class="px-4 py-2 font-medium">
+            {i18nStore.t('machines.machineHealthPanel.tableColumns.ready')}
+          </th>
+          <th class="px-4 py-2 font-medium">
+            {i18nStore.t('machines.machineHealthPanel.tableColumns.version')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each runtimeRows as runtime (runtime.name)}
+          {@const installedState = toTruthyState(runtime.installed)}
+          {@const readyState = toTruthyState(runtime.ready)}
+          {@const InstalledIcon = truthyIcon[installedState]}
+          {@const ReadyIcon = truthyIcon[readyState]}
+          <tr class="border-border/60 border-b last:border-0">
+            <td class="px-4 py-3 font-medium">{runtimeLabel(runtime)}</td>
+            <td class="px-4 py-3">
+              <InstalledIcon class={`size-4 ${truthyColorClass[installedState]}`} />
+            </td>
+            <td class="px-4 py-3 text-xs">
+              {[runtime.authStatus, runtime.authMode].filter(Boolean).join(' · ') ||
+                i18nStore.t('machines.machineHealthPanel.status.unknown')}
+            </td>
+            <td class="px-4 py-3">
+              <ReadyIcon class={`size-4 ${truthyColorClass[readyState]}`} />
+            </td>
+            <td class="text-muted-foreground px-4 py-3 text-xs">
+              {runtime.version ?? i18nStore.t('machines.machineHealthPanel.status.unknown')}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/web/src/lib/features/machines/components/machine-health-setup-panel.svelte
+++ b/web/src/lib/features/machines/components/machine-health-setup-panel.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import { ChevronDown, ChevronUp, Loader2, Wrench } from '@lucide/svelte'
+  import { slide } from 'svelte/transition'
+  import { Badge } from '$ui/badge'
+  import { Button } from '$ui/button'
+  import { i18nStore } from '$lib/i18n/store.svelte'
+  import MachineSetupCommandList from './machine-setup-command-list.svelte'
+  import type { MachineSSHBootstrapResult } from '$lib/api/contracts'
+  import type { MachineSetupGuide } from '../machine-setup'
+
+  let {
+    setupGuide,
+    hasTrouble,
+    setupExpanded,
+    showBootstrapRepair,
+    bootstrapRunning = false,
+    bootstrapResult = null,
+    bootstrapError = '',
+    onToggle,
+    onBootstrapRepair,
+  }: {
+    setupGuide: MachineSetupGuide
+    hasTrouble: boolean
+    setupExpanded: boolean
+    showBootstrapRepair: boolean
+    bootstrapRunning?: boolean
+    bootstrapResult?: MachineSSHBootstrapResult | null
+    bootstrapError?: string
+    onToggle?: () => void
+    onBootstrapRepair?: () => void
+  } = $props()
+</script>
+
+<div class="border-border bg-card rounded-xl border">
+  <button
+    type="button"
+    class="hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-xl px-4 py-2.5 text-left transition-colors"
+    onclick={onToggle}
+    aria-expanded={setupExpanded}
+    data-testid="machine-health-setup-toggle"
+  >
+    <div class="flex min-w-0 items-center gap-2">
+      <span class="text-foreground text-sm font-medium">
+        {i18nStore.t('machines.machineHealthPanel.heading.setupGuidance')}
+      </span>
+      <Badge variant="outline" class="text-[10px]">{setupGuide.topologyLabel}</Badge>
+      {#if hasTrouble}
+        <Badge variant="destructive" class="text-[10px]">
+          {i18nStore.t('machines.machineHealthPanel.status.needsAttention')}
+        </Badge>
+      {/if}
+    </div>
+    {#if setupExpanded}
+      <ChevronUp class="text-muted-foreground size-4" />
+    {:else}
+      <ChevronDown class="text-muted-foreground size-4" />
+    {/if}
+  </button>
+
+  {#if setupExpanded}
+    <div class="border-border border-t" transition:slide={{ duration: 200 }}>
+      <div class="flex flex-wrap items-center justify-between gap-2 px-4 py-3">
+        <Badge variant="outline">{setupGuide.stateLabel}</Badge>
+        {#if showBootstrapRepair}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={bootstrapRunning}
+            onclick={onBootstrapRepair}
+            data-testid="machine-health-bootstrap-repair"
+          >
+            {#if bootstrapRunning}
+              <Loader2 class="size-3.5 animate-spin" />
+              {i18nStore.t('machines.machineHealthPanel.bootstrapRepair.running')}
+            {:else}
+              <Wrench class="size-3.5" />
+              {i18nStore.t('machines.machineHealthPanel.bootstrapRepair.action')}
+            {/if}
+          </Button>
+        {/if}
+      </div>
+      <p class="text-muted-foreground px-4 pb-3 text-xs leading-relaxed">
+        {hasTrouble && showBootstrapRepair
+          ? i18nStore.t('machines.machineHealthPanel.bootstrapRepair.description')
+          : setupGuide.topologySummary}
+      </p>
+
+      {#if bootstrapError}
+        <div
+          class="border-destructive/20 bg-destructive/5 text-destructive mx-4 mb-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
+        >
+          {bootstrapError}
+        </div>
+      {/if}
+
+      {#if bootstrapResult}
+        <div
+          class="border-primary/20 bg-primary/5 mx-4 mb-3 rounded-md border px-3 py-2 text-[11px] leading-relaxed"
+        >
+          <div class="flex flex-wrap gap-x-4 gap-y-1">
+            <span>
+              <span class="text-muted-foreground">
+                {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.serviceManager')}
+              </span>
+              <span class="text-foreground ml-1">{bootstrapResult.service_manager}</span>
+            </span>
+            <span>
+              <span class="text-muted-foreground">
+                {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.serviceName')}
+              </span>
+              <span class="text-foreground ml-1">{bootstrapResult.service_name}</span>
+            </span>
+            <span>
+              <span class="text-muted-foreground">
+                {i18nStore.t('machines.machineEditorGuidance.progressive.bootstrap.serviceStatus')}
+              </span>
+              <span class="text-foreground ml-1">{bootstrapResult.service_status}</span>
+            </span>
+          </div>
+          {#if bootstrapResult.connection_target}
+            <p class="text-muted-foreground mt-1">
+              <span>
+                {i18nStore.t(
+                  'machines.machineEditorGuidance.progressive.bootstrap.connectionTarget',
+                )}
+              </span>
+              <span class="text-foreground ml-1">{bootstrapResult.connection_target}</span>
+            </p>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="grid gap-3 px-4 py-3 lg:grid-cols-3">
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">{setupGuide.runtimeLabel}</p>
+          <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.runtimeSummary}</p>
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">{setupGuide.helperLabel}</p>
+          <p class="text-muted-foreground text-xs leading-relaxed">{setupGuide.helperSummary}</p>
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-foreground text-sm font-medium">
+            {i18nStore.t('machines.machineHealthPanel.heading.nextSteps')}
+          </p>
+          <ul class="text-muted-foreground space-y-1.5 text-xs leading-relaxed">
+            {#each setupGuide.nextSteps as step, index (`${step}-${index}`)}
+              <li>{step}</li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+
+      {#if setupGuide.commands.length > 0}
+        <div class="border-border border-t px-4 py-4">
+          <MachineSetupCommandList
+            commands={setupGuide.commands}
+            dashed={true}
+            className="grid gap-3"
+          />
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/features/machines/components/machine-setup-command-list.svelte
+++ b/web/src/lib/features/machines/components/machine-setup-command-list.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { MachineSetupCommand } from '../machine-setup'
+
+  let {
+    commands,
+    dashed = false,
+    className = '',
+  }: {
+    commands: MachineSetupCommand[]
+    dashed?: boolean
+    className?: string
+  } = $props()
+</script>
+
+<div class={className}>
+  {#each commands as command (command.title)}
+    <div
+      class={`rounded-lg px-3.5 py-3 ${dashed ? 'border border-dashed' : 'border-border bg-card border'}`}
+    >
+      <p class="text-foreground text-sm font-medium">{command.title}</p>
+      <p class="text-muted-foreground mt-1 text-xs leading-relaxed">{command.description}</p>
+      <pre
+        class="bg-muted/60 text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 text-xs whitespace-pre-wrap">{command.command}</pre>
+    </div>
+  {/each}
+</div>

--- a/web/src/lib/features/settings/components/security-settings.test-helpers.ts
+++ b/web/src/lib/features/settings/components/security-settings.test-helpers.ts
@@ -9,7 +9,12 @@ export function currentProject() {
     /* i18n-exempt */ description: '',
     /* i18n-exempt */ status: 'active',
     default_agent_provider_id: null,
-    project_ai_platform_access_allowed: ['project_updates.read', 'project_updates.write', 'projects.update', 'projects.add_repo'],
+    project_ai_platform_access_allowed: [
+      'project_updates.read',
+      'project_updates.write',
+      'projects.update',
+      'projects.add_repo',
+    ],
     accessible_machine_ids: [],
     max_concurrent_agents: 4,
   }
@@ -108,11 +113,21 @@ export function configuredSecurity() {
       environment_variable: 'OPENASE_AGENT_TOKEN',
       token_prefix: 'ase_agent_',
       default_scopes: ['tickets.create', 'tickets.list'],
-      supported_project_scopes: ['project_updates.read', 'project_updates.write', 'projects.update', 'projects.add_repo'],
+      supported_project_scopes: [
+        'project_updates.read',
+        'project_updates.write',
+        'projects.update',
+        'projects.add_repo',
+      ],
       supported_scope_groups: [
         {
           category: 'projects',
-          scopes: ['project_updates.read', 'project_updates.write', 'projects.update', 'projects.add_repo'],
+          scopes: [
+            'project_updates.read',
+            'project_updates.write',
+            'projects.update',
+            'projects.add_repo',
+          ],
         },
       ],
     },

--- a/web/src/lib/testing/e2e/mock-api/security.ts
+++ b/web/src/lib/testing/e2e/mock-api/security.ts
@@ -99,7 +99,12 @@ export function createDefaultSecuritySettings(projectId: string): MockSecuritySe
       environment_variable: 'OPENASE_AGENT_TOKEN',
       token_prefix: 'ase_agent_',
       default_scopes: ['tickets.create', 'tickets.list'],
-      supported_project_scopes: ['project_updates.read', 'project_updates.write', 'projects.update', 'projects.add_repo'],
+      supported_project_scopes: [
+        'project_updates.read',
+        'project_updates.write',
+        'projects.update',
+        'projects.add_repo',
+      ],
     },
     github: {
       effective: clone(organization),


### PR DESCRIPTION
## Summary
- remove the per-file machine component budget overrides from `web/file-budgets.config.mjs`
- split the machine create wizard, editor guidance, and health panel into focused subcomponents
- keep the existing machine setup/bootstrap UX and test ids while bringing the large Svelte files back under the standard hard limit

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/machines/components/machines-page.test.ts src/lib/features/machines/components/machine-health-panel-view.test.ts --reporter=dot`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run build`

## Ticket
- ASE-258
