### PR TITLE
ASE-303: fix run summary prompt save with legacy Project AI scopes

### DIFF
--- a/internal/agentplatform/service.go
+++ b/internal/agentplatform/service.go
@@ -388,6 +388,10 @@ func SupportedScopesForPrincipalKind(kind PrincipalKind) []string {
 	return scopeStrings(supportedScopesForPrincipalKind(kind))
 }
 
+func NormalizeSupportedScopesForPrincipalKind(kind PrincipalKind, raw []string) []string {
+	return domain.NormalizeSupportedScopesForPrincipalKind(kind, raw)
+}
+
 func PrivilegedScopes() []string {
 	return privilegedScopesForPrincipalKind(PrincipalKindTicketAgent)
 }

--- a/internal/chat/project_conversation_runtime.go
+++ b/internal/chat/project_conversation_runtime.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -642,21 +641,12 @@ func (s *ProjectConversationService) projectConversationPlatformContractInput(
 
 func projectConversationPlatformAccessAllowed(project catalogdomain.Project) []string {
 	supported := agentplatform.SupportedScopesForPrincipalKind(agentplatform.PrincipalKindProjectConversation)
-	if len(project.ProjectAIPlatformAccessAllowed) > 0 {
-		normalized := make([]string, 0, len(project.ProjectAIPlatformAccessAllowed))
-		for _, item := range project.ProjectAIPlatformAccessAllowed {
-			trimmed := strings.TrimSpace(item)
-			if trimmed == "" {
-				continue
-			}
-			if !slices.Contains(supported, trimmed) || slices.Contains(normalized, trimmed) {
-				continue
-			}
-			normalized = append(normalized, trimmed)
-		}
-		if len(normalized) > 0 {
-			return normalized
-		}
+	normalized := agentplatform.NormalizeSupportedScopesForPrincipalKind(
+		agentplatform.PrincipalKindProjectConversation,
+		project.ProjectAIPlatformAccessAllowed,
+	)
+	if len(normalized) > 0 {
+		return normalized
 	}
 	return append([]string(nil), supported...)
 }

--- a/internal/domain/agentplatform/contracts.go
+++ b/internal/domain/agentplatform/contracts.go
@@ -206,6 +206,23 @@ func SupportedScopesForPrincipalKind(kind PrincipalKind) []string {
 	}
 }
 
+func NormalizeSupportedScopesForPrincipalKind(kind PrincipalKind, raw []string) []string {
+	supported := SupportedScopesForPrincipalKind(kind)
+	if len(raw) == 0 {
+		return []string{}
+	}
+
+	normalized := make([]string, 0, len(raw))
+	for _, item := range raw {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" || !slices.Contains(supported, trimmed) || slices.Contains(normalized, trimmed) {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
 type IssueInput struct {
 	PrincipalKind  PrincipalKind
 	PrincipalID    uuid.UUID

--- a/internal/domain/agentplatform/contracts_test.go
+++ b/internal/domain/agentplatform/contracts_test.go
@@ -348,3 +348,38 @@ func TestPrincipalKindScopeHelpers(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeSupportedScopesForPrincipalKind(t *testing.T) {
+	t.Run("empty input stays empty", func(t *testing.T) {
+		if got := NormalizeSupportedScopesForPrincipalKind(PrincipalKindProjectConversation, nil); len(got) != 0 {
+			t.Fatalf("NormalizeSupportedScopesForPrincipalKind(nil) = %#v, want empty", got)
+		}
+	})
+
+	t.Run("project conversation filters unsupported scopes and deduplicates", func(t *testing.T) {
+		got := NormalizeSupportedScopesForPrincipalKind(PrincipalKindProjectConversation, []string{
+			" projects.update ",
+			"",
+			"tickets.report_usage",
+			"projects.update",
+			"tickets.update.self",
+			"tickets.list",
+		})
+		want := []string{"projects.update", "tickets.list"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("NormalizeSupportedScopesForPrincipalKind(project conversation) = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("ticket agent keeps supported ticket runtime scopes", func(t *testing.T) {
+		got := NormalizeSupportedScopesForPrincipalKind(PrincipalKindTicketAgent, []string{
+			"tickets.update.self",
+			"tickets.report_usage",
+			" tickets.update.self ",
+		})
+		want := []string{"tickets.update.self", "tickets.report_usage"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("NormalizeSupportedScopesForPrincipalKind(ticket agent) = %#v, want %#v", got, want)
+		}
+	})
+}

--- a/internal/httpapi/agent_platform_requests.go
+++ b/internal/httpapi/agent_platform_requests.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	agentplatformdomain "github.com/BetterAndBetterII/openase/internal/domain/agentplatform"
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/BetterAndBetterII/openase/internal/domain/ticketing"
 	projectupdateservice "github.com/BetterAndBetterII/openase/internal/projectupdate"
@@ -227,16 +228,19 @@ func parseAgentProjectPatchRequest(
 	}
 
 	request := domain.ProjectInput{
-		Name:                           current.Name,
-		Slug:                           current.Slug,
-		Description:                    current.Description,
-		Status:                         current.Status.String(),
-		DefaultAgentProviderID:         uuidToStringPointer(current.DefaultAgentProviderID),
-		ProjectAIPlatformAccessAllowed: cloneStringSlice(current.ProjectAIPlatformAccessAllowed),
-		AccessibleMachineIDs:           uuidSliceToStrings(current.AccessibleMachineIDs),
-		MaxConcurrentAgents:            intPointer(current.MaxConcurrentAgents),
-		AgentRunSummaryPrompt:          stringPointerOrNil(current.AgentRunSummaryPrompt),
-		ProjectAIRetention:             mergeProjectAIRetentionPatch(current.ProjectAIRetention, raw.ProjectAIRetention),
+		Name:                   current.Name,
+		Slug:                   current.Slug,
+		Description:            current.Description,
+		Status:                 current.Status.String(),
+		DefaultAgentProviderID: uuidToStringPointer(current.DefaultAgentProviderID),
+		ProjectAIPlatformAccessAllowed: agentplatformdomain.NormalizeSupportedScopesForPrincipalKind(
+			agentplatformdomain.PrincipalKindProjectConversation,
+			current.ProjectAIPlatformAccessAllowed,
+		),
+		AccessibleMachineIDs:  uuidSliceToStrings(current.AccessibleMachineIDs),
+		MaxConcurrentAgents:   intPointer(current.MaxConcurrentAgents),
+		AgentRunSummaryPrompt: stringPointerOrNil(current.AgentRunSummaryPrompt),
+		ProjectAIRetention:    mergeProjectAIRetentionPatch(current.ProjectAIRetention, raw.ProjectAIRetention),
 	}
 	if raw.Name != nil {
 		request.Name = strings.TrimSpace(*raw.Name)

--- a/internal/httpapi/agent_platform_requests_test.go
+++ b/internal/httpapi/agent_platform_requests_test.go
@@ -65,3 +65,31 @@ func TestParseAgentProjectPatchRequestSupportsFullProjectSurface(t *testing.T) {
 		t.Fatalf("project ai platform access allowed = %+v", input.ProjectAIPlatformAccessAllowed)
 	}
 }
+
+func TestParseAgentProjectPatchRequestFiltersLegacyProjectAIScopesOnUnrelatedUpdates(t *testing.T) {
+	projectID := uuid.New()
+	orgID := uuid.New()
+	runSummaryPrompt := "Summarize blockers first."
+
+	input, err := parseAgentProjectPatchRequest(projectID, domain.Project{
+		ID:                             projectID,
+		OrganizationID:                 orgID,
+		Name:                           "OpenASE",
+		Slug:                           "openase",
+		Status:                         domain.ProjectStatusInProgress,
+		ProjectAIPlatformAccessAllowed: []string{"projects.update", "tickets.report_usage"},
+		MaxConcurrentAgents:            1,
+	}, rawAgentProjectPatchRequest{
+		AgentRunSummaryPrompt: &runSummaryPrompt,
+	})
+	if err != nil {
+		t.Fatalf("parseAgentProjectPatchRequest() error = %v", err)
+	}
+
+	if input.AgentRunSummaryPrompt != runSummaryPrompt {
+		t.Fatalf("agent run summary prompt = %q, want %q", input.AgentRunSummaryPrompt, runSummaryPrompt)
+	}
+	if got, want := input.ProjectAIPlatformAccessAllowed, []string{"projects.update"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("project ai platform access allowed = %v, want %v", got, want)
+	}
+}

--- a/internal/httpapi/catalog_projects_requests.go
+++ b/internal/httpapi/catalog_projects_requests.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	agentplatformdomain "github.com/BetterAndBetterII/openase/internal/domain/agentplatform"
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	"github.com/google/uuid"
 )
@@ -30,16 +31,19 @@ func parseProjectPatchRequest(
 	patch projectPatchRequest,
 ) (domain.UpdateProject, error) {
 	request := domain.ProjectInput{
-		Name:                           current.Name,
-		Slug:                           current.Slug,
-		Description:                    current.Description,
-		Status:                         current.Status.String(),
-		DefaultAgentProviderID:         uuidToStringPointer(current.DefaultAgentProviderID),
-		ProjectAIPlatformAccessAllowed: cloneStringSlice(current.ProjectAIPlatformAccessAllowed),
-		AccessibleMachineIDs:           uuidSliceToStrings(current.AccessibleMachineIDs),
-		MaxConcurrentAgents:            intPointer(current.MaxConcurrentAgents),
-		AgentRunSummaryPrompt:          stringPointerOrNil(current.AgentRunSummaryPrompt),
-		ProjectAIRetention:             mergeProjectAIRetentionPatch(current.ProjectAIRetention, patch.ProjectAIRetention),
+		Name:                   current.Name,
+		Slug:                   current.Slug,
+		Description:            current.Description,
+		Status:                 current.Status.String(),
+		DefaultAgentProviderID: uuidToStringPointer(current.DefaultAgentProviderID),
+		ProjectAIPlatformAccessAllowed: agentplatformdomain.NormalizeSupportedScopesForPrincipalKind(
+			agentplatformdomain.PrincipalKindProjectConversation,
+			current.ProjectAIPlatformAccessAllowed,
+		),
+		AccessibleMachineIDs:  uuidSliceToStrings(current.AccessibleMachineIDs),
+		MaxConcurrentAgents:   intPointer(current.MaxConcurrentAgents),
+		AgentRunSummaryPrompt: stringPointerOrNil(current.AgentRunSummaryPrompt),
+		ProjectAIRetention:    mergeProjectAIRetentionPatch(current.ProjectAIRetention, patch.ProjectAIRetention),
 	}
 	if patch.Name != nil {
 		request.Name = *patch.Name

--- a/internal/httpapi/catalog_projects_requests_test.go
+++ b/internal/httpapi/catalog_projects_requests_test.go
@@ -1,0 +1,37 @@
+package httpapi
+
+import (
+	"slices"
+	"testing"
+
+	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	"github.com/google/uuid"
+)
+
+func TestParseProjectPatchRequestFiltersLegacyProjectAIScopesOnUnrelatedUpdates(t *testing.T) {
+	projectID := uuid.New()
+	orgID := uuid.New()
+	runSummaryPrompt := "Summarize blockers first."
+
+	input, err := parseProjectPatchRequest(projectID, domain.Project{
+		ID:                             projectID,
+		OrganizationID:                 orgID,
+		Name:                           "OpenASE",
+		Slug:                           "openase",
+		Status:                         domain.ProjectStatusInProgress,
+		ProjectAIPlatformAccessAllowed: []string{"projects.update", "tickets.report_usage"},
+		MaxConcurrentAgents:            1,
+	}, projectPatchRequest{
+		AgentRunSummaryPrompt: &runSummaryPrompt,
+	})
+	if err != nil {
+		t.Fatalf("parseProjectPatchRequest() error = %v", err)
+	}
+
+	if input.AgentRunSummaryPrompt != runSummaryPrompt {
+		t.Fatalf("agent run summary prompt = %q, want %q", input.AgentRunSummaryPrompt, runSummaryPrompt)
+	}
+	if got, want := input.ProjectAIPlatformAccessAllowed, []string{"projects.update"}; !slices.Equal(got, want) {
+		t.Fatalf("project ai platform access allowed = %v, want %v", got, want)
+	}
+}

--- a/internal/httpapi/catalog_test.go
+++ b/internal/httpapi/catalog_test.go
@@ -370,6 +370,64 @@ func TestCatalogCRUDRoutes(t *testing.T) {
 	}
 }
 
+func TestPatchProjectSanitizesLegacyProjectAIScopesOnUnrelatedUpdate(t *testing.T) {
+	service := newFakeCatalogService()
+	server := NewServer(
+		config.ServerConfig{Port: 40023},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		nil,
+		nil,
+		nil,
+		service,
+		nil,
+	)
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	service.organizations[orgID] = domain.Organization{
+		ID:     orgID,
+		Name:   "Acme Platform",
+		Slug:   "acme-platform",
+		Status: domain.OrganizationStatusActive,
+	}
+	service.projects[projectID] = domain.Project{
+		ID:                             projectID,
+		OrganizationID:                 orgID,
+		Name:                           "OpenASE",
+		Slug:                           "openase",
+		Status:                         domain.ProjectStatusInProgress,
+		ProjectAIPlatformAccessAllowed: []string{"projects.update", "tickets.report_usage"},
+		MaxConcurrentAgents:            2,
+	}
+
+	rec := performJSONRequest(
+		t,
+		server,
+		http.MethodPatch,
+		"/api/v1/projects/"+projectID.String(),
+		`{"agent_run_summary_prompt":"Summarize blockers first."}`,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected project patch 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Project projectResponse `json:"project"`
+	}
+	decodeResponse(t, rec, &payload)
+	if got, want := payload.Project.ProjectAIPlatformAccessAllowed, []string{"projects.update"}; !slices.Equal(got, want) {
+		t.Fatalf("project ai platform access allowed = %v, want %v", got, want)
+	}
+	if payload.Project.AgentRunSummaryPrompt == nil || *payload.Project.AgentRunSummaryPrompt != "Summarize blockers first." {
+		t.Fatalf("expected run summary prompt to update, got %+v", payload.Project)
+	}
+	if got, want := service.projects[projectID].ProjectAIPlatformAccessAllowed, []string{"projects.update"}; !slices.Equal(got, want) {
+		t.Fatalf("stored project ai platform access allowed = %v, want %v", got, want)
+	}
+}
+
 func TestSSHBootstrapRefreshesMachineHealthAfterSuccess(t *testing.T) {
 	catalog := newFakeCatalogService()
 	machineID := uuid.New()


### PR DESCRIPTION
## What changed
- sanitize stored Project AI conversation scopes before unrelated project patch requests are parsed
- reuse the scope-normalization helper where project conversation runtime contracts read persisted scopes
- add regression coverage for the standard project settings patch path, the catalog patch route, and the agent platform patch parser
- rebase the fix branch onto `main@624ff0b` before handoff

## Why
Projects that still persisted the legacy `tickets.report_usage` scope could no longer save unrelated settings such as `agent_run_summary_prompt`, because the patch handlers merged the stored scopes back into every update request and then revalidated them.

## Impact
- saving the Run summary prompt now succeeds for projects carrying legacy Project AI scope data
- unrelated project updates automatically drop unsupported legacy conversation scopes instead of failing validation
- existing explicit scope updates still go through the normal validation path

## Validation
- `go test ./internal/httpapi`
- `go test ./internal/chat ./internal/domain/agentplatform ./internal/agentplatform`
- `make openapi-check`
