### PR TITLE
fix: sanitize runtime command output before persistence

### DIFF
--- a/internal/orchestrator/runtime_event_projection.go
+++ b/internal/orchestrator/runtime_event_projection.go
@@ -125,7 +125,7 @@ func (l *RuntimeLauncher) appendAgentRawEvent(
 	if raw == nil {
 		return nil
 	}
-	dedupKey := sanitizeRawEventDBText(raw.DedupKey)
+	dedupKey := sanitizeRuntimeDBToken(raw.DedupKey)
 	if dedupKey == "" {
 		return nil
 	}
@@ -148,22 +148,22 @@ func (l *RuntimeLauncher) appendAgentRawEvent(
 		SetAgentID(input.AgentID).
 		SetAgentRunID(input.RunID).
 		SetDedupKey(dedupKey).
-		SetProvider(sanitizeRawEventDBText(input.Provider)).
-		SetProviderEventKind(sanitizeRawEventDBText(raw.ProviderEventKind)).
-		SetProviderEventSubtype(sanitizeRawEventDBText(raw.ProviderEventSubtype)).
+		SetProvider(sanitizeRuntimeDBToken(input.Provider)).
+		SetProviderEventKind(sanitizeRuntimeDBToken(raw.ProviderEventKind)).
+		SetProviderEventSubtype(sanitizeRuntimeDBToken(raw.ProviderEventSubtype)).
 		SetOccurredAt(input.ObservedAt.UTC()).
 		SetPayload(cloneProjectionMap(raw.Payload)).
-		SetTextExcerpt(sanitizeRawEventDBText(raw.TextExcerpt))
-	if trimmed := sanitizeRawEventDBText(raw.ProviderEventID); trimmed != "" {
+		SetTextExcerpt(sanitizeRuntimeDBToken(raw.TextExcerpt))
+	if trimmed := sanitizeRuntimeDBToken(raw.ProviderEventID); trimmed != "" {
 		create.SetProviderEventID(trimmed)
 	}
-	if trimmed := sanitizeRawEventDBText(raw.ThreadID); trimmed != "" {
+	if trimmed := sanitizeRuntimeDBToken(raw.ThreadID); trimmed != "" {
 		create.SetThreadID(trimmed)
 	}
-	if trimmed := sanitizeRawEventDBText(raw.TurnID); trimmed != "" {
+	if trimmed := sanitizeRuntimeDBToken(raw.TurnID); trimmed != "" {
 		create.SetTurnID(trimmed)
 	}
-	if trimmed := sanitizeRawEventDBText(raw.ActivityHintID); trimmed != "" {
+	if trimmed := sanitizeRuntimeDBToken(raw.ActivityHintID); trimmed != "" {
 		create.SetActivityHintID(trimmed)
 	}
 	if _, err := create.Save(ctx); err != nil {
@@ -172,8 +172,37 @@ func (l *RuntimeLauncher) appendAgentRawEvent(
 	return nil
 }
 
-func sanitizeRawEventDBText(raw string) string {
-	return strings.TrimSpace(strings.ReplaceAll(strings.ToValidUTF8(raw, ""), "\x00", ""))
+func sanitizeRuntimeDBText(raw string) string {
+	return strings.ReplaceAll(strings.ToValidUTF8(raw, ""), "\x00", "")
+}
+
+func sanitizeRuntimeDBToken(raw string) string {
+	return strings.TrimSpace(sanitizeRuntimeDBText(raw))
+}
+
+func sanitizeRuntimeOptionalDBToken(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	sanitized := sanitizeRuntimeDBToken(*value)
+	if sanitized == "" {
+		return nil
+	}
+	return &sanitized
+}
+
+func sanitizeActivityIdentityForDB(identity activityIdentity) activityIdentity {
+	identity.Kind = sanitizeRuntimeDBToken(identity.Kind)
+	identity.ActivityID = sanitizeRuntimeDBToken(identity.ActivityID)
+	identity.IDSource = sanitizeRuntimeDBToken(identity.IDSource)
+	identity.IdentityConfidence = sanitizeRuntimeDBToken(identity.IdentityConfidence)
+	identity.ParentActivityID = sanitizeRuntimeOptionalDBToken(identity.ParentActivityID)
+	identity.ThreadID = sanitizeRuntimeOptionalDBToken(identity.ThreadID)
+	identity.TurnID = sanitizeRuntimeOptionalDBToken(identity.TurnID)
+	identity.Command = sanitizeRuntimeOptionalDBToken(identity.Command)
+	identity.ToolName = sanitizeRuntimeOptionalDBToken(identity.ToolName)
+	identity.Title = sanitizeRuntimeOptionalDBToken(identity.Title)
+	return identity
 }
 
 func (l *RuntimeLauncher) projectItemStartedEvent(ctx context.Context, input runtimeEventProjectionInput) error {
@@ -598,7 +627,8 @@ func (l *RuntimeLauncher) upsertAgentActivity(
 	input runtimeEventProjectionInput,
 	update activityUpsertInput,
 ) error {
-	identity := update.Identity
+	identity := sanitizeActivityIdentityForDB(update.Identity)
+	status := sanitizeRuntimeDBToken(update.Status)
 	if strings.TrimSpace(identity.Kind) == "" || strings.TrimSpace(identity.ActivityID) == "" {
 		return nil
 	}
@@ -620,12 +650,12 @@ func (l *RuntimeLauncher) upsertAgentActivity(
 			SetTicketID(input.TicketID).
 			SetAgentID(input.AgentID).
 			SetAgentRunID(input.RunID).
-			SetProvider(strings.TrimSpace(input.Provider)).
+			SetProvider(sanitizeRuntimeDBToken(input.Provider)).
 			SetActivityKind(identity.Kind).
 			SetActivityID(identity.ActivityID).
 			SetIDSource(identity.IDSource).
 			SetIdentityConfidence(identity.IdentityConfidence).
-			SetStatus(defaultIfEmpty(update.Status, "in_progress")).
+			SetStatus(defaultIfEmpty(status, "in_progress")).
 			SetMetadata(cloneProjectionMap(identity.Metadata)).
 			SetUpdatedAt(input.ObservedAt.UTC())
 		if identity.ParentActivityID != nil {
@@ -647,7 +677,7 @@ func (l *RuntimeLauncher) upsertAgentActivity(
 			create.SetTitle(*identity.Title)
 		}
 		if update.LiveText != nil {
-			liveText := truncateTranscriptBody(update.LiveText.Text)
+			liveText := truncateLiveText(update.LiveText.Text)
 			if liveText != "" {
 				create.SetLiveText(liveText)
 				create.SetLiveTextBytes(len([]byte(liveText)))
@@ -674,7 +704,7 @@ func (l *RuntimeLauncher) upsertAgentActivity(
 
 	builder := existing.Update().
 		SetUpdatedAt(input.ObservedAt.UTC()).
-		SetStatus(defaultIfEmpty(update.Status, existing.Status)).
+		SetStatus(defaultIfEmpty(status, existing.Status)).
 		SetMetadata(mergeProjectionMaps(existing.Metadata, identity.Metadata))
 	if identity.ParentActivityID != nil && strings.TrimSpace(stringOrEmpty(existing.ParentActivityID)) == "" {
 		builder.SetParentActivityID(*identity.ParentActivityID)
@@ -726,8 +756,8 @@ func (l *RuntimeLauncher) appendAgentTranscriptEntry(
 	input runtimeEventProjectionInput,
 	entry transcriptAppendInput,
 ) error {
-	entryKey := strings.TrimSpace(entry.EntryKey)
-	entryKind := strings.TrimSpace(entry.EntryKind)
+	entryKey := sanitizeRuntimeDBToken(entry.EntryKey)
+	entryKind := sanitizeRuntimeDBToken(entry.EntryKind)
 	if entryKey == "" || entryKind == "" {
 		return nil
 	}
@@ -749,31 +779,35 @@ func (l *RuntimeLauncher) appendAgentTranscriptEntry(
 		SetTicketID(input.TicketID).
 		SetAgentID(input.AgentID).
 		SetAgentRunID(input.RunID).
-		SetProvider(strings.TrimSpace(input.Provider)).
+		SetProvider(sanitizeRuntimeDBToken(input.Provider)).
 		SetEntryKey(entryKey).
 		SetEntryKind(entryKind).
 		SetMetadata(cloneProjectionMap(entry.Metadata)).
 		SetCreatedAt(entry.CreatedAt.UTC())
-	if entry.ActivityKind != nil {
-		create.SetActivityKind(*entry.ActivityKind)
+	if sanitized := sanitizeRuntimeOptionalDBToken(entry.ActivityKind); sanitized != nil {
+		create.SetActivityKind(*sanitized)
 	}
-	if entry.ActivityID != nil {
-		create.SetActivityID(*entry.ActivityID)
+	if sanitized := sanitizeRuntimeOptionalDBToken(entry.ActivityID); sanitized != nil {
+		create.SetActivityID(*sanitized)
 	}
-	if entry.Title != nil {
-		create.SetTitle(*entry.Title)
+	if sanitized := sanitizeRuntimeOptionalDBToken(entry.Title); sanitized != nil {
+		create.SetTitle(*sanitized)
 	}
 	if entry.Summary != nil {
-		create.SetSummary(truncateTranscriptSummary(*entry.Summary))
+		if summary := truncateTranscriptSummary(*entry.Summary); summary != "" {
+			create.SetSummary(summary)
+		}
 	}
 	if entry.BodyText != nil {
-		create.SetBodyText(truncateTranscriptBody(*entry.BodyText))
+		if bodyText := truncateTranscriptBody(*entry.BodyText); bodyText != "" {
+			create.SetBodyText(bodyText)
+		}
 	}
-	if entry.Command != nil {
-		create.SetCommand(*entry.Command)
+	if sanitized := sanitizeRuntimeOptionalDBToken(entry.Command); sanitized != nil {
+		create.SetCommand(*sanitized)
 	}
-	if entry.ToolName != nil {
-		create.SetToolName(*entry.ToolName)
+	if sanitized := sanitizeRuntimeOptionalDBToken(entry.ToolName); sanitized != nil {
+		create.SetToolName(*sanitized)
 	}
 	if _, err := create.Save(ctx); err != nil {
 		return fmt.Errorf("append transcript entry %s for run %s: %w", entryKey, input.RunID, err)
@@ -1201,7 +1235,7 @@ func truncateFinalText(text string) string {
 }
 
 func truncateTranscriptSummary(text string) string {
-	trimmed := strings.TrimSpace(text)
+	trimmed := strings.TrimSpace(sanitizeRuntimeDBText(text))
 	if trimmed == "" {
 		return ""
 	}
@@ -1216,7 +1250,7 @@ func truncateTranscriptBody(text string) string {
 }
 
 func truncateTailUTF8(text string, maxBytes int) string {
-	text = strings.TrimSpace(text)
+	text = strings.TrimSpace(sanitizeRuntimeDBText(text))
 	if text == "" || maxBytes <= 0 || len([]byte(text)) <= maxBytes {
 		return text
 	}

--- a/internal/orchestrator/runtime_event_projection_test.go
+++ b/internal/orchestrator/runtime_event_projection_test.go
@@ -8,11 +8,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
+	entagentactivityinstance "github.com/BetterAndBetterII/openase/ent/agentactivityinstance"
 	entagentrawevent "github.com/BetterAndBetterII/openase/ent/agentrawevent"
 	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
+	entagenttranscriptentry "github.com/BetterAndBetterII/openase/ent/agenttranscriptentry"
 	entticket "github.com/BetterAndBetterII/openase/ent/ticket"
 	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/BetterAndBetterII/openase/internal/provider"
 )
 
@@ -98,5 +102,148 @@ func TestProjectRuntimeEventPersistsClaudeRawEventWithoutNULDedupKey(t *testing.
 	}
 	if rawEvent.Provider != "claude" {
 		t.Fatalf("provider = %q, want claude", rawEvent.Provider)
+	}
+}
+
+func TestProjectRuntimeEventSanitizesCommandOutputBeforePersistence(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	fixture := seedProjectFixture(ctx, t, client)
+	now := time.Date(2026, time.April, 19, 14, 0, 0, 0, time.UTC)
+
+	workflowItem, err := client.Workflow.Create().
+		SetProjectID(fixture.projectID).
+		SetName("Command output projection").
+		SetType(entworkflow.TypeCoding).
+		SetHarnessPath(".openase/harnesses/coding.md").
+		AddPickupStatusIDs(fixture.statusIDs["Todo"]).
+		AddFinishStatusIDs(fixture.statusIDs["Done"]).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(fixture.projectID).
+		SetIdentifier("ASE-RUNTIME-OUTPUT").
+		SetTitle("Sanitize command output persistence").
+		SetStatusID(fixture.statusIDs["Todo"]).
+		SetWorkflowID(workflowItem.ID).
+		SetPriority(entticket.PriorityHigh).
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	agentItem := fixture.createAgent(ctx, t, "codex-output-01", 0)
+	runItem := mustCreateCurrentRun(ctx, t, client, agentItem, workflowItem.ID, ticketItem.ID, entagentrun.StatusExecuting, now)
+
+	launcher := NewRuntimeLauncher(client, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, nil)
+
+	events := []runtimeEventProjectionInput{
+		{
+			ProjectID:  fixture.projectID,
+			AgentID:    agentItem.ID,
+			TicketID:   ticketItem.ID,
+			RunID:      runItem.ID,
+			Provider:   "codex",
+			ObservedAt: now,
+			Event: agentEvent{
+				Type: agentEventTypeOutputProduced,
+				Output: &agentOutputEvent{
+					ThreadID: "thread-output-1",
+					TurnID:   "turn-output-1",
+					ItemID:   "command-output-1",
+					Stream:   "command",
+					Text:     string([]byte{'o', 'k', 0, 'b', 'a', 'd', 0xff, '\n'}),
+				},
+			},
+		},
+		{
+			ProjectID:  fixture.projectID,
+			AgentID:    agentItem.ID,
+			TicketID:   ticketItem.ID,
+			RunID:      runItem.ID,
+			Provider:   "codex",
+			ObservedAt: now.Add(time.Second),
+			Event: agentEvent{
+				Type: agentEventTypeOutputProduced,
+				Output: &agentOutputEvent{
+					ThreadID: "thread-output-1",
+					TurnID:   "turn-output-1",
+					ItemID:   "command-output-1",
+					Stream:   "command",
+					Text:     string([]byte{'f', 'i', 'n', 'a', 'l', 0, '-', 'o', 'u', 't', 0xfe, '\n'}),
+					Snapshot: true,
+				},
+			},
+		},
+	}
+	for _, input := range events {
+		if err := launcher.projectRuntimeEvent(ctx, input); err != nil {
+			t.Fatalf("projectRuntimeEvent() error = %v", err)
+		}
+	}
+
+	activity, err := client.AgentActivityInstance.Query().
+		Where(
+			entagentactivityinstance.AgentRunIDEQ(runItem.ID),
+			entagentactivityinstance.ActivityKindEQ(catalogdomain.AgentActivityKindCommandExecution),
+			entagentactivityinstance.ActivityIDEQ("command-output-1"),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query activity: %v", err)
+	}
+	if got, want := stringOrEmpty(activity.LiveText), "final-out"; got != want {
+		t.Fatalf("live_text = %q, want %q", got, want)
+	}
+	if got, want := stringOrEmpty(activity.FinalText), "final-out"; got != want {
+		t.Fatalf("final_text = %q, want %q", got, want)
+	}
+	if got, want := stringOrEmpty(activity.Title), "okbad"; got != want {
+		t.Fatalf("title = %q, want %q", got, want)
+	}
+	for fieldName, value := range map[string]string{
+		"live_text":  stringOrEmpty(activity.LiveText),
+		"final_text": stringOrEmpty(activity.FinalText),
+		"title":      stringOrEmpty(activity.Title),
+	} {
+		if strings.Contains(value, "\x00") {
+			t.Fatalf("%s must not contain NUL bytes: %q", fieldName, value)
+		}
+		if !utf8.ValidString(value) {
+			t.Fatalf("%s must be valid UTF-8: %q", fieldName, value)
+		}
+	}
+
+	entry, err := client.AgentTranscriptEntry.Query().
+		Where(
+			entagenttranscriptentry.AgentRunIDEQ(runItem.ID),
+			entagenttranscriptentry.EntryKeyEQ("command_completed:command-output-1"),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query transcript entry: %v", err)
+	}
+	if got, want := stringOrEmpty(entry.BodyText), "final-out"; got != want {
+		t.Fatalf("body_text = %q, want %q", got, want)
+	}
+	if got, want := stringOrEmpty(entry.Summary), "final-out"; got != want {
+		t.Fatalf("summary = %q, want %q", got, want)
+	}
+	if got, want := stringOrEmpty(entry.Title), "final-out"; got != want {
+		t.Fatalf("transcript title = %q, want %q", got, want)
+	}
+	for fieldName, value := range map[string]string{
+		"body_text": stringOrEmpty(entry.BodyText),
+		"summary":   stringOrEmpty(entry.Summary),
+		"title":     stringOrEmpty(entry.Title),
+	} {
+		if strings.Contains(value, "\x00") {
+			t.Fatalf("transcript %s must not contain NUL bytes: %q", fieldName, value)
+		}
+		if !utf8.ValidString(value) {
+			t.Fatalf("transcript %s must be valid UTF-8: %q", fieldName, value)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a shared runtime DB text sanitizer that removes embedded NUL bytes and invalid UTF-8 before projection persistence
- apply the sanitizer across raw-event persistence, activity identity/text fields, and transcript text fields at the projection boundary
- add a Postgres-backed regression test covering command output delta/snapshot persistence with embedded NUL bytes

## Validation
- `go test -v ./internal/orchestrator -run 'TestProjectRuntimeEvent(SanitizesCommandOutputBeforePersistence|PersistsClaudeRawEventWithoutNULDedupKey)$' -count=1`
- `make check` *(fails in unrelated existing test: `TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync` because the reverse runtime machine never becomes ready in this environment)*
- `go test -v ./internal/orchestrator -run '^TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync$' -count=1` *(reproduces the same unrelated reverse-runtime readiness failure)*

## Ticket
- ASE-293
