### PR TITLE
ASE-309: reduce frontend state budget bypasses

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 400                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 400,
+    hardLimit: 350,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-controller-api.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-api.ts
@@ -1,0 +1,105 @@
+import type { ProjectConversation } from '$lib/api/chat'
+import type { AgentProvider } from '$lib/api/contracts'
+import type { ProjectConversationTabState } from './project-conversation-controller-state'
+
+type ProjectConversationControllerApiInput<TActions extends object> = {
+  snapshot: () => unknown
+  getProviders: () => AgentProvider[]
+  getConversations: () => ProjectConversation[]
+  getTabs: () => ProjectConversationTabState[]
+  getActiveTabId: () => string
+  getActiveTab: () => ProjectConversationTabState | null
+  getProviderId: () => string
+  getPhase: () => ProjectConversationTabState['phase'] | 'idle'
+  getSelectedProvider: () => AgentProvider | null
+  getBusy: () => boolean
+  getPending: () => boolean
+  getConversationId: () => string
+  getEntries: () => ProjectConversationTabState['entries']
+  getDraft: () => string
+  getQueuedTurns: () => ProjectConversationTabState['queuedTurns']
+  getWorkspaceDiff: () => ProjectConversationTabState['workspaceDiff']
+  getWorkspaceDiffLoading: () => boolean
+  getWorkspaceDiffError: () => string
+  getHasPendingInterrupt: () => boolean
+  getInputDisabled: () => boolean
+  getSendDisabled: () => boolean
+  getCanQueueTurn: () => boolean
+  getProviderSelectionDisabled: () => boolean
+  actions: TActions
+}
+
+export function createProjectConversationControllerApi<TActions extends object>(
+  input: ProjectConversationControllerApiInput<TActions>,
+) {
+  return {
+    snapshot: input.snapshot,
+    get providers() {
+      return input.getProviders()
+    },
+    get conversations() {
+      return input.getConversations()
+    },
+    get tabs() {
+      return input.getTabs()
+    },
+    get activeTabId() {
+      return input.getActiveTabId()
+    },
+    get activeTab() {
+      return input.getActiveTab()
+    },
+    get providerId() {
+      return input.getProviderId()
+    },
+    get phase() {
+      return input.getPhase()
+    },
+    get selectedProvider() {
+      return input.getSelectedProvider()
+    },
+    get busy() {
+      return input.getBusy()
+    },
+    get pending() {
+      return input.getPending()
+    },
+    get conversationId() {
+      return input.getConversationId()
+    },
+    get entries() {
+      return input.getEntries()
+    },
+    get draft() {
+      return input.getDraft()
+    },
+    get queuedTurns() {
+      return input.getQueuedTurns()
+    },
+    get workspaceDiff() {
+      return input.getWorkspaceDiff()
+    },
+    get workspaceDiffLoading() {
+      return input.getWorkspaceDiffLoading()
+    },
+    get workspaceDiffError() {
+      return input.getWorkspaceDiffError()
+    },
+    get hasPendingInterrupt() {
+      return input.getHasPendingInterrupt()
+    },
+    get inputDisabled() {
+      return input.getInputDisabled()
+    },
+    get sendDisabled() {
+      return input.getSendDisabled()
+    },
+    get canQueueTurn() {
+      return input.getCanQueueTurn()
+    },
+    get providerSelectionDisabled() {
+      return input.getProviderSelectionDisabled()
+    },
+    ...input.actions,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-controller.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-controller.svelte.ts
@@ -1,6 +1,7 @@
 import { type ProjectConversation } from '$lib/api/chat'
 import type { AgentProvider } from '$lib/api/contracts'
 import type { ProjectAIFocus } from './project-ai-focus'
+import { createProjectConversationControllerApi } from './project-conversation-controller-api'
 import { projectConversationHasPendingInterrupt } from './project-conversation-controller-helpers'
 import { createProjectConversationControllerOperations } from './project-conversation-controller-operations'
 import {
@@ -222,77 +223,66 @@ export function createProjectConversationController(
 
   ensureTabExists()
 
-  return {
+  return createProjectConversationControllerApi({
     snapshot,
-    get providers() {
-      return providers
-    },
-    get conversations() {
-      return conversations
-    },
-    get tabs() {
+    getProviders: () => providers,
+    getConversations: () => conversations,
+    getTabs: () => {
       void revision
       return tabs
     },
-    get activeTabId() {
-      return activeTabId
-    },
-    get activeTab() {
+    getActiveTabId: () => activeTabId,
+    getActiveTab: () => {
       void revision
       return getActiveTab()
     },
-    get providerId() {
-      return getActiveProviderId()
-    },
-    get phase() {
+    getProviderId: () => getActiveProviderId(),
+    getPhase: () => {
       void revision
       return getActiveTab()?.phase ?? 'idle'
     },
-    get selectedProvider() {
-      return providers.find((provider) => provider.id === getActiveProviderId()) ?? null
-    },
-    get busy() {
-      return (getActiveTab()?.phase ?? 'idle') !== 'idle'
-    },
-    get pending() {
+    getSelectedProvider: () =>
+      providers.find((provider) => provider.id === getActiveProviderId()) ?? null,
+    getBusy: () => (getActiveTab()?.phase ?? 'idle') !== 'idle',
+    getPending: () => {
       void revision
       const activeTab = getActiveTab()
       return activeTab ? isProjectConversationTabPending(activeTab) : false
     },
-    get conversationId() {
+    getConversationId: () => {
       void revision
       return getActiveTab()?.conversationId ?? ''
     },
-    get entries() {
+    getEntries: () => {
       void revision
       return getActiveTab()?.entries ?? []
     },
-    get draft() {
+    getDraft: () => {
       void revision
       return getActiveTab()?.draft ?? ''
     },
-    get queuedTurns() {
+    getQueuedTurns: () => {
       void revision
       return getActiveTab()?.queuedTurns ?? []
     },
-    get workspaceDiff() {
+    getWorkspaceDiff: () => {
       void revision
       return getActiveTab()?.workspaceDiff ?? null
     },
-    get workspaceDiffLoading() {
+    getWorkspaceDiffLoading: () => {
       void revision
       return getActiveTab()?.workspaceDiffLoading ?? false
     },
-    get workspaceDiffError() {
+    getWorkspaceDiffError: () => {
       void revision
       return getActiveTab()?.workspaceDiffError ?? ''
     },
-    get hasPendingInterrupt() {
+    getHasPendingInterrupt: () => {
       void revision
       const activeTab = getActiveTab()
       return activeTab ? projectConversationHasPendingInterrupt(activeTab.entries) : false
     },
-    get inputDisabled() {
+    getInputDisabled: () => {
       void revision
       const activeTab = getActiveTab()
       return (
@@ -302,7 +292,7 @@ export function createProjectConversationController(
         projectConversationHasPendingInterrupt(activeTab.entries)
       )
     },
-    get sendDisabled() {
+    getSendDisabled: () => {
       void revision
       const activeTab = getActiveTab()
       return (
@@ -313,15 +303,15 @@ export function createProjectConversationController(
         projectConversationHasPendingInterrupt(activeTab.entries)
       )
     },
-    get canQueueTurn() {
+    getCanQueueTurn: () => {
       void revision
       return canQueueOnTab(getActiveTab())
     },
-    get providerSelectionDisabled() {
+    getProviderSelectionDisabled: () => {
       void revision
       const activeTab = getActiveTab()
       return activeTab ? isProjectConversationTabPending(activeTab) : false
     },
-    ...actions,
-  }
+    actions,
+  })
 }

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-loaders.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-loaders.ts
@@ -1,0 +1,166 @@
+import {
+  getProjectConversationWorkspaceDiff,
+  type ProjectConversationWorkspaceDiff,
+  type ProjectConversationWorkspaceGitGraph,
+  type ProjectConversationWorkspaceMetadata,
+  type ProjectConversationWorkspaceRepoRefs,
+  type ProjectConversationWorkspaceTreeEntry,
+} from '$lib/api/chat'
+import { refreshWorkspaceBrowserState } from './project-conversation-workspace-browser-loader'
+import {
+  loadWorkspaceDirEntries,
+  refreshWorkspaceRepoGitContext,
+  revealWorkspaceFileInTree,
+} from './project-conversation-workspace-browser-repo-ops'
+
+type WorkspaceFileLoader = (
+  repoPath: string,
+  filePath: string,
+  options?: { silent?: boolean },
+) => Promise<void>
+
+export function createWorkspaceBrowserLoaders(input: {
+  getConversationId: () => string
+  getCurrentRequestID: () => number
+  reserveRequestID: () => number
+  onWorkspaceDiffUpdated?: (workspaceDiff: ProjectConversationWorkspaceDiff | null) => void
+  getTreeRepoPath: () => string
+  setTreeRepoPath: (repoPath: string) => void
+  getTreeNodes: () => Map<string, ProjectConversationWorkspaceTreeEntry[]>
+  getExpandedDirs: () => Set<string>
+  getOpenTabs: () => Array<{ repoPath: string; filePath: string }>
+  setMetadataLoading: (loading: boolean) => void
+  setMetadataError: (error: string) => void
+  setMetadata: (metadata: ProjectConversationWorkspaceMetadata) => void
+  clearMetadata: () => void
+  resetTreeState: () => void
+  closeAllTabs: () => void
+  setRepoRefsLoading: (loading: boolean) => void
+  setRepoRefsError: (error: string) => void
+  setRepoRefs: (repoRefs: ProjectConversationWorkspaceRepoRefs | null) => void
+  setGitGraphLoading: (loading: boolean) => void
+  setGitGraphError: (error: string) => void
+  setGitGraph: (gitGraph: ProjectConversationWorkspaceGitGraph | null) => void
+  getSelectedGitCommitID: () => string
+  setSelectedGitCommitID: (commitId: string) => void
+  setDirLoading: (dirPath: string, loading: boolean) => void
+  setTreeEntries: (dirPath: string, entries: ProjectConversationWorkspaceTreeEntry[]) => void
+  setDirExpanded: (dirPath: string, expanded: boolean) => void
+  loadFile: WorkspaceFileLoader
+}) {
+  async function refreshWorkspaceDiff() {
+    const conversationId = input.getConversationId()
+    if (!conversationId || !input.onWorkspaceDiffUpdated) return
+    const payload = await getProjectConversationWorkspaceDiff(conversationId)
+    input.onWorkspaceDiffUpdated(payload.workspaceDiff)
+  }
+
+  async function refreshRepoGitContext(repoPath = input.getTreeRepoPath()) {
+    const conversationId = input.getConversationId()
+    await refreshWorkspaceRepoGitContext({
+      conversationId,
+      repoPath,
+      treeRepoPath: input.getTreeRepoPath(),
+      selectedGitCommitID: input.getSelectedGitCommitID(),
+      setRepoRefsLoading: input.setRepoRefsLoading,
+      setRepoRefsError: input.setRepoRefsError,
+      setRepoRefs: input.setRepoRefs,
+      setGitGraphLoading: input.setGitGraphLoading,
+      setGitGraphError: input.setGitGraphError,
+      setGitGraph: input.setGitGraph,
+      setSelectedGitCommitID: input.setSelectedGitCommitID,
+      isCurrentConversation: () => input.getConversationId() === conversationId,
+    })
+  }
+
+  async function loadDirEntries(
+    dirPath: string,
+    externalRequestID?: number,
+    options: { silent?: boolean } = {},
+  ) {
+    await loadWorkspaceDirEntries({
+      conversationId: input.getConversationId(),
+      repoPath: input.getTreeRepoPath(),
+      dirPath,
+      requestID: externalRequestID ?? input.getCurrentRequestID(),
+      currentRequestID: input.getCurrentRequestID(),
+      silent: options.silent ?? false,
+      treeRepoPath: input.getTreeRepoPath(),
+      setDirLoading: input.setDirLoading,
+      setTreeEntries: input.setTreeEntries,
+    })
+  }
+
+  async function toggleDir(dirPath: string) {
+    const expandedDirs = input.getExpandedDirs()
+    if (expandedDirs.has(dirPath)) {
+      input.setDirExpanded(dirPath, false)
+      return
+    }
+    input.setDirExpanded(dirPath, true)
+    if (!input.getTreeNodes().has(dirPath)) await loadDirEntries(dirPath)
+  }
+
+  async function revealFileInTree(
+    path: string,
+    options: { requestID?: number; silent?: boolean } = {},
+  ) {
+    await revealWorkspaceFileInTree({
+      path,
+      requestID: options.requestID ?? input.getCurrentRequestID(),
+      currentRequestID: input.getCurrentRequestID,
+      hasTreeEntries: (dirPath) => input.getTreeNodes().has(dirPath),
+      setDirExpanded: input.setDirExpanded,
+      loadDirEntries,
+      options,
+    })
+  }
+
+  async function reloadFile(repoPath: string, filePath: string) {
+    if (!repoPath || !filePath) return
+    await input.loadFile(repoPath, filePath, { silent: true })
+  }
+
+  async function refreshWorkspace(preserveSelection: boolean) {
+    const conversationId = input.getConversationId()
+    const requestID = input.reserveRequestID()
+    await refreshWorkspaceBrowserState({
+      conversationId,
+      requestID,
+      getCurrentRequestID: input.getCurrentRequestID,
+      getCurrentConversationId: input.getConversationId,
+      preserveSelection,
+      treeRepoPath: input.getTreeRepoPath(),
+      treeNodes: input.getTreeNodes(),
+      expandedDirs: input.getExpandedDirs(),
+      openTabs: input.getOpenTabs(),
+      setMetadataLoading: input.setMetadataLoading,
+      setMetadataError: input.setMetadataError,
+      setMetadata: input.setMetadata,
+      clearMetadata: input.clearMetadata,
+      setTreeRepoPath: input.setTreeRepoPath,
+      resetTreeState: input.resetTreeState,
+      closeAllTabs: input.closeAllTabs,
+      clearGitContext: () => {
+        input.setRepoRefs(null)
+        input.setRepoRefsError('')
+        input.setGitGraph(null)
+        input.setGitGraphError('')
+        input.setSelectedGitCommitID('')
+      },
+      loadDirEntries,
+      loadFile: input.loadFile,
+      refreshRepoGitContext,
+    })
+  }
+
+  return {
+    refreshWorkspaceDiff,
+    refreshRepoGitContext,
+    loadDirEntries,
+    toggleDir,
+    revealFileInTree,
+    reloadFile,
+    refreshWorkspace,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,5 +1,4 @@
 import {
-  getProjectConversationWorkspaceDiff,
   type ProjectConversationWorkspaceDiff,
   type ProjectConversationWorkspaceGitGraph,
   type ProjectConversationWorkspaceMetadata,
@@ -14,13 +13,8 @@ import { createWorkspaceBrowserTreeState } from './workspace-browser-tree-state.
 import { createWorkspaceBrowserTabs } from './workspace-browser-tabs.svelte'
 import { createWorkspaceFileEditorStore } from './project-conversation-workspace-file-editor-state.svelte'
 import { createWorkspaceBrowserActions } from './project-conversation-workspace-browser-actions'
-import { refreshWorkspaceBrowserState } from './project-conversation-workspace-browser-loader'
+import { createWorkspaceBrowserLoaders } from './project-conversation-workspace-browser-loaders'
 import { loadWorkspaceFile } from './project-conversation-workspace-data-loader'
-import {
-  loadWorkspaceDirEntries,
-  refreshWorkspaceRepoGitContext,
-  revealWorkspaceFileInTree,
-} from './project-conversation-workspace-browser-repo-ops'
 import {
   buildWorkspaceFocusContext,
   workspaceSelectedChangedFiles,
@@ -57,6 +51,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   let gitGraphError = $state('')
   let selectedGitCommitID = $state('')
   let detailMode = $state<'file' | 'git_graph'>('file')
+
   function loadFile(repoPath: string, filePath: string, options: { silent?: boolean } = {}) {
     return loadWorkspaceFile(
       {
@@ -91,12 +86,65 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
     if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) metadata = nextMetadata
   }
-  async function refreshWorkspaceDiff() {
-    const conversationId = input.getConversationId()
-    if (!conversationId || !input.onWorkspaceDiffUpdated) return
-    const payload = await getProjectConversationWorkspaceDiff(conversationId)
-    input.onWorkspaceDiffUpdated(payload.workspaceDiff)
-  }
+  const {
+    refreshWorkspaceDiff,
+    refreshRepoGitContext,
+    loadDirEntries,
+    toggleDir,
+    revealFileInTree,
+    reloadFile,
+    refreshWorkspace,
+  } = createWorkspaceBrowserLoaders({
+    getConversationId: input.getConversationId,
+    getCurrentRequestID: () => loadRequestID,
+    reserveRequestID: () => ++loadRequestID,
+    onWorkspaceDiffUpdated: input.onWorkspaceDiffUpdated,
+    getTreeRepoPath: () => tabs.treeRepoPath,
+    setTreeRepoPath: tabs.setTreeRepoPath,
+    getTreeNodes: () => tree.treeNodes,
+    getExpandedDirs: () => tree.expandedDirs,
+    getOpenTabs: () => tabs.openTabs,
+    setMetadataLoading: (loading) => {
+      metadataLoading = loading
+    },
+    setMetadataError: (error) => {
+      metadataError = error
+    },
+    setMetadata,
+    clearMetadata: () => {
+      metadata = null
+    },
+    resetTreeState: () => {
+      tree.reset()
+    },
+    closeAllTabs: tabs.closeAllTabs,
+    setRepoRefsLoading: (loading) => {
+      repoRefsLoading = loading
+    },
+    setRepoRefsError: (error) => {
+      repoRefsError = error
+    },
+    setRepoRefs: (value) => {
+      repoRefs = value
+    },
+    setGitGraphLoading: (loading) => {
+      gitGraphLoading = loading
+    },
+    setGitGraphError: (error) => {
+      gitGraphError = error
+    },
+    setGitGraph: (value) => {
+      gitGraph = value
+    },
+    getSelectedGitCommitID: () => selectedGitCommitID,
+    setSelectedGitCommitID: (commitId) => {
+      selectedGitCommitID = commitId
+    },
+    setDirLoading: tree.setDirLoading,
+    setTreeEntries: tree.setTreeEntries,
+    setDirExpanded: tree.setDirExpanded,
+    loadFile,
+  })
   const editorStore = createWorkspaceFileEditorStore({
     getConversationId: input.getConversationId,
     getSelectedRepoPath: () => getActiveTab()?.repoPath ?? '',
@@ -117,6 +165,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     refreshWorkspaceDiff,
     getAutosaveEnabled: () => autosaveEnabled,
   })
+
   function reset() {
     metadata = null
     metadataLoading = false
@@ -132,122 +181,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     selectedGitCommitID = ''
     detailMode = 'file'
     editorStore.reset()
-  }
-  async function refreshWorkspace(preserveSelection: boolean) {
-    const conversationId = input.getConversationId()
-    const requestID = ++loadRequestID
-    await refreshWorkspaceBrowserState({
-      conversationId,
-      requestID,
-      getCurrentRequestID: () => loadRequestID,
-      getCurrentConversationId: input.getConversationId,
-      preserveSelection,
-      treeRepoPath: tabs.treeRepoPath,
-      treeNodes: tree.treeNodes,
-      expandedDirs: tree.expandedDirs,
-      openTabs: tabs.openTabs,
-      setMetadataLoading: (loading) => {
-        metadataLoading = loading
-      },
-      setMetadataError: (error) => {
-        metadataError = error
-      },
-      setMetadata,
-      clearMetadata: () => {
-        metadata = null
-      },
-      setTreeRepoPath: (repoPath) => {
-        tabs.setTreeRepoPath(repoPath)
-      },
-      resetTreeState: () => {
-        tree.reset()
-      },
-      closeAllTabs: tabs.closeAllTabs,
-      clearGitContext: () => {
-        repoRefs = null
-        repoRefsError = ''
-        gitGraph = null
-        gitGraphError = ''
-        selectedGitCommitID = ''
-      },
-      loadDirEntries,
-      loadFile,
-      refreshRepoGitContext,
-    })
-  }
-  async function refreshRepoGitContext(repoPath = tabs.treeRepoPath) {
-    const conversationId = input.getConversationId()
-    await refreshWorkspaceRepoGitContext({
-      conversationId,
-      repoPath,
-      treeRepoPath: tabs.treeRepoPath,
-      selectedGitCommitID,
-      setRepoRefsLoading: (loading) => {
-        repoRefsLoading = loading
-      },
-      setRepoRefsError: (error) => {
-        repoRefsError = error
-      },
-      setRepoRefs: (value) => {
-        repoRefs = value
-      },
-      setGitGraphLoading: (loading) => {
-        gitGraphLoading = loading
-      },
-      setGitGraphError: (error) => {
-        gitGraphError = error
-      },
-      setGitGraph: (value) => {
-        gitGraph = value
-      },
-      setSelectedGitCommitID: (commitId) => {
-        selectedGitCommitID = commitId
-      },
-      isCurrentConversation: () => input.getConversationId() === conversationId,
-    })
-  }
-  async function loadDirEntries(
-    dirPath: string,
-    externalRequestID?: number,
-    options: { silent?: boolean } = {},
-  ) {
-    await loadWorkspaceDirEntries({
-      conversationId: input.getConversationId(),
-      repoPath: tabs.treeRepoPath,
-      dirPath,
-      requestID: externalRequestID ?? loadRequestID,
-      currentRequestID: loadRequestID,
-      silent: options.silent ?? false,
-      treeRepoPath: tabs.treeRepoPath,
-      setDirLoading: tree.setDirLoading,
-      setTreeEntries: tree.setTreeEntries,
-    })
-  }
-  async function toggleDir(dirPath: string) {
-    if (tree.expandedDirs.has(dirPath)) {
-      tree.setDirExpanded(dirPath, false)
-      return
-    }
-    tree.setDirExpanded(dirPath, true)
-    if (!tree.treeNodes.has(dirPath)) await loadDirEntries(dirPath)
-  }
-  async function revealFileInTree(
-    path: string,
-    options: { requestID?: number; silent?: boolean } = {},
-  ) {
-    await revealWorkspaceFileInTree({
-      path,
-      requestID: options.requestID ?? loadRequestID,
-      currentRequestID: () => loadRequestID,
-      hasTreeEntries: (dirPath) => tree.treeNodes.has(dirPath),
-      setDirExpanded: tree.setDirExpanded,
-      loadDirEntries,
-      options,
-    })
-  }
-  async function reloadFile(repoPath: string, filePath: string) {
-    if (!repoPath || !filePath) return
-    await loadFile(repoPath, filePath, { silent: true })
   }
   const workspaceActions = createWorkspaceBrowserActions({
     getConversationId: input.getConversationId,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -27,6 +27,7 @@ import {
   updateWorkspaceEditorDraft,
   updateWorkspaceEditorSelection,
 } from './project-conversation-workspace-file-editor-state-transforms'
+import { createWorkspaceFileEditorStoreApi } from './project-conversation-workspace-file-editor-store-api'
 
 const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
 export function createWorkspaceFileEditorStore(input: {
@@ -314,11 +315,9 @@ export function createWorkspaceFileEditorStore(input: {
   async function saveSelectedFile(): Promise<boolean> {
     return saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
   }
-  return {
-    get selectedEditorState() {
-      return getEditorState()
-    },
-    get selectedDraftLineDiff(): WorkspaceFileLineDiffMarkers | null {
+  return createWorkspaceFileEditorStoreApi({
+    getSelectedEditorState: () => getEditorState(),
+    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
       const repoPath = input.getSelectedRepoPath()
       const filePath = input.getSelectedFilePath()
       const editor = getEditorState(repoPath, filePath)
@@ -344,5 +343,5 @@ export function createWorkspaceFileEditorStore(input: {
     saveFile,
     discardSelectedDraft,
     discardDraft,
-  }
+  })
 }

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-store-api.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-store-api.ts
@@ -1,0 +1,63 @@
+import { type ChatDiffPayload, type ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
+import type {
+  WorkspaceFileEditorState,
+  WorkspaceFileLineDiffMarkers,
+  WorkspaceRecentFile,
+} from './project-conversation-workspace-browser-state-helpers'
+import type { WorkspaceWorkingSetEntry } from './project-conversation-workspace-editor-helpers'
+
+export function createWorkspaceFileEditorStoreApi<TSelection>(input: {
+  getSelectedEditorState: () => WorkspaceFileEditorState | null
+  getSelectedDraftLineDiff: () => WorkspaceFileLineDiffMarkers | null
+  getEditorState: (repoPath?: string, filePath?: string) => WorkspaceFileEditorState | null
+  reset: () => void
+  syncFromPreview: (
+    repoPath: string,
+    filePath: string,
+    nextPreview: ProjectConversationWorkspaceFilePreview,
+  ) => void
+  updateSelectedDraft: (nextDraftContent: string) => void
+  updateSelectedSelection: (selection: TSelection) => void
+  revertSelectedDraft: () => void
+  keepSelectedDraft: () => void
+  reloadSelectedSavedVersion: () => void
+  reviewPatch: (repoPath: string, filePath: string, diff: ChatDiffPayload) => boolean
+  applyPendingPatch: (repoPath: string, filePath: string) => boolean
+  discardPendingPatch: (repoPath?: string, filePath?: string) => void
+  formatSelectedDocument: () => boolean
+  formatSelectedSelection: () => boolean
+  renameFileState: (repoPath: string, fromPath: string, toPath: string) => void
+  buildWorkingSet: (recentFiles: WorkspaceRecentFile[]) => WorkspaceWorkingSetEntry[]
+  saveSelectedFile: () => Promise<boolean>
+  saveFile: (repoPath: string, filePath: string) => Promise<boolean>
+  discardSelectedDraft: () => void
+  discardDraft: (repoPath: string, filePath: string) => void
+}) {
+  return {
+    get selectedEditorState() {
+      return input.getSelectedEditorState()
+    },
+    get selectedDraftLineDiff() {
+      return input.getSelectedDraftLineDiff()
+    },
+    getEditorState: input.getEditorState,
+    reset: input.reset,
+    syncFromPreview: input.syncFromPreview,
+    updateSelectedDraft: input.updateSelectedDraft,
+    updateSelectedSelection: input.updateSelectedSelection,
+    revertSelectedDraft: input.revertSelectedDraft,
+    keepSelectedDraft: input.keepSelectedDraft,
+    reloadSelectedSavedVersion: input.reloadSelectedSavedVersion,
+    reviewPatch: input.reviewPatch,
+    applyPendingPatch: input.applyPendingPatch,
+    discardPendingPatch: input.discardPendingPatch,
+    formatSelectedDocument: input.formatSelectedDocument,
+    formatSelectedSelection: input.formatSelectedSelection,
+    renameFileState: input.renameFileState,
+    buildWorkingSet: input.buildWorkingSet,
+    saveSelectedFile: input.saveSelectedFile,
+    saveFile: input.saveFile,
+    discardSelectedDraft: input.discardSelectedDraft,
+    discardDraft: input.discardDraft,
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager-runtime.ts
+++ b/web/src/lib/features/chat/terminal-manager-runtime.ts
@@ -1,0 +1,53 @@
+import type { TerminalInstanceRuntime } from './terminal-manager-types'
+
+const reconnectDelaysMs = [750, 1_500, 3_000, 5_000] as const
+export const TERMINAL_RECONNECT_ATTEMPT_LIMIT = reconnectDelaysMs.length
+
+let nextTerminalID = 1
+
+export function generateTerminalManagerID(): string {
+  return `term-${nextTerminalID++}`
+}
+
+export function ensureTerminalRuntime(
+  runtimeMap: Map<string, TerminalInstanceRuntime>,
+  id: string,
+) {
+  let runtime = runtimeMap.get(id)
+  if (!runtime) {
+    runtime = {
+      mountRevision: 0,
+      connectRevision: 0,
+      reconnectAttempts: 0,
+      reconnectEnabled: false,
+      reconnectTimer: null,
+      session: null,
+    }
+    runtimeMap.set(id, runtime)
+  }
+  return runtime
+}
+
+export function clearTerminalReconnectTimer(
+  runtimeMap: Map<string, TerminalInstanceRuntime>,
+  id: string,
+) {
+  const runtime = runtimeMap.get(id)
+  if (!runtime?.reconnectTimer) {
+    return
+  }
+  clearTimeout(runtime.reconnectTimer)
+  runtime.reconnectTimer = null
+}
+
+export function forgetTerminalRuntime(
+  runtimeMap: Map<string, TerminalInstanceRuntime>,
+  id: string,
+) {
+  clearTerminalReconnectTimer(runtimeMap, id)
+  runtimeMap.delete(id)
+}
+
+export function nextTerminalReconnectDelay(attempt: number) {
+  return reconnectDelaysMs[Math.min(attempt - 1, reconnectDelaysMs.length - 1)]
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -3,18 +3,19 @@ import {
   mountProjectConversationTerminal,
 } from './project-conversation-terminal-panel-helpers'
 import { createTerminalConnectionHelpers } from './terminal-manager-connection'
+import {
+  TERMINAL_RECONNECT_ATTEMPT_LIMIT,
+  clearTerminalReconnectTimer,
+  ensureTerminalRuntime,
+  forgetTerminalRuntime,
+  generateTerminalManagerID,
+  nextTerminalReconnectDelay,
+} from './terminal-manager-runtime'
 import type {
   MountedTerminal,
   TerminalInstance,
   TerminalInstanceRuntime,
 } from './terminal-manager-types'
-
-let nextId = 1
-const reconnectDelaysMs = [750, 1_500, 3_000, 5_000] as const
-
-function generateId(): string {
-  return `term-${nextId++}`
-}
 
 export function createTerminalManager(input: {
   getConversationId: () => string
@@ -43,40 +44,6 @@ export function createTerminalManager(input: {
     return instances.some((inst) => inst.id === id)
   }
 
-  function ensureRuntime(id: string) {
-    let runtime = runtimeMap.get(id)
-    if (!runtime) {
-      runtime = {
-        mountRevision: 0,
-        connectRevision: 0,
-        reconnectAttempts: 0,
-        reconnectEnabled: false,
-        reconnectTimer: null,
-        session: null,
-      }
-      runtimeMap.set(id, runtime)
-    }
-    return runtime
-  }
-
-  function clearReconnectTimer(id: string) {
-    const runtime = runtimeMap.get(id)
-    if (!runtime?.reconnectTimer) {
-      return
-    }
-    clearTimeout(runtime.reconnectTimer)
-    runtime.reconnectTimer = null
-  }
-
-  function forgetRuntime(id: string) {
-    clearReconnectTimer(id)
-    runtimeMap.delete(id)
-  }
-
-  function nextReconnectDelay(attempt: number) {
-    return reconnectDelaysMs[Math.min(attempt - 1, reconnectDelaysMs.length - 1)]
-  }
-
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
     createTerminalConnectionHelpers({
       getConversationId: input.getConversationId,
@@ -92,7 +59,7 @@ export function createTerminalManager(input: {
     // Prevent double-mount
     if (xtermMap.has(id) && elementMap.get(id) === element) return
 
-    const runtime = ensureRuntime(id)
+    const runtime = ensureTerminalRuntime(runtimeMap, id)
     runtime.mountRevision += 1
     const mountRevision = runtime.mountRevision
 
@@ -148,7 +115,7 @@ export function createTerminalManager(input: {
     xtermMap.delete(id)
     elementMap.delete(id)
     if (forget) {
-      forgetRuntime(id)
+      forgetTerminalRuntime(runtimeMap, id)
     }
   }
 
@@ -160,9 +127,9 @@ export function createTerminalManager(input: {
       terminate: boolean
     },
   ) {
-    const runtime = ensureRuntime(id)
+    const runtime = ensureTerminalRuntime(runtimeMap, id)
     runtime.reconnectEnabled = options.reconnect
-    clearReconnectTimer(id)
+    clearTerminalReconnectTimer(runtimeMap, id)
 
     const socket = socketMap.get(id)
     socketMap.delete(id)
@@ -194,7 +161,7 @@ export function createTerminalManager(input: {
       return
     }
 
-    if (runtime.reconnectAttempts >= reconnectDelaysMs.length) {
+    if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
       runtime.reconnectEnabled = false
       updateInstance(id, {
         status: 'error',
@@ -205,7 +172,7 @@ export function createTerminalManager(input: {
     }
 
     runtime.reconnectAttempts += 1
-    const delay = nextReconnectDelay(runtime.reconnectAttempts)
+    const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
     updateInstance(id, {
       status: 'connecting',
       statusMessage: `Reconnecting shell in ${label}...`,
@@ -223,7 +190,7 @@ export function createTerminalManager(input: {
   async function connectTerminal(id: string, isReconnect = false) {
     const conversationId = input.getConversationId()
     const workspacePath = input.getWorkspacePath()
-    const runtime = ensureRuntime(id)
+    const runtime = ensureTerminalRuntime(runtimeMap, id)
     const entry = xtermMap.get(id)
     if (!conversationId || !entry || !hasInstance(id)) return
 
@@ -231,7 +198,7 @@ export function createTerminalManager(input: {
     runtime.connectRevision += 1
     const connectRevision = runtime.connectRevision
     runtime.reconnectEnabled = true
-    clearReconnectTimer(id)
+    clearTerminalReconnectTimer(runtimeMap, id)
     entry.fitAddon.fit()
 
     const label = workspacePath || 'workspace root'
@@ -267,7 +234,7 @@ export function createTerminalManager(input: {
   }
 
   function createInstance(): string {
-    const id = generateId()
+    const id = generateTerminalManagerID()
     const index = instances.length + 1
     instances = [
       ...instances,

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller-helpers.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller-helpers.ts
@@ -1,0 +1,45 @@
+import { getHRAdvisor } from '$lib/api/openase'
+import type { ProjectDashboardRefreshSection } from '$lib/features/project-events'
+import type { DashboardStats, HRAdvisorSnapshot } from '../types'
+
+export const systemDashboardRefreshIntervalMs = 10_000
+
+export const emptyDashboardStats: DashboardStats = {
+  runningAgents: 0,
+  activeTickets: 0,
+  totalTickets: 0,
+  pendingApprovals: 0,
+  ticketSpendToday: 0,
+  ticketSpendTotal: 0,
+  ticketsCreatedToday: 0,
+  ticketsCompletedToday: 0,
+  ticketInputTokens: 0,
+  ticketOutputTokens: 0,
+  agentLifetimeTokens: 0,
+  avgCycleMinutes: 0,
+  prMergeRate: 0,
+}
+
+export type DashboardSection = ProjectDashboardRefreshSection | 'memory'
+
+export function mergeDashboardSections(
+  current: DashboardSection[],
+  incoming: Iterable<DashboardSection>,
+): DashboardSection[] {
+  const merged = [...current]
+  for (const section of incoming) {
+    if (!merged.includes(section)) merged.push(section)
+  }
+  return merged
+}
+
+export const toAdvisorSnapshot = (
+  payload: Awaited<ReturnType<typeof getHRAdvisor>> | null,
+): HRAdvisorSnapshot | null =>
+  payload
+    ? {
+        summary: payload.summary,
+        staffing: payload.staffing,
+        recommendations: payload.recommendations,
+      }
+    : null

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
@@ -12,7 +12,6 @@ import {
   isProjectDashboardRefreshEvent,
   readProjectDashboardRefreshSections,
   subscribeProjectEvents,
-  type ProjectDashboardRefreshSection,
 } from '$lib/features/project-events'
 import {
   markProjectOnboardingCompleted,
@@ -22,6 +21,13 @@ import { createProjectUpdatesController } from '$lib/features/project-updates'
 import { appStore } from '$lib/stores/app.svelte'
 import { toastStore } from '$lib/stores/toast.svelte'
 import {
+  type DashboardSection,
+  emptyDashboardStats,
+  mergeDashboardSections,
+  systemDashboardRefreshIntervalMs,
+  toAdvisorSnapshot,
+} from './org-dashboard-controller-helpers'
+import {
   buildActivityItems,
   buildDashboardStats,
   buildExceptionItems,
@@ -30,47 +36,6 @@ import {
 import { createOrgDashboardControllerApi } from './org-dashboard-controller-api'
 import { loadOrganizationDashboardSummary } from '../organization-summary'
 import type { DashboardStats, HRAdvisorSnapshot, MemorySnapshot, ProjectStatus } from '../types'
-
-const systemDashboardRefreshIntervalMs = 10_000
-const emptyDashboardStats: DashboardStats = {
-  runningAgents: 0,
-  activeTickets: 0,
-  totalTickets: 0,
-  pendingApprovals: 0,
-  ticketSpendToday: 0,
-  ticketSpendTotal: 0,
-  ticketsCreatedToday: 0,
-  ticketsCompletedToday: 0,
-  ticketInputTokens: 0,
-  ticketOutputTokens: 0,
-  agentLifetimeTokens: 0,
-  avgCycleMinutes: 0,
-  prMergeRate: 0,
-}
-
-type DashboardSection = ProjectDashboardRefreshSection | 'memory'
-
-function mergeDashboardSections(
-  current: DashboardSection[],
-  incoming: Iterable<DashboardSection>,
-): DashboardSection[] {
-  const merged = [...current]
-  for (const section of incoming) {
-    if (!merged.includes(section)) merged.push(section)
-  }
-  return merged
-}
-
-const toAdvisorSnapshot = (
-  payload: Awaited<ReturnType<typeof getHRAdvisor>> | null,
-): HRAdvisorSnapshot | null =>
-  payload
-    ? {
-        summary: payload.summary,
-        staffing: payload.staffing,
-        recommendations: payload.recommendations,
-      }
-    : null
 
 export function createOrgDashboardController() {
   let loading = $state(false)


### PR DESCRIPTION
## What changed
- split several oversized frontend `.svelte.ts` controllers/stores into focused helper modules so the state-layer files no longer need the temporary 400-line budget escape hatch
- lowered the shared `featureStateModule` hard limit from 400 to 350 and updated the frontend budget docs to match
- kept the refactor behavior-preserving by extracting controller API, workspace browser loader, file-editor store API, terminal runtime, and dashboard helper seams instead of rewriting feature behavior

## Why
ASE-309 is about cleaning up the temporary budget-bypass path that had accumulated around the frontend file-length checks. The current formal shape keeps state modules as a first-class category, but tightens the hard limit and moves the extra complexity into maintainable helper modules instead of carrying a broad temporary ceiling.

## Impact
- frontend budget policy is stricter again for feature state modules
- the main chat/dashboard state files are easier to navigate and extend
- no intended product behavior change

## Root cause
The frontend budget system had been relaxed to accommodate several large reactive state/controller files. That stopped the immediate budget failures, but it left a wide hard-limit bypass in place. This PR replaces that bypass with smaller, better-factored modules and a narrower shared limit.

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm install --frozen-lockfile`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec svelte-check --tsconfig ./tsconfig.json --output machine --threshold error`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run --reporter=dot src/lib/features/chat/project-conversation-controller*.test.ts src/lib/features/chat/project-conversation-workspace-browser*.test.ts src/lib/features/chat/terminal-manager.test.ts` *(1 pre-existing failure also present on `origin/main`: `project-conversation-workspace-browser-change-management.test.ts` still expects `Close README.md` while the shipped label remains `Chat Close Tab README.md`)*
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vite build --logLevel warn`
