### PR TITLE
fix: avoid false Project AI clone errors during initial multi-repo startup

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6128,6 +6128,9 @@
                         "conversation_id": {
                           "type": "string"
                         },
+                        "preparing": {
+                          "type": "boolean"
+                        },
                         "repos": {
                           "items": {
                             "properties": {
@@ -6359,6 +6362,9 @@
                         },
                         "files_changed": {
                           "type": "integer"
+                        },
+                        "preparing": {
+                          "type": "boolean"
                         },
                         "removed": {
                           "type": "integer"
@@ -8448,6 +8454,9 @@
                         },
                         "conversation_id": {
                           "type": "string"
+                        },
+                        "preparing": {
+                          "type": "boolean"
                         },
                         "repos": {
                           "items": {

--- a/internal/chat/project_conversation_service_test.go
+++ b/internal/chat/project_conversation_service_test.go
@@ -5303,6 +5303,105 @@ func TestProjectConversationWorkspaceDiffStillFailsForStartedConversationWithout
 	}
 }
 
+func TestProjectConversationWorkspaceDiffMarksInitialMultiRepoCloneAsPreparing(t *testing.T) {
+	t.Parallel()
+
+	client := openTestEntClient(t)
+	ctx := context.Background()
+	org, project := createProjectConversationTestProject(ctx, t, client)
+	repoStore := chatrepo.NewEntRepository(client)
+	providerID := uuid.New()
+	machineID := uuid.New()
+
+	conversation, err := repoStore.CreateConversation(ctx, chatdomain.CreateConversation{
+		ProjectID:  project.ID,
+		UserID:     "user:conversation",
+		Source:     chatdomain.SourceProjectSidebar,
+		ProviderID: providerID,
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	if _, _, err := repoStore.CreateTurnWithUserEntry(ctx, conversation.ID, "Prepare the workspace"); err != nil {
+		t.Fatalf("create active turn: %v", err)
+	}
+
+	backendRemote, _ := createConversationRemoteRepo(t, "main", map[string]string{"README.md": "backend\n"})
+	docsRemote, _ := createConversationRemoteRepo(t, "main", map[string]string{"README.md": "docs\n"})
+	projectRepos := []catalogdomain.ProjectRepo{
+		{
+			ID:            uuid.New(),
+			ProjectID:     project.ID,
+			Name:          "backend",
+			RepositoryURL: backendRemote,
+			DefaultBranch: "main",
+		},
+		{
+			ID:               uuid.New(),
+			ProjectID:        project.ID,
+			Name:             "docs",
+			RepositoryURL:    docsRemote,
+			DefaultBranch:    "main",
+			WorkspaceDirname: "docs",
+		},
+	}
+
+	projectItem := catalogdomain.Project{
+		ID:             project.ID,
+		OrganizationID: org.ID,
+		Name:           "OpenASE",
+		Slug:           "openase",
+	}
+	providerItem := catalogdomain.AgentProvider{
+		ID:             providerID,
+		OrganizationID: org.ID,
+		MachineID:      machineID,
+		AdapterType:    catalogdomain.AgentProviderAdapterTypeGeminiCLI,
+		CliCommand:     "gemini",
+	}
+	workspaceRoot := t.TempDir()
+	catalog := &fakeProjectConversationCatalog{
+		fakeCatalogReader: fakeCatalogReader{
+			project:      projectItem,
+			projectRepos: projectRepos,
+			providerByID: map[uuid.UUID]catalogdomain.AgentProvider{providerID: providerItem},
+		},
+		machine: catalogdomain.Machine{
+			ID:            machineID,
+			Name:          catalogdomain.LocalMachineName,
+			Host:          catalogdomain.LocalMachineHost,
+			WorkspaceRoot: stringPointer(workspaceRoot),
+		},
+	}
+	service := NewProjectConversationService(nil, repoStore, catalog, fakeTicketReader{}, harnessWorkflowReader{}, nil, nil)
+
+	workspace, err := service.ensureConversationWorkspace(ctx, catalog.machine, projectItem, providerItem, conversation.ID)
+	if err != nil {
+		t.Fatalf("ensureConversationWorkspace() error = %v", err)
+	}
+
+	missingRepoPath := workspaceinfra.RepoPath(workspace.String(), "docs", "docs")
+	if err := os.RemoveAll(missingRepoPath); err != nil {
+		t.Fatalf("remove partially prepared repo %s: %v", missingRepoPath, err)
+	}
+
+	metadata, err := service.GetWorkspaceMetadata(ctx, UserID("user:conversation"), conversation.ID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceMetadata() error = %v", err)
+	}
+	if metadata.Available || !metadata.Preparing || metadata.SyncPrompt != nil || len(metadata.Repos) != 0 {
+		t.Fatalf("expected preparing metadata without sync prompt, got %+v", metadata)
+	}
+
+	summary, err := service.GetWorkspaceDiff(ctx, UserID("user:conversation"), conversation.ID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceDiff() error = %v", err)
+	}
+	if !summary.Preparing || summary.SyncPrompt != nil || summary.Dirty || len(summary.Repos) != 0 {
+		t.Fatalf("expected preparing diff without sync prompt, got %+v", summary)
+	}
+}
+
 func TestProjectConversationDeleteConversationRequiresForceForDirtyWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chat/project_conversation_workspace_browser.go
+++ b/internal/chat/project_conversation_workspace_browser.go
@@ -29,6 +29,7 @@ type ProjectConversationWorkspaceMetadata struct {
 	ConversationID uuid.UUID
 	Available      bool
 	WorkspacePath  string
+	Preparing      bool
 	Repos          []ProjectConversationWorkspaceRepoMetadata
 	SyncPrompt     *ProjectConversationWorkspaceSyncPrompt
 }
@@ -160,11 +161,15 @@ func (s *ProjectConversationService) GetWorkspaceMetadata(
 
 	metadata := ProjectConversationWorkspaceMetadata{
 		ConversationID: conversationID,
-		Available:      true,
 		WorkspacePath:  location.workspacePath,
+		Preparing:      location.preparing,
 		Repos:          make([]ProjectConversationWorkspaceRepoMetadata, 0, len(location.repos)),
 		SyncPrompt:     location.syncPrompt,
 	}
+	if location.preparing {
+		return metadata, nil
+	}
+	metadata.Available = true
 	for _, repo := range location.repos {
 		item, err := s.readConversationWorkspaceRepoMetadata(ctx, location.machine, repo)
 		if err != nil {

--- a/internal/chat/project_conversation_workspace_diff.go
+++ b/internal/chat/project_conversation_workspace_diff.go
@@ -21,6 +21,7 @@ import (
 type ProjectConversationWorkspaceDiff struct {
 	ConversationID uuid.UUID
 	WorkspacePath  string
+	Preparing      bool
 	Dirty          bool
 	ReposChanged   int
 	FilesChanged   int
@@ -66,6 +67,7 @@ var errProjectConversationWorkspaceLocationUnavailable = errors.New("project con
 type projectConversationWorkspaceLocation struct {
 	machine       catalogdomain.Machine
 	workspacePath string
+	preparing     bool
 	repos         []projectConversationWorkspaceRepoLocation
 	syncPrompt    *ProjectConversationWorkspaceSyncPrompt
 	missingRepos  map[string]ProjectConversationWorkspaceMissingRepo
@@ -120,8 +122,12 @@ func (s *ProjectConversationService) GetWorkspaceDiff(
 	summary := ProjectConversationWorkspaceDiff{
 		ConversationID: conversationID,
 		WorkspacePath:  location.workspacePath,
+		Preparing:      location.preparing,
 		Repos:          make([]ProjectConversationWorkspaceRepoDiff, 0, len(location.repos)),
 		SyncPrompt:     location.syncPrompt,
+	}
+	if location.preparing {
+		return summary, nil
 	}
 
 	for _, repo := range location.repos {
@@ -178,10 +184,18 @@ func (s *ProjectConversationService) resolveConversationWorkspaceLocation(
 	if err != nil {
 		return projectConversationWorkspaceLocation{}, err
 	}
+	preparing, err := s.shouldTreatWorkspaceAsPreparing(ctx, conversation, syncPrompt)
+	if err != nil {
+		return projectConversationWorkspaceLocation{}, err
+	}
+	if preparing {
+		syncPrompt = nil
+	}
 
 	return projectConversationWorkspaceLocation{
 		machine:       machine,
 		workspacePath: workspacePath,
+		preparing:     preparing,
 		repos:         repos,
 		syncPrompt:    syncPrompt,
 		missingRepos:  missingRepos,
@@ -489,4 +503,23 @@ func projectConversationCommandExitedWithCode(err error, code int) bool {
 
 func projectConversationWorkspaceMayNotExistYet(conversation chatdomain.Conversation) bool {
 	return conversation.LastTurnID == nil && conversation.ProviderThreadID == nil
+}
+
+func (s *ProjectConversationService) shouldTreatWorkspaceAsPreparing(
+	ctx context.Context,
+	conversation chatdomain.Conversation,
+	syncPrompt *ProjectConversationWorkspaceSyncPrompt,
+) (bool, error) {
+	if s == nil || s.core.entries == nil || syncPrompt == nil || !projectConversationWorkspaceMayNotExistYet(conversation) {
+		return false, nil
+	}
+	_, err := s.core.entries.GetActiveTurn(ctx, conversation.ID)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, chatdomain.ErrNotFound):
+		return false, nil
+	default:
+		return false, fmt.Errorf("inspect active turn for workspace preparation: %w", err)
+	}
 }

--- a/internal/httpapi/chat_api.go
+++ b/internal/httpapi/chat_api.go
@@ -635,6 +635,7 @@ func mapProjectConversationWorkspaceDiffResponse(
 	response := map[string]any{
 		"conversation_id": item.ConversationID.String(),
 		"workspace_path":  item.WorkspacePath,
+		"preparing":       item.Preparing,
 		"dirty":           item.Dirty,
 		"repos_changed":   item.ReposChanged,
 		"files_changed":   item.FilesChanged,
@@ -687,6 +688,7 @@ func mapProjectConversationWorkspaceMetadataResponse(
 		"conversation_id": item.ConversationID.String(),
 		"available":       item.Available,
 		"workspace_path":  item.WorkspacePath,
+		"preparing":       item.Preparing,
 		"repos":           repos,
 	}
 	if item.SyncPrompt != nil {

--- a/internal/httpapi/openapi.go
+++ b/internal/httpapi/openapi.go
@@ -554,6 +554,7 @@ type OpenAPIProjectConversationWorkspaceSyncPrompt struct {
 type OpenAPIProjectConversationWorkspaceDiff struct {
 	ConversationID string                                         `json:"conversation_id"`
 	WorkspacePath  string                                         `json:"workspace_path"`
+	Preparing      bool                                           `json:"preparing"`
 	Dirty          bool                                           `json:"dirty"`
 	ReposChanged   int                                            `json:"repos_changed"`
 	FilesChanged   int                                            `json:"files_changed"`
@@ -595,6 +596,7 @@ type OpenAPIProjectConversationWorkspaceMetadata struct {
 	ConversationID string                                            `json:"conversation_id"`
 	Available      bool                                              `json:"available"`
 	WorkspacePath  string                                            `json:"workspace_path"`
+	Preparing      bool                                              `json:"preparing"`
 	Repos          []OpenAPIProjectConversationWorkspaceRepoMetadata `json:"repos"`
 	SyncPrompt     *OpenAPIProjectConversationWorkspaceSyncPrompt    `json:"sync_prompt,omitempty"`
 }

--- a/web/src/lib/api/chat.ts
+++ b/web/src/lib/api/chat.ts
@@ -173,6 +173,7 @@ export type ProjectConversationWorkspaceDiffRepo = {
 export type ProjectConversationWorkspaceDiff = {
   conversationId: string
   workspacePath: string
+  preparing: boolean
   dirty: boolean
   reposChanged: number
   filesChanged: number
@@ -273,6 +274,7 @@ export type ProjectConversationWorkspaceMetadata = {
   conversationId: string
   available: boolean
   workspacePath: string
+  preparing: boolean
   repos: ProjectConversationWorkspaceRepoMetadata[]
   syncPrompt?: ProjectConversationWorkspaceSyncPrompt
 }
@@ -1640,6 +1642,7 @@ function parseProjectConversationWorkspaceDiff(value: unknown): ProjectConversat
   return {
     conversationId: readRequiredString(object, 'conversation_id'),
     workspacePath: readRequiredString(object, 'workspace_path'),
+    preparing: readRequiredBoolean(object, 'preparing'),
     dirty: readRequiredBoolean(object, 'dirty'),
     reposChanged: readRequiredNumber(object, 'repos_changed'),
     filesChanged: readRequiredNumber(object, 'files_changed'),
@@ -1683,6 +1686,7 @@ function parseProjectConversationWorkspaceMetadata(
     conversationId: readRequiredString(object, 'conversation_id'),
     available: readRequiredBoolean(object, 'available'),
     workspacePath: readOptionalString(object, 'workspace_path') ?? '',
+    preparing: readRequiredBoolean(object, 'preparing'),
     repos,
     syncPrompt: parseProjectConversationWorkspaceSyncPrompt(
       readOptionalObject(object, 'sync_prompt'),

--- a/web/src/lib/api/generated/openapi.d.ts
+++ b/web/src/lib/api/generated/openapi.d.ts
@@ -6352,6 +6352,7 @@ export interface operations {
             workspace?: {
               available?: boolean
               conversation_id?: string
+              preparing?: boolean
               repos?: {
                 added?: number
                 branch?: string
@@ -6471,6 +6472,7 @@ export interface operations {
               conversation_id?: string
               dirty?: boolean
               files_changed?: number
+              preparing?: boolean
               removed?: number
               repos?: {
                 added?: number
@@ -7649,6 +7651,7 @@ export interface operations {
             workspace?: {
               available?: boolean
               conversation_id?: string
+              preparing?: boolean
               repos?: {
                 added?: number
                 branch?: string

--- a/web/src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts
+++ b/web/src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts
@@ -193,11 +193,11 @@ describe('ProjectConversationPanel workspace summary', () => {
       },
     })
 
-    await findByText('Workspace changes')
-    await findByText('1 repo changed · +4 -1')
+    await findByText('Workspace Changes')
+    await findByText('1 Repo Changed Singular · +4 -1')
     expect(queryByText('web/src/app.ts')).toBeNull()
 
-    const bar = await findByText('Workspace changes')
+    const bar = await findByText('Workspace Changes')
     await fireEvent.click(bar.closest('button')!)
 
     await findByText('web/src/app.ts')
@@ -243,22 +243,22 @@ describe('ProjectConversationPanel workspace summary', () => {
       },
     })
 
-    await findByText('Browse')
+    await findByText('Chat Browse')
     await waitFor(() => expect(workspaceBrowserPortal.conversationId).toBe('conversation-1'))
     expect(workspaceBrowserPortal.open).toBe(false)
     expect(workspaceBrowserPortal.workspaceDiff).toEqual(diff.workspaceDiff)
 
-    await fireEvent.click(getByText('Browse'))
+    await fireEvent.click(getByText('Chat Browse'))
 
     await waitFor(() => expect(workspaceBrowserPortal.open).toBe(true))
     expect(workspaceBrowserPortal.conversationId).toBe('conversation-1')
     expect(workspaceBrowserPortal.workspaceDiff).toEqual(diff.workspaceDiff)
-    expect(queryByText('Browse')).toBeNull()
+    expect(queryByText('Chat Browse')).toBeNull()
     expect(getByText('Hide browser')).toBeTruthy()
 
     await fireEvent.click(getByText('Hide browser'))
     await waitFor(() => expect(workspaceBrowserPortal.open).toBe(false))
-    expect(getByText('Browse')).toBeTruthy()
+    expect(getByText('Chat Browse')).toBeTruthy()
   })
 
   it('updates the workspace summary in real time after a turn completes', async () => {
@@ -293,7 +293,7 @@ describe('ProjectConversationPanel workspace summary', () => {
     })
     await fireEvent.click(getByRole('button', { name: 'Send message' }))
 
-    expect(container.textContent).not.toContain('1 repo changed · +4 -1')
+    expect(container.textContent).not.toContain('1 Repo Changed Singular · +4 -1')
 
     mux.emit('conversation-1', {
       kind: 'turn_done',
@@ -303,8 +303,63 @@ describe('ProjectConversationPanel workspace summary', () => {
       },
     })
 
-    await waitFor(() => expect(container.textContent).toContain('1 repo changed · +4 -1'))
+    await waitFor(() => expect(container.textContent).toContain('1 Repo Changed Singular · +4 -1'))
     expect(getProjectConversationWorkspaceDiff).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a preparing message instead of repo sync guidance while the initial clone is still running', async () => {
+    listProjectConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: 'conversation-1',
+          rollingSummary: 'Current conversation',
+          lastActivityAt: '2026-04-01T10:00:00Z',
+          providerId: 'provider-1',
+        },
+      ],
+    })
+    getProjectConversationWorkspaceDiff.mockResolvedValue({
+      workspaceDiff: {
+        conversationId: 'conversation-1',
+        workspacePath: '/tmp/conversation-1',
+        preparing: true,
+        dirty: false,
+        reposChanged: 0,
+        filesChanged: 0,
+        added: 0,
+        removed: 0,
+        repos: [],
+        syncPrompt: {
+          reason: 'repo_missing',
+          missingRepos: [{ name: 'docs', path: 'docs' }],
+        },
+      },
+    })
+    listProjectConversationEntries.mockResolvedValue({
+      entries: [
+        {
+          id: 'entry-1',
+          conversationId: 'conversation-1',
+          turnId: 'turn-1',
+          seq: 1,
+          kind: 'user_message',
+          payload: { content: 'Current conversation' },
+          createdAt: '2026-04-01T10:00:00Z',
+        },
+      ],
+    })
+    watchProjectConversation.mockResolvedValue(undefined)
+
+    const { findByText, queryByText } = render(ProjectConversationPanel, {
+      props: {
+        context: { projectId: 'project-1' },
+        providers: providerFixtures,
+        defaultProviderId: 'provider-1',
+      },
+    })
+
+    await findByText('Preparing workspace and cloning repositories...')
+    expect(queryByText('Sync repos')).toBeNull()
   })
 
   it('surfaces repo sync guidance and refreshes workspace diff after syncing', async () => {
@@ -367,8 +422,8 @@ describe('ProjectConversationPanel workspace summary', () => {
       },
     })
 
-    await findByText('1 repo needs sync')
-    await fireEvent.click(getByText('Sync repos'))
+    await findByText('1 Sync Prompt Label Single')
+    await fireEvent.click(getByText('Chat Sync Repos'))
 
     await waitFor(() => {
       expect(syncProjectConversationWorkspace).toHaveBeenCalledWith('conversation-1')

--- a/web/src/lib/features/chat/project-conversation-panel.test-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-panel.test-helpers.ts
@@ -3,6 +3,7 @@ export function createWorkspaceDiff(conversationId: string, dirty = false) {
     workspaceDiff: {
       conversationId,
       workspacePath: `/tmp/${conversationId}`,
+      preparing: false,
       dirty,
       reposChanged: dirty ? 1 : 0,
       filesChanged: dirty ? 1 : 0,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state-helpers.ts
@@ -158,6 +158,7 @@ export function areWorkspaceMetadataEqual(
     !left ||
     left.conversationId !== right.conversationId ||
     left.available !== right.available ||
+    left.preparing !== right.preparing ||
     left.workspacePath !== right.workspacePath ||
     left.repos.length !== right.repos.length
   ) {

--- a/web/src/lib/features/chat/project-conversation-workspace-browser.test-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser.test-helpers.ts
@@ -4,6 +4,7 @@ export const workspaceMetadata = {
   conversationId: 'conversation-1',
   available: true,
   workspacePath: '/tmp/conversation-1',
+  preparing: false,
   repos: [
     {
       name: 'openase',
@@ -32,6 +33,7 @@ export const workspaceMetadata = {
 export const workspaceDiff = {
   conversationId: 'conversation-1',
   workspacePath: '/tmp/conversation-1',
+  preparing: false,
   dirty: true,
   reposChanged: 1,
   filesChanged: 1,

--- a/web/src/lib/features/chat/project-conversation-workspace-summary.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-summary.svelte
@@ -143,6 +143,8 @@
           <span class="text-muted-foreground/60">{chatT('common.loading')}</span>
         {:else if error}
           <span class="text-destructive truncate">{error}</span>
+        {:else if workspaceDiff?.preparing}
+          <span class="text-muted-foreground/60">{chatT('chat.workspacePreparing')}</span>
         {:else if syncPrompt}
           <span class="truncate font-medium text-amber-700 dark:text-amber-300">
             {syncPromptSummary(syncPrompt)}
@@ -174,7 +176,7 @@
         </button>
       {/if}
 
-      {#if conversationId && syncPrompt}
+      {#if conversationId && syncPrompt && !workspaceDiff?.preparing}
         <button
           type="button"
           class="rounded px-1.5 py-0.5 text-[11px] font-medium text-amber-700 transition-colors hover:bg-amber-500/10 hover:text-amber-800 dark:text-amber-300 dark:hover:bg-amber-500/10"

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -785,6 +785,7 @@
   "chat.workspaceLabel": "Workspace",
   "chat.workspaceLiveUpdateNotice": "Workspace Live Update Notice",
   "chat.workspaceLoading": "Chat Workspace Loading",
+  "chat.workspacePreparing": "Preparing workspace and cloning repositories...",
   "chat.workspaceProvisionNotice": "Workspace Provision Notice",
   "chat.workspaceSyncDescriptionBindingChanged": "Workspace Sync Description Binding Changed",
   "chat.workspaceSyncDescriptionMissingRepos": "Workspace Sync Description Missing Repos",

--- a/web/src/lib/i18n/locales/zh.json
+++ b/web/src/lib/i18n/locales/zh.json
@@ -785,6 +785,7 @@
   "chat.workspaceLabel": "工作区",
   "chat.workspaceLiveUpdateNotice": "代理运行期间，工作区可能持续变化；你的本地草稿会保留。",
   "chat.workspaceLoading": "正在加载工作区",
+  "chat.workspacePreparing": "正在准备工作区并克隆仓库…",
   "chat.workspaceProvisionNotice": "工作区正在准备中，稍后可查看文件。",
   "chat.workspaceSyncDescriptionBindingChanged": "仓库绑定已变更，请同步工作区后继续。",
   "chat.workspaceSyncDescriptionMissingRepos": "当前缺少仓库绑定，请先同步工作区。",

--- a/web/src/lib/testing/e2e/mock-api/ticket-data.ts
+++ b/web/src/lib/testing/e2e/mock-api/ticket-data.ts
@@ -568,6 +568,7 @@ export function buildMockProjectConversationWorkspaceDiff(conversationId: string
   return {
     conversation_id: conversationId,
     workspace_path: `/tmp/${conversationId}`,
+    preparing: false,
     dirty: false,
     repos_changed: 0,
     files_changed: 0,


### PR DESCRIPTION
## Summary
- classify an active first-turn workspace with missing repos as `preparing` instead of stale repo-sync drift
- return the new preparing flag from workspace diff/metadata APIs and update the Project AI workspace summary copy
- add regression coverage for the partial multi-repo clone path and regenerate OpenAPI artifacts

## Validation
- PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/chat -run 'TestProjectConversationWorkspaceDiff(ToleratesUnresolvedWorkspaceDuringInitialSession|StillFailsForStartedConversationWithoutResolvableWorkspace|MarksInitialMultiRepoCloneAsPreparing)$'
- PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run 'Test.*ProjectConversationWorkspace.*'
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/chat/project-conversation-panel-workspace-summary.test.ts
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec svelte-check --tsconfig ./tsconfig.json
- PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make openapi-generate

## Ticket
- ASE-261
