### PR TITLE
ASE-298 refactor(web): formalize workspace state budgets

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 500                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 400                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 500,
+    hardLimit: 400,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-actions.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-actions.ts
@@ -1,0 +1,213 @@
+import type {
+  ChatDiffPayload,
+  ProjectConversationWorkspaceBranchScope,
+  ProjectConversationWorkspaceDiff,
+  ProjectConversationWorkspaceMetadata,
+  ProjectConversationWorkspaceRepoRefs,
+  ProjectConversationWorkspaceSearchResult,
+} from '$lib/api/chat'
+import {
+  checkoutWorkspaceBranch as runCheckoutWorkspaceBranch,
+  computeWorkspaceCheckoutBlockers,
+} from './project-conversation-workspace-browser-repo-ops'
+import {
+  createWorkspaceFileEntry,
+  deleteWorkspaceFileEntry,
+  relativeChangedFilePath,
+  renameWorkspaceFileEntry,
+  reviewWorkspacePatch,
+  searchWorkspacePaths,
+  workspaceSelectedChangedFiles,
+} from './project-conversation-workspace-browser-file-ops'
+import type {
+  WorkspaceFileEditorState,
+  WorkspaceTab,
+} from './project-conversation-workspace-browser-state-helpers'
+
+type WorkspaceBrowserEditorStore = {
+  getEditorState: (repoPath?: string, filePath?: string) => WorkspaceFileEditorState | null
+  reviewPatch: (repoPath: string, filePath: string, diff: ChatDiffPayload) => boolean
+  applyPendingPatch: (repoPath: string, filePath: string) => boolean
+  discardDraft: (repoPath: string, filePath: string) => void
+}
+
+export function createWorkspaceBrowserActions(input: {
+  getConversationId: () => string
+  currentWorkspaceDiff: () => ProjectConversationWorkspaceDiff | null
+  getMetadata: () => ProjectConversationWorkspaceMetadata | null
+  setMetadata: (nextMetadata: ProjectConversationWorkspaceMetadata) => void
+  getRepoRefs: () => ProjectConversationWorkspaceRepoRefs | null
+  getTreeRepoPath: () => string
+  setTreeRepoPath: (repoPath: string) => void
+  resetTree: () => void
+  getOpenTabs: () => WorkspaceTab[]
+  getActiveFilePath: () => string
+  getActiveTabKey: () => string
+  reserveRequestID: () => number
+  setDetailMode: (mode: 'file' | 'git_graph') => void
+  revealFileInTree: (
+    path: string,
+    options?: { requestID?: number; silent?: boolean },
+  ) => Promise<void>
+  refreshRepoGitContext: (repoPath?: string) => Promise<void>
+  refreshRepoGitContextAfterCheckout?: (repoPath?: string) => Promise<void>
+  refreshWorkspace: (preserveSelection: boolean) => Promise<void>
+  loadDirEntries: (
+    dirPath: string,
+    requestID?: number,
+    options?: { silent?: boolean },
+  ) => Promise<void>
+  loadFile: (repoPath: string, filePath: string, options?: { silent?: boolean }) => Promise<void>
+  openTab: (repoPath: string, filePath: string) => void
+  activateTab: (repoPath: string, filePath: string) => void
+  closeTab: (repoPath: string, filePath: string) => void
+  remapTabPath: (repoPath: string, fromPath: string, toPath: string) => void
+  editorStore: WorkspaceBrowserEditorStore
+}) {
+  function activeFilePath() {
+    return input.getActiveFilePath()
+  }
+
+  function selectFile(path: string) {
+    const repoPath = input.getTreeRepoPath()
+    if (!path || !repoPath) return
+    input.setDetailMode('file')
+    const requestID = input.reserveRequestID()
+    void input.revealFileInTree(path, { requestID, silent: true })
+    input.openTab(repoPath, path)
+  }
+
+  function openRepo(repoPath: string) {
+    if (!repoPath || repoPath === input.getTreeRepoPath()) return
+    input.setTreeRepoPath(repoPath)
+    input.resetTree()
+    void input.loadDirEntries('')
+    void input.refreshRepoGitContext(repoPath)
+  }
+
+  async function createFile(path: string) {
+    return createWorkspaceFileEntry({
+      conversationId: input.getConversationId(),
+      repoPath: input.getTreeRepoPath(),
+      path,
+      refreshWorkspace: input.refreshWorkspace,
+      selectFile,
+    })
+  }
+
+  async function searchPaths(
+    query: string,
+    limit = 20,
+  ): Promise<ProjectConversationWorkspaceSearchResult[]> {
+    return searchWorkspacePaths({
+      conversationId: input.getConversationId(),
+      repoPath: input.getTreeRepoPath(),
+      query,
+      limit,
+    })
+  }
+
+  function checkoutBlockers(repoPath: string): string[] {
+    return computeWorkspaceCheckoutBlockers({
+      repoPath,
+      metadata: input.getMetadata(),
+      workspaceDiff: input.currentWorkspaceDiff(),
+      openTabs: input.getOpenTabs(),
+      getEditorState: input.editorStore.getEditorState,
+    })
+  }
+
+  async function checkoutBranch(request: {
+    repoPath: string
+    targetKind: ProjectConversationWorkspaceBranchScope
+    targetName: string
+    createTrackingBranch: boolean
+    localBranchName?: string
+  }): Promise<{
+    ok: boolean
+    blockers: string[]
+  }> {
+    const conversationId = input.getConversationId()
+    if (!conversationId || !request.repoPath) {
+      return { ok: false, blockers: ['Workspace conversation is unavailable.'] }
+    }
+    return runCheckoutWorkspaceBranch({
+      conversationId,
+      ...request,
+      repoRefs: input.getRepoRefs(),
+      metadata: input.getMetadata(),
+      workspaceDiff: input.currentWorkspaceDiff(),
+      openTabs: input.getOpenTabs(),
+      getEditorState: input.editorStore.getEditorState,
+      setMetadata: input.setMetadata,
+      refreshWorkspace: input.refreshWorkspace,
+      refreshRepoGitContext:
+        input.refreshRepoGitContextAfterCheckout ?? input.refreshRepoGitContext,
+    })
+  }
+
+  async function renameFile(fromPath: string, toPath: string) {
+    const repoPath = input.getTreeRepoPath()
+    return renameWorkspaceFileEntry({
+      conversationId: input.getConversationId(),
+      repoPath,
+      fromPath,
+      toPath,
+      remapTabPath: () => input.remapTabPath(repoPath, fromPath, toPath),
+      refreshWorkspace: input.refreshWorkspace,
+      activateTab: input.activateTab,
+      getActiveTabKey: input.getActiveTabKey,
+      loadFile: input.loadFile,
+    })
+  }
+
+  async function deleteFile(path: string) {
+    return deleteWorkspaceFileEntry({
+      conversationId: input.getConversationId(),
+      repoPath: input.getTreeRepoPath(),
+      path,
+      discardDraft: input.editorStore.discardDraft,
+      closeTab: input.closeTab,
+      refreshWorkspace: input.refreshWorkspace,
+    })
+  }
+
+  function selectRelativeChangedFile(offset: 1 | -1) {
+    const nextPath = relativeChangedFilePath({
+      selectedChangedFiles: workspaceSelectedChangedFiles({
+        repoPath: input.getTreeRepoPath(),
+        activeFilePath: activeFilePath(),
+        workspaceDiff: input.currentWorkspaceDiff(),
+      }),
+      activeFilePath: activeFilePath(),
+      offset,
+    })
+    if (nextPath) selectFile(nextPath)
+  }
+
+  async function reviewPatch(diff: ChatDiffPayload, options: { autoApply?: boolean } = {}) {
+    return reviewWorkspacePatch({
+      repoPath: input.getTreeRepoPath(),
+      diff,
+      autoApply: options.autoApply ?? false,
+      openTab: input.openTab,
+      loadFile: input.loadFile,
+      reviewPatch: input.editorStore.reviewPatch,
+      applyPendingPatch: input.editorStore.applyPendingPatch,
+    })
+  }
+
+  return {
+    openRepo,
+    selectFile,
+    createFile,
+    searchPaths,
+    checkoutBlockers,
+    checkoutBranch,
+    renameFile,
+    deleteFile,
+    selectNextChangedFile: () => selectRelativeChangedFile(1),
+    selectPreviousChangedFile: () => selectRelativeChangedFile(-1),
+    reviewPatch,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,12 +1,9 @@
 import {
   getProjectConversationWorkspaceDiff,
-  type ChatDiffPayload,
-  type ProjectConversationWorkspaceBranchScope,
   type ProjectConversationWorkspaceDiff,
   type ProjectConversationWorkspaceGitGraph,
   type ProjectConversationWorkspaceMetadata,
   type ProjectConversationWorkspaceRepoRefs,
-  type ProjectConversationWorkspaceSearchResult,
 } from '$lib/api/chat'
 import { buildProjectConversationWorkspaceBrowserStateView } from './workspace-browser-state-view'
 import {
@@ -16,23 +13,16 @@ import {
 import { createWorkspaceBrowserTreeState } from './workspace-browser-tree-state.svelte'
 import { createWorkspaceBrowserTabs } from './workspace-browser-tabs.svelte'
 import { createWorkspaceFileEditorStore } from './project-conversation-workspace-file-editor-state.svelte'
+import { createWorkspaceBrowserActions } from './project-conversation-workspace-browser-actions'
 import { refreshWorkspaceBrowserState } from './project-conversation-workspace-browser-loader'
 import { loadWorkspaceFile } from './project-conversation-workspace-data-loader'
 import {
-  checkoutWorkspaceBranch as runCheckoutWorkspaceBranch,
-  computeWorkspaceCheckoutBlockers,
   loadWorkspaceDirEntries,
   refreshWorkspaceRepoGitContext,
   revealWorkspaceFileInTree,
 } from './project-conversation-workspace-browser-repo-ops'
 import {
   buildWorkspaceFocusContext,
-  createWorkspaceFileEntry,
-  deleteWorkspaceFileEntry,
-  relativeChangedFilePath,
-  renameWorkspaceFileEntry,
-  reviewWorkspacePatch,
-  searchWorkspacePaths,
   workspaceSelectedChangedFiles,
 } from './project-conversation-workspace-browser-file-ops'
 import {
@@ -259,133 +249,56 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     if (!repoPath || !filePath) return
     await loadFile(repoPath, filePath, { silent: true })
   }
-  function openRepo(repoPath: string) {
-    if (!repoPath || repoPath === tabs.treeRepoPath) return
-    tabs.setTreeRepoPath(repoPath)
-    tree.reset()
-    void loadDirEntries('')
-    void refreshRepoGitContext(repoPath)
-  }
-  function selectFile(path: string) {
-    const repoPath = tabs.treeRepoPath
-    if (!path || !repoPath) return
-    detailMode = 'file'
-    const requestID = ++loadRequestID
-    void revealFileInTree(path, { requestID, silent: true })
-    tabs.openTab(repoPath, path)
-  }
-  async function createFile(path: string) {
-    return createWorkspaceFileEntry({
-      conversationId: input.getConversationId(),
-      repoPath: tabs.treeRepoPath,
-      path,
-      refreshWorkspace,
-      selectFile,
-    })
-  }
-  async function searchPaths(
-    query: string,
-    limit = 20,
-  ): Promise<ProjectConversationWorkspaceSearchResult[]> {
-    return searchWorkspacePaths({
-      conversationId: input.getConversationId(),
-      repoPath: tabs.treeRepoPath,
-      query,
-      limit,
-    })
-  }
-  function checkoutBlockers(repoPath: string): string[] {
-    return computeWorkspaceCheckoutBlockers({
-      repoPath,
-      metadata,
-      workspaceDiff: currentWorkspaceDiff(),
-      openTabs: tabs.openTabs,
-      getEditorState: editorStore.getEditorState,
-    })
-  }
-  async function checkoutBranch(request: {
-    repoPath: string
-    targetKind: ProjectConversationWorkspaceBranchScope
-    targetName: string
-    createTrackingBranch: boolean
-    localBranchName?: string
-  }): Promise<{
-    ok: boolean
-    blockers: string[]
-  }> {
-    const conversationId = input.getConversationId()
-    if (!conversationId || !request.repoPath) {
-      return { ok: false, blockers: ['Workspace conversation is unavailable.'] }
-    }
-    return runCheckoutWorkspaceBranch({
-      conversationId,
-      ...request,
-      repoRefs,
-      metadata,
-      workspaceDiff: currentWorkspaceDiff(),
-      openTabs: tabs.openTabs,
-      getEditorState: editorStore.getEditorState,
-      setMetadata,
-      refreshWorkspace,
-      refreshRepoGitContext: async (repoPath) => {
-        await refreshRepoGitContext(repoPath)
-        await refreshWorkspaceDiff()
-      },
-    })
-  }
-  async function renameFile(fromPath: string, toPath: string) {
-    const repoPath = tabs.treeRepoPath
-    return renameWorkspaceFileEntry({
-      conversationId: input.getConversationId(),
-      repoPath,
-      fromPath,
-      toPath,
-      remapTabPath: () => tabs.remapTabPath(repoPath, fromPath, toPath),
-      refreshWorkspace,
-      activateTab: tabs.activateTab,
-      getActiveTabKey: () => tabs.activeTabKey,
-      loadFile,
-    })
-  }
-  async function deleteFile(path: string) {
-    return deleteWorkspaceFileEntry({
-      conversationId: input.getConversationId(),
-      repoPath: tabs.treeRepoPath,
-      path,
-      discardDraft: editorStore.discardDraft,
-      closeTab: tabs.closeTab,
-      refreshWorkspace,
-    })
-  }
+  const workspaceActions = createWorkspaceBrowserActions({
+    getConversationId: input.getConversationId,
+    currentWorkspaceDiff,
+    getMetadata: () => metadata,
+    setMetadata,
+    getRepoRefs: () => repoRefs,
+    getTreeRepoPath: () => tabs.treeRepoPath,
+    setTreeRepoPath: tabs.setTreeRepoPath,
+    resetTree: tree.reset,
+    getOpenTabs: () => tabs.openTabs,
+    getActiveFilePath: () => tabs.activeFilePath(tabs.treeRepoPath),
+    getActiveTabKey: () => tabs.activeTabKey,
+    reserveRequestID: () => ++loadRequestID,
+    setDetailMode: (mode) => {
+      detailMode = mode
+    },
+    revealFileInTree,
+    refreshRepoGitContext,
+    refreshRepoGitContextAfterCheckout: async (repoPath) => {
+      await refreshRepoGitContext(repoPath)
+      await refreshWorkspaceDiff()
+    },
+    refreshWorkspace,
+    loadDirEntries,
+    loadFile,
+    openTab: tabs.openTab,
+    activateTab: tabs.activateTab,
+    closeTab: tabs.closeTab,
+    remapTabPath: (repoPath, fromPath, toPath) => tabs.remapTabPath(repoPath, fromPath, toPath),
+    editorStore,
+  })
+  const {
+    openRepo,
+    selectFile,
+    createFile,
+    searchPaths,
+    checkoutBlockers,
+    checkoutBranch,
+    renameFile,
+    deleteFile,
+    selectNextChangedFile,
+    selectPreviousChangedFile,
+    reviewPatch,
+  } = workspaceActions
   function setAutosaveEnabled(enabled: boolean) {
     autosaveEnabled = enabled
     storeWorkspaceAutosavePreference(enabled)
   }
   function activeFilePath() {
     return tabs.activeFilePath(tabs.treeRepoPath)
-  }
-  function selectRelativeChangedFile(offset: 1 | -1) {
-    const nextPath = relativeChangedFilePath({
-      selectedChangedFiles: workspaceSelectedChangedFiles({
-        repoPath: tabs.treeRepoPath,
-        activeFilePath: activeFilePath(),
-        workspaceDiff: currentWorkspaceDiff(),
-      }),
-      activeFilePath: activeFilePath(),
-      offset,
-    })
-    if (nextPath) selectFile(nextPath)
-  }
-  async function reviewPatch(diff: ChatDiffPayload, options: { autoApply?: boolean } = {}) {
-    return reviewWorkspacePatch({
-      repoPath: tabs.treeRepoPath,
-      diff,
-      autoApply: options.autoApply ?? false,
-      openTab: tabs.openTab,
-      loadFile,
-      reviewPatch: editorStore.reviewPatch,
-      applyPendingPatch: editorStore.applyPendingPatch,
-    })
   }
   return buildProjectConversationWorkspaceBrowserStateView({
     getMetadata: () => metadata,
@@ -458,8 +371,8 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     checkoutBlockers,
     checkoutBranch,
     setAutosaveEnabled,
-    selectNextChangedFile: () => selectRelativeChangedFile(1),
-    selectPreviousChangedFile: () => selectRelativeChangedFile(-1),
+    selectNextChangedFile,
+    selectPreviousChangedFile,
     reviewPatch,
     applySelectedPendingPatch: () =>
       editorStore.applyPendingPatch(tabs.treeRepoPath, activeFilePath()),

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-transforms.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-transforms.ts
@@ -1,0 +1,256 @@
+import { type ChatDiffPayload, type ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
+import type { PersistedWorkspaceFileDraft } from './project-conversation-workspace-file-drafts'
+import {
+  buildWorkspaceSelection,
+  createWorkspacePatchProposal,
+  formatWorkspaceDocument,
+  formatWorkspaceSelection,
+  type WorkspaceSelectionInput,
+} from './project-conversation-workspace-editor-helpers'
+import {
+  createInitialEditorState,
+  type WorkspaceFileEditorState,
+} from './project-conversation-workspace-browser-state-helpers'
+import { chatT } from './i18n'
+
+export function syncWorkspaceEditorStateFromPreview(input: {
+  existing: WorkspaceFileEditorState | null
+  persisted: PersistedWorkspaceFileDraft | null
+  nextPreview: ProjectConversationWorkspaceFilePreview
+}): WorkspaceFileEditorState {
+  const { existing, persisted, nextPreview } = input
+  if (!existing) {
+    if (!persisted) {
+      return createInitialEditorState(nextPreview)
+    }
+    const dirty = persisted.draftContent !== nextPreview.content
+    return {
+      baseSavedContent: persisted.baseSavedContent,
+      baseSavedRevision: persisted.baseSavedRevision,
+      latestSavedContent: nextPreview.content,
+      latestSavedRevision: nextPreview.revision,
+      draftContent: persisted.draftContent,
+      dirty,
+      savePhase: 'idle',
+      externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
+      errorMessage: '',
+      encoding: nextPreview.encoding,
+      lineEnding: nextPreview.lineEnding,
+      lastSavedAt: '',
+      selection: null,
+      pendingPatch: null,
+    }
+  }
+
+  if (existing.dirty) {
+    const latestChanged = existing.latestSavedRevision !== nextPreview.revision
+    return {
+      ...existing,
+      latestSavedContent: nextPreview.content,
+      latestSavedRevision: nextPreview.revision,
+      dirty: existing.draftContent !== nextPreview.content,
+      externalChange: latestChanged || existing.baseSavedRevision !== nextPreview.revision,
+      encoding: nextPreview.encoding,
+      lineEnding: nextPreview.lineEnding,
+      selection: buildWorkspaceSelection(existing.draftContent, existing.selection),
+    }
+  }
+
+  return {
+    ...existing,
+    baseSavedContent: nextPreview.content,
+    baseSavedRevision: nextPreview.revision,
+    latestSavedContent: nextPreview.content,
+    latestSavedRevision: nextPreview.revision,
+    draftContent: nextPreview.content,
+    dirty: false,
+    externalChange: false,
+    savePhase: 'idle',
+    errorMessage: '',
+    encoding: nextPreview.encoding,
+    lineEnding: nextPreview.lineEnding,
+    selection: null,
+    pendingPatch: null,
+  }
+}
+
+export function updateWorkspaceEditorDraft(
+  editor: WorkspaceFileEditorState,
+  nextDraftContent: string,
+): WorkspaceFileEditorState {
+  return {
+    ...editor,
+    draftContent: nextDraftContent,
+    dirty: nextDraftContent !== editor.latestSavedContent,
+    savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
+    errorMessage: '',
+    selection: buildWorkspaceSelection(nextDraftContent, editor.selection),
+    pendingPatch: null,
+  }
+}
+
+export function updateWorkspaceEditorSelection(
+  editor: WorkspaceFileEditorState,
+  selection: WorkspaceSelectionInput | null,
+): WorkspaceFileEditorState {
+  return {
+    ...editor,
+    selection: buildWorkspaceSelection(editor.draftContent, selection),
+  }
+}
+
+export function revertWorkspaceEditorDraft(
+  editor: WorkspaceFileEditorState,
+): WorkspaceFileEditorState {
+  return {
+    ...editor,
+    baseSavedContent: editor.latestSavedContent,
+    baseSavedRevision: editor.latestSavedRevision,
+    draftContent: editor.latestSavedContent,
+    dirty: false,
+    savePhase: 'idle',
+    externalChange: false,
+    errorMessage: '',
+    selection: null,
+    pendingPatch: null,
+  }
+}
+
+export function keepWorkspaceEditorDraft(
+  editor: WorkspaceFileEditorState,
+): WorkspaceFileEditorState {
+  return {
+    ...editor,
+    baseSavedContent: editor.latestSavedContent,
+    baseSavedRevision: editor.latestSavedRevision,
+    dirty: editor.draftContent !== editor.latestSavedContent,
+    savePhase: 'idle',
+    externalChange: false,
+    errorMessage: '',
+  }
+}
+
+export function reviewWorkspaceEditorPatch(input: {
+  editor: WorkspaceFileEditorState
+  diff: ChatDiffPayload
+}): { ok: boolean; nextState: WorkspaceFileEditorState } {
+  const proposal = createWorkspacePatchProposal(input.editor.draftContent, input.diff)
+  if (!proposal) {
+    return {
+      ok: false,
+      nextState: {
+        ...input.editor,
+        errorMessage: 'The draft changed and this Project AI patch no longer applies cleanly.',
+        pendingPatch: null,
+      },
+    }
+  }
+
+  return {
+    ok: true,
+    nextState: {
+      ...input.editor,
+      errorMessage: '',
+      pendingPatch: proposal,
+    },
+  }
+}
+
+export function applyWorkspaceEditorPendingPatch(editor: WorkspaceFileEditorState): {
+  ok: boolean
+  nextState: WorkspaceFileEditorState
+} {
+  const proposal = editor.pendingPatch
+  if (!proposal) {
+    return { ok: false, nextState: editor }
+  }
+
+  return {
+    ok: true,
+    nextState: {
+      ...editor,
+      draftContent: proposal.proposedContent,
+      dirty: proposal.proposedContent !== editor.latestSavedContent,
+      savePhase: 'idle',
+      errorMessage: '',
+      selection: buildWorkspaceSelection(proposal.proposedContent, editor.selection),
+      pendingPatch: null,
+    },
+  }
+}
+
+export function formatWorkspaceEditorDocument(input: {
+  filePath: string
+  editor: WorkspaceFileEditorState
+}): { ok: boolean; nextState: WorkspaceFileEditorState } {
+  try {
+    const formatted = formatWorkspaceDocument(input.filePath, input.editor.draftContent)
+    if (formatted == null) {
+      return {
+        ok: false,
+        nextState: {
+          ...input.editor,
+          errorMessage: chatT('chat.formatDocumentUnavailable'),
+        },
+      }
+    }
+    return {
+      ok: true,
+      nextState: {
+        ...input.editor,
+        draftContent: formatted,
+        dirty: formatted !== input.editor.latestSavedContent,
+        errorMessage: '',
+        selection: buildWorkspaceSelection(formatted, input.editor.selection),
+      },
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      nextState: {
+        ...input.editor,
+        errorMessage: error instanceof Error ? error.message : chatT('chat.formatDocumentFailed'),
+      },
+    }
+  }
+}
+
+export function formatWorkspaceEditorSelection(input: {
+  filePath: string
+  editor: WorkspaceFileEditorState
+}): { ok: boolean; nextState: WorkspaceFileEditorState } {
+  try {
+    const formatted = formatWorkspaceSelection(
+      input.filePath,
+      input.editor.draftContent,
+      input.editor.selection,
+    )
+    if (formatted == null) {
+      return {
+        ok: false,
+        nextState: {
+          ...input.editor,
+          errorMessage: chatT('chat.formatSelectionUnavailable'),
+        },
+      }
+    }
+    return {
+      ok: true,
+      nextState: {
+        ...input.editor,
+        draftContent: formatted.content,
+        dirty: formatted.content !== input.editor.latestSavedContent,
+        errorMessage: '',
+        selection: buildWorkspaceSelection(formatted.content, formatted.selection),
+      },
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      nextState: {
+        ...input.editor,
+        errorMessage: error instanceof Error ? error.message : chatT('chat.formatSelectionFailed'),
+      },
+    }
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -7,21 +7,26 @@ import {
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
 import {
-  buildWorkspaceSelection,
   buildWorkspaceWorkingSet,
-  createWorkspacePatchProposal,
-  formatWorkspaceDocument,
-  formatWorkspaceSelection,
   type WorkspaceSelectionInput,
 } from './project-conversation-workspace-editor-helpers'
 import {
   computeDraftLineDiff,
-  createInitialEditorState,
   type WorkspaceFileEditorState,
   type WorkspaceFileLineDiffMarkers,
   type WorkspaceRecentFile,
 } from './project-conversation-workspace-browser-state-helpers'
-import { chatT } from './i18n'
+import {
+  applyWorkspaceEditorPendingPatch,
+  formatWorkspaceEditorDocument,
+  formatWorkspaceEditorSelection,
+  keepWorkspaceEditorDraft,
+  revertWorkspaceEditorDraft,
+  reviewWorkspaceEditorPatch,
+  syncWorkspaceEditorStateFromPreview,
+  updateWorkspaceEditorDraft,
+  updateWorkspaceEditorSelection,
+} from './project-conversation-workspace-file-editor-state-transforms'
 
 const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
 export function createWorkspaceFileEditorStore(input: {
@@ -129,62 +134,15 @@ export function createWorkspaceFileEditorStore(input: {
     nextPreview: ProjectConversationWorkspaceFilePreview,
   ) {
     const key = selectedFileStorageKey(repoPath, filePath)
-    const existing = editorStates.get(key)
-    if (!existing) {
-      const persisted = loadPersistedWorkspaceFileDraft(key)
-      if (!persisted) {
-        setEditorState(repoPath, filePath, createInitialEditorState(nextPreview))
-        return
-      }
-      const dirty = persisted.draftContent !== nextPreview.content
-      setEditorState(repoPath, filePath, {
-        baseSavedContent: persisted.baseSavedContent,
-        baseSavedRevision: persisted.baseSavedRevision,
-        latestSavedContent: nextPreview.content,
-        latestSavedRevision: nextPreview.revision,
-        draftContent: persisted.draftContent,
-        dirty,
-        savePhase: 'idle',
-        externalChange: dirty && persisted.baseSavedRevision !== nextPreview.revision,
-        errorMessage: '',
-        encoding: nextPreview.encoding,
-        lineEnding: nextPreview.lineEnding,
-        lastSavedAt: '',
-        selection: null,
-        pendingPatch: null,
-      })
-      return
-    }
-    if (existing.dirty) {
-      const latestChanged = existing.latestSavedRevision !== nextPreview.revision
-      setEditorState(repoPath, filePath, {
-        ...existing,
-        latestSavedContent: nextPreview.content,
-        latestSavedRevision: nextPreview.revision,
-        dirty: existing.draftContent !== nextPreview.content,
-        externalChange: latestChanged || existing.baseSavedRevision !== nextPreview.revision,
-        encoding: nextPreview.encoding,
-        lineEnding: nextPreview.lineEnding,
-        selection: buildWorkspaceSelection(existing.draftContent, existing.selection),
-      })
-      return
-    }
-    setEditorState(repoPath, filePath, {
-      ...existing,
-      baseSavedContent: nextPreview.content,
-      baseSavedRevision: nextPreview.revision,
-      latestSavedContent: nextPreview.content,
-      latestSavedRevision: nextPreview.revision,
-      draftContent: nextPreview.content,
-      dirty: false,
-      externalChange: false,
-      savePhase: 'idle',
-      errorMessage: '',
-      encoding: nextPreview.encoding,
-      lineEnding: nextPreview.lineEnding,
-      selection: null,
-      pendingPatch: null,
-    })
+    setEditorState(
+      repoPath,
+      filePath,
+      syncWorkspaceEditorStateFromPreview({
+        existing: editorStates.get(key) ?? null,
+        persisted: loadPersistedWorkspaceFileDraft(key),
+        nextPreview,
+      }),
+    )
   }
   function reset() {
     for (const key of autosaveTimers.keys()) {
@@ -199,15 +157,7 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return
     }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      draftContent: nextDraftContent,
-      dirty: nextDraftContent !== editor.latestSavedContent,
-      savePhase: editor.savePhase === 'saving' ? editor.savePhase : 'idle',
-      errorMessage: '',
-      selection: buildWorkspaceSelection(nextDraftContent, editor.selection),
-      pendingPatch: null,
-    })
+    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
   }
   function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
     const repoPath = input.getSelectedRepoPath()
@@ -216,10 +166,7 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return
     }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      selection: buildWorkspaceSelection(editor.draftContent, selection),
-    })
+    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
   }
   function revertSelectedDraft() {
     const repoPath = input.getSelectedRepoPath()
@@ -228,18 +175,7 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return
     }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      baseSavedContent: editor.latestSavedContent,
-      baseSavedRevision: editor.latestSavedRevision,
-      draftContent: editor.latestSavedContent,
-      dirty: false,
-      savePhase: 'idle',
-      externalChange: false,
-      errorMessage: '',
-      selection: null,
-      pendingPatch: null,
-    })
+    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
   }
   function keepSelectedDraft() {
     const repoPath = input.getSelectedRepoPath()
@@ -248,15 +184,7 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return
     }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      baseSavedContent: editor.latestSavedContent,
-      baseSavedRevision: editor.latestSavedRevision,
-      dirty: editor.draftContent !== editor.latestSavedContent,
-      savePhase: 'idle',
-      externalChange: false,
-      errorMessage: '',
-    })
+    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
   }
   function discardSelectedDraft() {
     const repoPath = input.getSelectedRepoPath()
@@ -276,38 +204,18 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor) {
       return false
     }
-    const proposal = createWorkspacePatchProposal(editor.draftContent, diff)
-    if (!proposal) {
-      setEditorState(repoPath, filePath, {
-        ...editor,
-        errorMessage: 'The draft changed and this Project AI patch no longer applies cleanly.',
-        pendingPatch: null,
-      })
-      return false
-    }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      errorMessage: '',
-      pendingPatch: proposal,
-    })
-    return true
+    const result = reviewWorkspaceEditorPatch({ editor, diff })
+    setEditorState(repoPath, filePath, result.nextState)
+    return result.ok
   }
   function applyPendingPatch(repoPath: string, filePath: string) {
     const editor = getEditorState(repoPath, filePath)
-    const proposal = editor?.pendingPatch
-    if (!editor || !proposal) {
+    if (!editor) {
       return false
     }
-    setEditorState(repoPath, filePath, {
-      ...editor,
-      draftContent: proposal.proposedContent,
-      dirty: proposal.proposedContent !== editor.latestSavedContent,
-      savePhase: 'idle',
-      errorMessage: '',
-      selection: buildWorkspaceSelection(proposal.proposedContent, editor.selection),
-      pendingPatch: null,
-    })
-    return true
+    const result = applyWorkspaceEditorPendingPatch(editor)
+    setEditorState(repoPath, filePath, result.nextState)
+    return result.ok
   }
   function discardPendingPatch(
     repoPath = input.getSelectedRepoPath(),
@@ -330,30 +238,9 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return false
     }
-    try {
-      const formatted = formatWorkspaceDocument(filePath, editor.draftContent)
-      if (formatted == null) {
-        setEditorState(repoPath, filePath, {
-          ...editor,
-          errorMessage: chatT('chat.formatDocumentUnavailable'),
-        })
-        return false
-      }
-      setEditorState(repoPath, filePath, {
-        ...editor,
-        draftContent: formatted,
-        dirty: formatted !== editor.latestSavedContent,
-        errorMessage: '',
-        selection: buildWorkspaceSelection(formatted, editor.selection),
-      })
-      return true
-    } catch (error) {
-      setEditorState(repoPath, filePath, {
-        ...editor,
-        errorMessage: error instanceof Error ? error.message : chatT('chat.formatDocumentFailed'),
-      })
-      return false
-    }
+    const result = formatWorkspaceEditorDocument({ filePath, editor })
+    setEditorState(repoPath, filePath, result.nextState)
+    return result.ok
   }
   function formatSelectedSelection() {
     const repoPath = input.getSelectedRepoPath()
@@ -362,30 +249,9 @@ export function createWorkspaceFileEditorStore(input: {
     if (!editor || !repoPath || !filePath) {
       return false
     }
-    try {
-      const formatted = formatWorkspaceSelection(filePath, editor.draftContent, editor.selection)
-      if (formatted == null) {
-        setEditorState(repoPath, filePath, {
-          ...editor,
-          errorMessage: chatT('chat.formatSelectionUnavailable'),
-        })
-        return false
-      }
-      setEditorState(repoPath, filePath, {
-        ...editor,
-        draftContent: formatted.content,
-        dirty: formatted.content !== editor.latestSavedContent,
-        errorMessage: '',
-        selection: buildWorkspaceSelection(formatted.content, formatted.selection),
-      })
-      return true
-    } catch (error) {
-      setEditorState(repoPath, filePath, {
-        ...editor,
-        errorMessage: error instanceof Error ? error.message : chatT('chat.formatSelectionFailed'),
-      })
-      return false
-    }
+    const result = formatWorkspaceEditorSelection({ filePath, editor })
+    setEditorState(repoPath, filePath, result.nextState)
+    return result.ok
   }
   function renameFileState(repoPath: string, fromPath: string, toPath: string) {
     const fromKey = selectedFileStorageKey(repoPath, fromPath)


### PR DESCRIPTION
## Summary
- split the workspace browser and file editor state stores into focused helper modules so the state controllers stay inside the shared feature-state budget without one-off allowances
- tighten the shared `lib/features/**/*.svelte.{ts,js}` hard budget from 500 to 400 now that the oversized workspace stores no longer require the broad cap
- document the tighter frontend budget in `web/README.md`

## Root Cause
The frontend budget system had been widened to accommodate a couple of oversized workspace state stores. That broad allowance became technical debt because it preserved a temporary bypass instead of a maintainable structure.

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run format:check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check:security-overrides`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/chat/project-conversation-workspace-browser-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout-refresh.test.ts`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vite build --logLevel warn`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci`
