### PR TITLE
ASE-287: clean up frontend guardrail bypasses

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -100,7 +100,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `lib/components/ui/**/*.svelte`     | 150        | 250                  |
 | single function                     | 40 target  | 60 warning threshold |
 
-There are no per-file budget waivers. If a recurring file shape needs a different limit, promote it into a named budget category for that feature family or UI layer instead of growing an allowlist.
+There are no per-file budget waivers. Budgets live in one shared category definition that drives both `lint:structure` and the mirrored ESLint `max-lines` rules, so any recurring exception should be promoted into a named category instead of growing an allowlist.
 
 ## Quality Gates
 
@@ -119,7 +119,7 @@ pnpm run ci
 - `pnpm run lint:i18n`: fails on newly introduced hardcoded user-visible strings that do not go through the shared i18n layer.
 - `pnpm run lint:mobile`: validates that every project route declares a mobile support policy and that responsive routes wire into the mobile regression templates.
 - `pnpm run lint:structure`: custom file budget enforcement with first-class categories for routes, feature tests, testing support modules, state modules, and UI layers.
-- `pnpm run lint:deps`: dependency boundary enforcement for `ui -> layout -> features -> routes`.
+- `pnpm run lint:deps`: dependency boundary enforcement for `ui -> layout -> features -> routes` with no waiver path.
 - `pnpm run check`: `svelte-check` type validation.
 - `pnpm run ci`: unified local and CI entrypoint for the frontend gate.
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -5,11 +5,21 @@ import sonarjs from 'eslint-plugin-sonarjs'
 import svelte from 'eslint-plugin-svelte'
 import globals from 'globals'
 import ts from 'typescript-eslint'
-import { fileBudgetLimits } from './file-budgets.config.mjs'
+import { eslintFileBudgetOverrides } from './file-budgets.config.mjs'
 import svelteConfig from './svelte.config.js'
 
 function maxLinesRule(max) {
   return ['error', { max, skipBlankLines: true, skipComments: true }]
+}
+
+function budgetOverrideToFlatConfig({ files, ignores, hardLimit }) {
+  return {
+    files,
+    ...(ignores.length > 0 ? { ignores } : {}),
+    rules: {
+      'max-lines': maxLinesRule(hardLimit),
+    },
+  }
 }
 
 export default defineConfig(
@@ -75,61 +85,7 @@ export default defineConfig(
       'svelte/require-each-key': 'off',
     },
   },
-  {
-    files: ['src/routes/**/+page.svelte'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.routePage.hard),
-    },
-  },
-  {
-    files: ['src/routes/**/+layout.svelte'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.routeLayout.hard),
-    },
-  },
-  {
-    files: ['src/lib/features/**/*.svelte'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.featureComponent.hard),
-    },
-  },
-  {
-    files: ['src/lib/features/**/*.test.{js,ts,mjs,cjs}'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.featureTest.hard),
-    },
-  },
-  {
-    files: ['src/lib/features/**/*.svelte.{ts,js}'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.featureStateModule.hard),
-    },
-  },
-  {
-    files: ['src/lib/features/**/*.{js,ts,mjs,cjs}'],
-    ignores: ['src/lib/features/**/*.test.{js,ts,mjs,cjs}', 'src/lib/features/**/*.svelte.{ts,js}'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.featureModule.hard),
-    },
-  },
-  {
-    files: ['src/lib/testing/**/*.{js,ts,mjs,cjs}'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.testingSupportModule.hard),
-    },
-  },
-  {
-    files: ['src/lib/components/layout/**/*.svelte'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.layoutComponent.hard),
-    },
-  },
-  {
-    files: ['src/lib/components/ui/**/*.svelte'],
-    rules: {
-      'max-lines': maxLinesRule(fileBudgetLimits.uiPrimitive.hard),
-    },
-  },
+  ...eslintFileBudgetOverrides.map(budgetOverrideToFlatConfig),
   {
     files: ['**/*.{js,cjs,mjs,ts}'],
     rules: {

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -1,107 +1,137 @@
-export const fileBudgetLimits = {
-  routePage: { soft: 150, hard: 250 },
-  routeLayout: { soft: 180, hard: 300 },
-  featureComponent: { soft: 200, hard: 350 },
-  featureTest: { soft: 300, hard: 650 },
-  featureStateModule: { soft: 250, hard: 500 },
-  featureModule: { soft: 200, hard: 325 },
-  testingSupportModule: { soft: 350, hard: 650 },
-  layoutComponent: { soft: 200, hard: 300 },
-  uiPrimitive: { soft: 150, hard: 250 },
+function matchesPattern(pattern) {
+  return (filePath) => pattern.test(filePath)
 }
 
-function isRoutePage(filePath) {
-  return /^src\/routes\/.+\/\+page\.svelte$|^src\/routes\/\+page\.svelte$/.test(filePath)
+function defineBudgetCategory({
+  key,
+  name,
+  softLimit,
+  hardLimit,
+  match,
+  eslintFiles,
+  eslintIgnores = [],
+}) {
+  return { key, name, softLimit, hardLimit, match, eslintFiles, eslintIgnores }
 }
 
-function isRouteLayout(filePath) {
-  return /^src\/routes\/.+\/\+layout\.svelte$|^src\/routes\/\+layout\.svelte$/.test(filePath)
-}
+const isRoutePage = matchesPattern(
+  /^src\/routes\/.+\/\+page\.svelte$|^src\/routes\/\+page\.svelte$/,
+)
+const isRouteLayout = matchesPattern(
+  /^src\/routes\/.+\/\+layout\.svelte$|^src\/routes\/\+layout\.svelte$/,
+)
+const isFeatureTestModule = matchesPattern(/^src\/lib\/features\/.+\.test\.(ts|js|mjs|cjs)$/)
+const isFeatureStateModule = matchesPattern(/^src\/lib\/features\/.+\.svelte\.(ts|js)$/)
+const isFeatureComponent = matchesPattern(/^src\/lib\/features\/.+\.svelte$/)
+const isFeatureModule = matchesPattern(/^src\/lib\/features\/.+\.(ts|js|mjs|cjs)$/)
+const isTestingSupportModule = matchesPattern(/^src\/lib\/testing\/.+\.(ts|js|mjs|cjs)$/)
+const isLayoutComponent = matchesPattern(/^src\/lib\/components\/layout\/.+\.svelte$/)
+const isUiPrimitive = matchesPattern(/^src\/lib\/components\/ui\/.+\.svelte$/)
 
-function isFeatureTestModule(filePath) {
-  return /^src\/lib\/features\/.+\.test\.(ts|js|mjs|cjs)$/.test(filePath)
-}
-
-function isFeatureStateModule(filePath) {
-  return /^src\/lib\/features\/.+\.svelte\.(ts|js)$/.test(filePath)
-}
-
-function isFeatureComponent(filePath) {
-  return /^src\/lib\/features\/.+\.svelte$/.test(filePath)
-}
-
-function isFeatureModule(filePath) {
-  return /^src\/lib\/features\/.+\.(ts|js|mjs|cjs)$/.test(filePath)
-}
-
-function isTestingSupportModule(filePath) {
-  return /^src\/lib\/testing\/.+\.(ts|js|mjs|cjs)$/.test(filePath)
-}
-
-function isLayoutComponent(filePath) {
-  return /^src\/lib\/components\/layout\/.+\.svelte$/.test(filePath)
-}
-
-function isUiPrimitive(filePath) {
-  return /^src\/lib\/components\/ui\/.+\.svelte$/.test(filePath)
-}
-
-export const fileBudgetRules = [
-  {
+export const fileBudgetCategories = [
+  defineBudgetCategory({
+    key: 'routePage',
     name: 'Route pages',
+    softLimit: 150,
+    hardLimit: 250,
     match: isRoutePage,
-    softLimit: fileBudgetLimits.routePage.soft,
-    hardLimit: fileBudgetLimits.routePage.hard,
-  },
-  {
+    eslintFiles: ['src/routes/**/+page.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'routeLayout',
     name: 'Route layouts',
+    softLimit: 180,
+    hardLimit: 300,
     match: isRouteLayout,
-    softLimit: fileBudgetLimits.routeLayout.soft,
-    hardLimit: fileBudgetLimits.routeLayout.hard,
-  },
-  {
+    eslintFiles: ['src/routes/**/+layout.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'featureTest',
     name: 'Feature tests',
+    softLimit: 300,
+    hardLimit: 650,
     match: isFeatureTestModule,
-    softLimit: fileBudgetLimits.featureTest.soft,
-    hardLimit: fileBudgetLimits.featureTest.hard,
-  },
-  {
+    eslintFiles: ['src/lib/features/**/*.test.{js,ts,mjs,cjs}'],
+  }),
+  defineBudgetCategory({
+    key: 'featureStateModule',
     name: 'Feature state modules',
+    softLimit: 250,
+    hardLimit: 500,
     match: isFeatureStateModule,
-    softLimit: fileBudgetLimits.featureStateModule.soft,
-    hardLimit: fileBudgetLimits.featureStateModule.hard,
-  },
-  {
+    eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
+  }),
+  defineBudgetCategory({
+    key: 'featureComponent',
     name: 'Feature components',
+    softLimit: 200,
+    hardLimit: 350,
     match: isFeatureComponent,
-    softLimit: fileBudgetLimits.featureComponent.soft,
-    hardLimit: fileBudgetLimits.featureComponent.hard,
-  },
-  {
+    eslintFiles: ['src/lib/features/**/*.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'featureModule',
     name: 'Feature modules',
+    softLimit: 200,
+    hardLimit: 325,
     match: (filePath) =>
       isFeatureModule(filePath) &&
       !isFeatureTestModule(filePath) &&
       !isFeatureStateModule(filePath),
-    softLimit: fileBudgetLimits.featureModule.soft,
-    hardLimit: fileBudgetLimits.featureModule.hard,
-  },
-  {
+    eslintFiles: ['src/lib/features/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: [
+      'src/lib/features/**/*.test.{js,ts,mjs,cjs}',
+      'src/lib/features/**/*.svelte.{ts,js}',
+    ],
+  }),
+  defineBudgetCategory({
+    key: 'testingSupportModule',
     name: 'Testing support modules',
+    softLimit: 350,
+    hardLimit: 650,
     match: isTestingSupportModule,
-    softLimit: fileBudgetLimits.testingSupportModule.soft,
-    hardLimit: fileBudgetLimits.testingSupportModule.hard,
-  },
-  {
+    eslintFiles: ['src/lib/testing/**/*.{js,ts,mjs,cjs}'],
+  }),
+  defineBudgetCategory({
+    key: 'layoutComponent',
     name: 'Layout components',
+    softLimit: 200,
+    hardLimit: 300,
     match: isLayoutComponent,
-    softLimit: fileBudgetLimits.layoutComponent.soft,
-    hardLimit: fileBudgetLimits.layoutComponent.hard,
-  },
-  {
+    eslintFiles: ['src/lib/components/layout/**/*.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'uiPrimitive',
     name: 'UI primitives',
+    softLimit: 150,
+    hardLimit: 250,
     match: isUiPrimitive,
-    softLimit: fileBudgetLimits.uiPrimitive.soft,
-    hardLimit: fileBudgetLimits.uiPrimitive.hard,
-  },
+    eslintFiles: ['src/lib/components/ui/**/*.svelte'],
+  }),
 ]
+
+export const fileBudgetLimits = Object.fromEntries(
+  fileBudgetCategories.map(({ key, softLimit, hardLimit }) => [
+    key,
+    { soft: softLimit, hard: hardLimit },
+  ]),
+)
+
+export const fileBudgetRules = fileBudgetCategories.map(
+  ({ name, match, softLimit, hardLimit }) => ({
+    name,
+    match,
+    softLimit,
+    hardLimit,
+  }),
+)
+
+// `lint:structure` uses first-match wins while ESLint uses last-match wins, so
+// the shared categories are reversed here to keep future specific overrides authoritative.
+export const eslintFileBudgetOverrides = [...fileBudgetCategories]
+  .reverse()
+  .map(({ eslintFiles, eslintIgnores, hardLimit }) => ({
+    files: eslintFiles,
+    ignores: eslintIgnores,
+    hardLimit,
+  }))

--- a/web/scripts/check-dependency-boundaries.mjs
+++ b/web/scripts/check-dependency-boundaries.mjs
@@ -8,7 +8,6 @@ const supportedExtensions = ['.svelte', '.svelte.ts', '.svelte.js', '.ts', '.js'
 
 const files = walkFiles(sourceRoot).filter(isSupportedSourceFile)
 const violations = []
-const waivedViolations = []
 
 for (const filePath of files) {
   const relativeFile = toRepoPath(filePath)
@@ -35,7 +34,6 @@ for (const filePath of files) {
         continue
       }
 
-      const waiverReason = rule.allowlist?.[relativeFile]
       const result = {
         file: relativeFile,
         line: imported.line,
@@ -45,25 +43,9 @@ for (const filePath of files) {
         reason: message,
       }
 
-      if (waiverReason) {
-        waivedViolations.push({ ...result, waiverReason })
-      } else {
-        violations.push(result)
-      }
+      violations.push(result)
     }
   }
-}
-
-if (waivedViolations.length > 0) {
-  console.warn('Legacy dependency boundary waivers:')
-  for (const waived of uniqueIssues(waivedViolations)) {
-    console.warn(
-      `  - ${waived.file}:${waived.line} imports ${waived.specifier} -> ${waived.target}`,
-    )
-    console.warn(`    ${waived.reason}`)
-    console.warn(`    waiver: ${waived.waiverReason}`)
-  }
-  console.warn('')
 }
 
 if (violations.length > 0) {


### PR DESCRIPTION
## What changed
- centralize frontend file budget categories into one shared definition that feeds both `lint:structure` and ESLint `max-lines`
- remove the legacy dependency-boundary waiver path so import boundary violations always fail instead of being silently allowlisted
- document the no-waiver policy in `web/README.md`

## Why
ASE-287 asks us to clean up temporary frontend bypasses that were added to satisfy file budget checks and similar guardrails. The old setup duplicated budget categories across multiple files and still carried a waiver code path for dependency boundaries, which made future exceptions easy to hide instead of formalizing them.

## Impact
- recurring frontend exceptions now have to become explicit category-level rules instead of per-file bypasses
- ESLint and the custom structure checker stay in sync from one source of truth
- dependency boundary violations no longer have a soft escape hatch

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci`
