### PR TITLE
refactor(web): formalize chat state budgets

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-session.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-session.svelte.ts
@@ -1,0 +1,111 @@
+import type {
+  ProjectConversationWorkspaceGitGraph,
+  ProjectConversationWorkspaceMetadata,
+  ProjectConversationWorkspaceRepoRefs,
+} from '$lib/api/chat'
+import { areWorkspaceMetadataEqual } from './project-conversation-workspace-browser-state-helpers'
+
+export function createWorkspaceBrowserSessionState() {
+  let metadata = $state<ProjectConversationWorkspaceMetadata | null>(null)
+  let metadataLoading = $state(false)
+  let metadataError = $state('')
+  let repoRefs = $state<ProjectConversationWorkspaceRepoRefs | null>(null)
+  let repoRefsLoading = $state(false)
+  let repoRefsError = $state('')
+  let gitGraph = $state<ProjectConversationWorkspaceGitGraph | null>(null)
+  let gitGraphLoading = $state(false)
+  let gitGraphError = $state('')
+  let selectedGitCommitID = $state('')
+  let detailMode = $state<'file' | 'git_graph'>('file')
+
+  function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
+    if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) {
+      metadata = nextMetadata
+    }
+  }
+
+  function reset() {
+    metadata = null
+    metadataLoading = false
+    metadataError = ''
+    repoRefs = null
+    repoRefsLoading = false
+    repoRefsError = ''
+    gitGraph = null
+    gitGraphLoading = false
+    gitGraphError = ''
+    selectedGitCommitID = ''
+    detailMode = 'file'
+  }
+
+  return {
+    get metadata() {
+      return metadata
+    },
+    setMetadata,
+    setMetadataLoading: (loading: boolean) => {
+      metadataLoading = loading
+    },
+    get metadataLoading() {
+      return metadataLoading
+    },
+    setMetadataError: (error: string) => {
+      metadataError = error
+    },
+    get metadataError() {
+      return metadataError
+    },
+    setRepoRefs: (value: ProjectConversationWorkspaceRepoRefs | null) => {
+      repoRefs = value
+    },
+    get repoRefs() {
+      return repoRefs
+    },
+    setRepoRefsLoading: (loading: boolean) => {
+      repoRefsLoading = loading
+    },
+    get repoRefsLoading() {
+      return repoRefsLoading
+    },
+    setRepoRefsError: (error: string) => {
+      repoRefsError = error
+    },
+    get repoRefsError() {
+      return repoRefsError
+    },
+    setGitGraph: (value: ProjectConversationWorkspaceGitGraph | null) => {
+      gitGraph = value
+    },
+    get gitGraph() {
+      return gitGraph
+    },
+    setGitGraphLoading: (loading: boolean) => {
+      gitGraphLoading = loading
+    },
+    get gitGraphLoading() {
+      return gitGraphLoading
+    },
+    setGitGraphError: (error: string) => {
+      gitGraphError = error
+    },
+    get gitGraphError() {
+      return gitGraphError
+    },
+    get selectedGitCommitID() {
+      return selectedGitCommitID
+    },
+    setSelectedGitCommitID: (commitId: string) => {
+      selectedGitCommitID = commitId
+    },
+    get detailMode() {
+      return detailMode
+    },
+    setDetailMode: (mode: 'file' | 'git_graph') => {
+      detailMode = mode
+    },
+    clearMetadata: () => {
+      metadata = null
+    },
+    reset,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,6 +1,4 @@
-import {
-  type ProjectConversationWorkspaceDiff,
-} from '$lib/api/chat'
+import { type ProjectConversationWorkspaceDiff } from '$lib/api/chat'
 import { buildProjectConversationWorkspaceBrowserStateView } from './workspace-browser-state-view'
 import {
   readWorkspaceAutosavePreference,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,8 +1,5 @@
 import {
   type ProjectConversationWorkspaceDiff,
-  type ProjectConversationWorkspaceGitGraph,
-  type ProjectConversationWorkspaceMetadata,
-  type ProjectConversationWorkspaceRepoRefs,
 } from '$lib/api/chat'
 import { buildProjectConversationWorkspaceBrowserStateView } from './workspace-browser-state-view'
 import {
@@ -20,12 +17,12 @@ import {
   workspaceSelectedChangedFiles,
 } from './project-conversation-workspace-browser-file-ops'
 import {
-  areWorkspaceMetadataEqual,
   workspaceTabKey,
   type WorkspaceRecentFile,
   type WorkspaceTab,
   type WorkspaceTabFileState,
 } from './project-conversation-workspace-browser-state-helpers'
+import { createWorkspaceBrowserSessionState } from './project-conversation-workspace-browser-session.svelte'
 export type {
   WorkspaceFileEditorState,
   WorkspaceTab,
@@ -37,20 +34,10 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   getWorkspaceDiff?: () => ProjectConversationWorkspaceDiff | null
   onWorkspaceDiffUpdated?: (workspaceDiff: ProjectConversationWorkspaceDiff | null) => void
 }) {
-  let metadata = $state<ProjectConversationWorkspaceMetadata | null>(null)
-  let metadataLoading = $state(false)
-  let metadataError = $state('')
+  const session = createWorkspaceBrowserSessionState()
   const tree = createWorkspaceBrowserTreeState()
   let autosaveEnabled = $state(readWorkspaceAutosavePreference())
   let loadRequestID = 0
-  let repoRefs = $state<ProjectConversationWorkspaceRepoRefs | null>(null)
-  let repoRefsLoading = $state(false)
-  let repoRefsError = $state('')
-  let gitGraph = $state<ProjectConversationWorkspaceGitGraph | null>(null)
-  let gitGraphLoading = $state(false)
-  let gitGraphError = $state('')
-  let selectedGitCommitID = $state('')
-  let detailMode = $state<'file' | 'git_graph'>('file')
 
   function loadFile(repoPath: string, filePath: string, options: { silent?: boolean } = {}) {
     return loadWorkspaceFile(
@@ -83,9 +70,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   function currentWorkspaceDiff() {
     return input.getWorkspaceDiff?.() ?? null
   }
-  function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
-    if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) metadata = nextMetadata
-  }
   const {
     refreshWorkspaceDiff,
     refreshRepoGitContext,
@@ -104,42 +88,22 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getTreeNodes: () => tree.treeNodes,
     getExpandedDirs: () => tree.expandedDirs,
     getOpenTabs: () => tabs.openTabs,
-    setMetadataLoading: (loading) => {
-      metadataLoading = loading
-    },
-    setMetadataError: (error) => {
-      metadataError = error
-    },
-    setMetadata,
-    clearMetadata: () => {
-      metadata = null
-    },
+    setMetadataLoading: session.setMetadataLoading,
+    setMetadataError: session.setMetadataError,
+    setMetadata: session.setMetadata,
+    clearMetadata: session.clearMetadata,
     resetTreeState: () => {
       tree.reset()
     },
     closeAllTabs: tabs.closeAllTabs,
-    setRepoRefsLoading: (loading) => {
-      repoRefsLoading = loading
-    },
-    setRepoRefsError: (error) => {
-      repoRefsError = error
-    },
-    setRepoRefs: (value) => {
-      repoRefs = value
-    },
-    setGitGraphLoading: (loading) => {
-      gitGraphLoading = loading
-    },
-    setGitGraphError: (error) => {
-      gitGraphError = error
-    },
-    setGitGraph: (value) => {
-      gitGraph = value
-    },
-    getSelectedGitCommitID: () => selectedGitCommitID,
-    setSelectedGitCommitID: (commitId) => {
-      selectedGitCommitID = commitId
-    },
+    setRepoRefsLoading: session.setRepoRefsLoading,
+    setRepoRefsError: session.setRepoRefsError,
+    setRepoRefs: session.setRepoRefs,
+    setGitGraphLoading: session.setGitGraphLoading,
+    setGitGraphError: session.setGitGraphError,
+    setGitGraph: session.setGitGraph,
+    getSelectedGitCommitID: () => session.selectedGitCommitID,
+    setSelectedGitCommitID: session.setSelectedGitCommitID,
     setDirLoading: tree.setDirLoading,
     setTreeEntries: tree.setTreeEntries,
     setDirExpanded: tree.setDirExpanded,
@@ -150,7 +114,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getSelectedRepoPath: () => getActiveTab()?.repoPath ?? '',
     getSelectedFilePath: () => getActiveTab()?.filePath ?? '',
     getRepoRefCacheKey: (repoPath) =>
-      metadata?.repos.find((repo) => repo.path === repoPath)?.currentRef.cacheKey ?? '',
+      session.metadata?.repos.find((repo) => repo.path === repoPath)?.currentRef.cacheKey ?? '',
     getPreview: (repoPath, filePath) => {
       const key = workspaceTabKey({ repoPath, filePath })
       return tabs.tabFileStates.get(key)?.preview ?? null
@@ -167,27 +131,17 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   })
 
   function reset() {
-    metadata = null
-    metadataLoading = false
-    metadataError = ''
     tree.reset()
     tabs.resetSelection()
-    repoRefs = null
-    repoRefsLoading = false
-    repoRefsError = ''
-    gitGraph = null
-    gitGraphLoading = false
-    gitGraphError = ''
-    selectedGitCommitID = ''
-    detailMode = 'file'
+    session.reset()
     editorStore.reset()
   }
   const workspaceActions = createWorkspaceBrowserActions({
     getConversationId: input.getConversationId,
     currentWorkspaceDiff,
-    getMetadata: () => metadata,
-    setMetadata,
-    getRepoRefs: () => repoRefs,
+    getMetadata: () => session.metadata,
+    setMetadata: session.setMetadata,
+    getRepoRefs: () => session.repoRefs,
     getTreeRepoPath: () => tabs.treeRepoPath,
     setTreeRepoPath: tabs.setTreeRepoPath,
     resetTree: tree.reset,
@@ -195,9 +149,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getActiveFilePath: () => tabs.activeFilePath(tabs.treeRepoPath),
     getActiveTabKey: () => tabs.activeTabKey,
     reserveRequestID: () => ++loadRequestID,
-    setDetailMode: (mode) => {
-      detailMode = mode
-    },
+    setDetailMode: session.setDetailMode,
     revealFileInTree,
     refreshRepoGitContext,
     refreshRepoGitContextAfterCheckout: async (repoPath) => {
@@ -234,9 +186,9 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     return tabs.activeFilePath(tabs.treeRepoPath)
   }
   return buildProjectConversationWorkspaceBrowserStateView({
-    getMetadata: () => metadata,
-    getMetadataLoading: () => metadataLoading,
-    getMetadataError: () => metadataError,
+    getMetadata: () => session.metadata,
+    getMetadataLoading: () => session.metadataLoading,
+    getMetadataError: () => session.metadataError,
     getTreeNodes: () => tree.treeNodes,
     getExpandedDirs: () => tree.expandedDirs,
     getLoadingDirs: () => tree.loadingDirs,
@@ -245,15 +197,16 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getTabFileStates: () => tabs.tabFileStates,
     getRecentFiles: () => tabs.recentFiles,
     getAutosaveEnabled: () => autosaveEnabled,
-    getDetailMode: () => detailMode,
-    getRepoRefs: () => repoRefs,
-    getRepoRefsLoading: () => repoRefsLoading,
-    getRepoRefsError: () => repoRefsError,
-    getGitGraph: () => gitGraph,
-    getGitGraphLoading: () => gitGraphLoading,
-    getGitGraphError: () => gitGraphError,
+    getDetailMode: () => session.detailMode,
+    getRepoRefs: () => session.repoRefs,
+    getRepoRefsLoading: () => session.repoRefsLoading,
+    getRepoRefsError: () => session.repoRefsError,
+    getGitGraph: () => session.gitGraph,
+    getGitGraphLoading: () => session.gitGraphLoading,
+    getGitGraphError: () => session.gitGraphError,
     getSelectedGitCommit: () =>
-      gitGraph?.commits.find((commit) => commit.commitId === selectedGitCommitID) ?? null,
+      session.gitGraph?.commits.find((commit) => commit.commitId === session.selectedGitCommitID) ??
+      null,
     getHasDirtyTabs: () =>
       tabs.openTabs.some(
         (tab) => editorStore.getEditorState(tab.repoPath, tab.filePath)?.dirty === true,
@@ -287,11 +240,11 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     toggleDir,
     openRepo,
     selectFile,
-    selectGitCommit: (commitId: string) => (selectedGitCommitID = commitId),
-    setDetailMode: (mode: 'file' | 'git_graph') => (detailMode = mode),
+    selectGitCommit: session.setSelectedGitCommitID,
+    setDetailMode: session.setDetailMode,
     searchPaths,
     openTab: (repoPath: string, filePath: string) => {
-      detailMode = 'file'
+      session.setDetailMode('file')
       tabs.openTab(repoPath, filePath)
     },
     closeTab: tabs.closeTab,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
@@ -1,0 +1,139 @@
+import type { WorkspaceSelectionInput } from './project-conversation-workspace-editor-helpers'
+import {
+  type WorkspaceFileEditorState,
+  type WorkspaceFileLineDiffMarkers,
+  computeDraftLineDiff,
+} from './project-conversation-workspace-browser-state-helpers'
+
+function readSelectedEditor(input: {
+  getSelectedRepoPath: () => string
+  getSelectedFilePath: () => string
+  getEditorState: (repoPath?: string, filePath?: string) => WorkspaceFileEditorState | null
+}) {
+  const repoPath = input.getSelectedRepoPath()
+  const filePath = input.getSelectedFilePath()
+  const editor = input.getEditorState(repoPath, filePath)
+  if (!repoPath || !filePath || !editor) {
+    return null
+  }
+  return { repoPath, filePath, editor }
+}
+
+export function createWorkspaceFileEditorSelectedActions(input: {
+  getSelectedRepoPath: () => string
+  getSelectedFilePath: () => string
+  getEditorState: (repoPath?: string, filePath?: string) => WorkspaceFileEditorState | null
+  setEditorState: (
+    repoPath: string,
+    filePath: string,
+    nextState: WorkspaceFileEditorState | null,
+  ) => void
+  updateDraft: (editor: WorkspaceFileEditorState, nextDraftContent: string) => WorkspaceFileEditorState
+  updateSelection: (
+    editor: WorkspaceFileEditorState,
+    selection: WorkspaceSelectionInput | null,
+  ) => WorkspaceFileEditorState
+  revertDraft: (editor: WorkspaceFileEditorState) => WorkspaceFileEditorState
+  keepDraft: (editor: WorkspaceFileEditorState) => WorkspaceFileEditorState
+  formatDocument: (args: {
+    filePath: string
+    editor: WorkspaceFileEditorState
+  }) => { ok: boolean; nextState: WorkspaceFileEditorState }
+  formatSelection: (args: {
+    filePath: string
+    editor: WorkspaceFileEditorState
+  }) => { ok: boolean; nextState: WorkspaceFileEditorState }
+  saveFile: (repoPath: string, filePath: string) => Promise<boolean>
+}) {
+  return {
+    getSelectedEditorState: () => readSelectedEditor(input)?.editor ?? null,
+    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return null
+      }
+      return computeDraftLineDiff(selected.editor.latestSavedContent, selected.editor.draftContent)
+    },
+    updateSelectedDraft: (nextDraftContent: string) => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(
+        selected.repoPath,
+        selected.filePath,
+        input.updateDraft(selected.editor, nextDraftContent),
+      )
+    },
+    updateSelectedSelection: (selection: WorkspaceSelectionInput | null) => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(
+        selected.repoPath,
+        selected.filePath,
+        input.updateSelection(selected.editor, selection),
+      )
+    },
+    revertSelectedDraft: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(selected.repoPath, selected.filePath, input.revertDraft(selected.editor))
+    },
+    keepSelectedDraft: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(selected.repoPath, selected.filePath, input.keepDraft(selected.editor))
+    },
+    discardSelectedDraft: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(selected.repoPath, selected.filePath, null)
+    },
+    formatSelectedDocument: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return false
+      }
+      const result = input.formatDocument({
+        filePath: selected.filePath,
+        editor: selected.editor,
+      })
+      input.setEditorState(selected.repoPath, selected.filePath, result.nextState)
+      return result.ok
+    },
+    formatSelectedSelection: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return false
+      }
+      const result = input.formatSelection({
+        filePath: selected.filePath,
+        editor: selected.editor,
+      })
+      input.setEditorState(selected.repoPath, selected.filePath, result.nextState)
+      return result.ok
+    },
+    reloadSelectedSavedVersion: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return
+      }
+      input.setEditorState(selected.repoPath, selected.filePath, input.revertDraft(selected.editor))
+    },
+    saveSelectedFile: () => {
+      const selected = readSelectedEditor(input)
+      if (!selected) {
+        return Promise.resolve(false)
+      }
+      return input.saveFile(selected.repoPath, selected.filePath)
+    },
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
@@ -28,21 +28,24 @@ export function createWorkspaceFileEditorSelectedActions(input: {
     filePath: string,
     nextState: WorkspaceFileEditorState | null,
   ) => void
-  updateDraft: (editor: WorkspaceFileEditorState, nextDraftContent: string) => WorkspaceFileEditorState
+  updateDraft: (
+    editor: WorkspaceFileEditorState,
+    nextDraftContent: string,
+  ) => WorkspaceFileEditorState
   updateSelection: (
     editor: WorkspaceFileEditorState,
     selection: WorkspaceSelectionInput | null,
   ) => WorkspaceFileEditorState
   revertDraft: (editor: WorkspaceFileEditorState) => WorkspaceFileEditorState
   keepDraft: (editor: WorkspaceFileEditorState) => WorkspaceFileEditorState
-  formatDocument: (args: {
-    filePath: string
-    editor: WorkspaceFileEditorState
-  }) => { ok: boolean; nextState: WorkspaceFileEditorState }
-  formatSelection: (args: {
-    filePath: string
-    editor: WorkspaceFileEditorState
-  }) => { ok: boolean; nextState: WorkspaceFileEditorState }
+  formatDocument: (args: { filePath: string; editor: WorkspaceFileEditorState }) => {
+    ok: boolean
+    nextState: WorkspaceFileEditorState
+  }
+  formatSelection: (args: { filePath: string; editor: WorkspaceFileEditorState }) => {
+    ok: boolean
+    nextState: WorkspaceFileEditorState
+  }
   saveFile: (repoPath: string, filePath: string) => Promise<boolean>
 }) {
   return {

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -8,14 +8,12 @@ import {
 } from './project-conversation-workspace-file-drafts'
 import {
   buildWorkspaceWorkingSet,
-  type WorkspaceSelectionInput,
 } from './project-conversation-workspace-editor-helpers'
 import {
-  computeDraftLineDiff,
   type WorkspaceFileEditorState,
-  type WorkspaceFileLineDiffMarkers,
   type WorkspaceRecentFile,
 } from './project-conversation-workspace-browser-state-helpers'
+import { createWorkspaceFileEditorSelectedActions } from './project-conversation-workspace-file-editor-selected-actions'
 import {
   applyWorkspaceEditorPendingPatch,
   formatWorkspaceEditorDocument,
@@ -151,54 +149,9 @@ export function createWorkspaceFileEditorStore(input: {
     }
     editorStates = new Map()
   }
-  function updateSelectedDraft(nextDraftContent: string) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
-  }
-  function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
-  }
-  function revertSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
-  }
-  function keepSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
-  }
-  function discardSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
-  }
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
     setEditorState(repoPath, filePath, null)
-  }
-  function reloadSelectedSavedVersion() {
-    revertSelectedDraft()
   }
   function reviewPatch(repoPath: string, filePath: string, diff: ChatDiffPayload) {
     const editor = getEditorState(repoPath, filePath)
@@ -231,28 +184,6 @@ export function createWorkspaceFileEditorStore(input: {
       pendingPatch: null,
       errorMessage: '',
     })
-  }
-  function formatSelectedDocument() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorDocument({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
-  }
-  function formatSelectedSelection() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorSelection({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
   }
   function renameFileState(repoPath: string, fromPath: string, toPath: string) {
     const fromKey = selectedFileStorageKey(repoPath, fromPath)
@@ -312,36 +243,40 @@ export function createWorkspaceFileEditorStore(input: {
       setPreview: input.setPreview,
     })
   }
-  async function saveSelectedFile(): Promise<boolean> {
-    return saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
-  }
+  const selectedActions = createWorkspaceFileEditorSelectedActions({
+    getSelectedRepoPath: input.getSelectedRepoPath,
+    getSelectedFilePath: input.getSelectedFilePath,
+    getEditorState,
+    setEditorState,
+    updateDraft: updateWorkspaceEditorDraft,
+    updateSelection: updateWorkspaceEditorSelection,
+    revertDraft: revertWorkspaceEditorDraft,
+    keepDraft: keepWorkspaceEditorDraft,
+    formatDocument: formatWorkspaceEditorDocument,
+    formatSelection: formatWorkspaceEditorSelection,
+    saveFile,
+  })
   return createWorkspaceFileEditorStoreApi({
-    getSelectedEditorState: () => getEditorState(),
-    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
-      const repoPath = input.getSelectedRepoPath()
-      const filePath = input.getSelectedFilePath()
-      const editor = getEditorState(repoPath, filePath)
-      if (!editor || !filePath) return null
-      return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
-    },
+    getSelectedEditorState: selectedActions.getSelectedEditorState,
+    getSelectedDraftLineDiff: selectedActions.getSelectedDraftLineDiff,
     getEditorState,
     reset,
     syncFromPreview,
-    updateSelectedDraft,
-    updateSelectedSelection,
-    revertSelectedDraft,
-    keepSelectedDraft,
-    reloadSelectedSavedVersion,
+    updateSelectedDraft: selectedActions.updateSelectedDraft,
+    updateSelectedSelection: selectedActions.updateSelectedSelection,
+    revertSelectedDraft: selectedActions.revertSelectedDraft,
+    keepSelectedDraft: selectedActions.keepSelectedDraft,
+    reloadSelectedSavedVersion: selectedActions.reloadSelectedSavedVersion,
     reviewPatch,
     applyPendingPatch,
     discardPendingPatch,
-    formatSelectedDocument,
-    formatSelectedSelection,
+    formatSelectedDocument: selectedActions.formatSelectedDocument,
+    formatSelectedSelection: selectedActions.formatSelectedSelection,
     renameFileState,
     buildWorkingSet,
-    saveSelectedFile,
+    saveSelectedFile: selectedActions.saveSelectedFile,
     saveFile,
-    discardSelectedDraft,
+    discardSelectedDraft: selectedActions.discardSelectedDraft,
     discardDraft,
   })
 }

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -6,9 +6,7 @@ import {
   savePersistedWorkspaceFileDraft,
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
-import {
-  buildWorkspaceWorkingSet,
-} from './project-conversation-workspace-editor-helpers'
+import { buildWorkspaceWorkingSet } from './project-conversation-workspace-editor-helpers'
 import {
   type WorkspaceFileEditorState,
   type WorkspaceRecentFile,

--- a/web/src/lib/features/chat/terminal-manager-panel-state.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager-panel-state.svelte.ts
@@ -1,0 +1,94 @@
+import type { TerminalInstance } from './terminal-manager-types'
+
+let nextTerminalID = 1
+
+export function createTerminalManagerPanelState() {
+  let instances = $state<TerminalInstance[]>([])
+  let activeId = $state('')
+  let panelOpen = $state(false)
+
+  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
+    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
+  }
+
+  function getActiveInstance(): TerminalInstance | undefined {
+    return instances.find((instance) => instance.id === activeId)
+  }
+
+  function hasInstance(id: string) {
+    return instances.some((instance) => instance.id === id)
+  }
+
+  function createInstance(): string {
+    const id = `term-${nextTerminalID++}`
+    const index = instances.length + 1
+    instances = [
+      ...instances,
+      {
+        id,
+        label: `Terminal ${index}`,
+        status: 'idle',
+        statusMessage: 'Connecting...',
+        sessionID: '',
+      },
+    ]
+    activeId = id
+    return id
+  }
+
+  function removeInstance(id: string) {
+    const closingIndex = instances.findIndex((instance) => instance.id === id)
+    instances = instances.filter((instance) => instance.id !== id)
+    if (activeId === id) {
+      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
+      activeId = nextActive?.id ?? ''
+    }
+    if (instances.length === 0) {
+      panelOpen = false
+    }
+  }
+
+  function openPanel() {
+    panelOpen = true
+    if (instances.length === 0) {
+      createInstance()
+    }
+  }
+
+  function togglePanel() {
+    panelOpen = !panelOpen
+    if (panelOpen && instances.length === 0) {
+      createInstance()
+    }
+  }
+
+  return {
+    get instances() {
+      return instances
+    },
+    get activeId() {
+      return activeId
+    },
+    set activeId(id: string) {
+      activeId = id
+    },
+    get panelOpen() {
+      return panelOpen
+    },
+    updateInstance,
+    getActiveInstance,
+    hasInstance,
+    createInstance,
+    removeInstance,
+    openPanel,
+    togglePanel,
+    closePanel: () => {
+      panelOpen = false
+    },
+    reset: () => {
+      instances = []
+      activeId = ''
+      panelOpen = false
+    },
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager-runtime.ts
+++ b/web/src/lib/features/chat/terminal-manager-runtime.ts
@@ -3,12 +3,6 @@ import type { TerminalInstanceRuntime } from './terminal-manager-types'
 const reconnectDelaysMs = [750, 1_500, 3_000, 5_000] as const
 export const TERMINAL_RECONNECT_ATTEMPT_LIMIT = reconnectDelaysMs.length
 
-let nextTerminalID = 1
-
-export function generateTerminalManagerID(): string {
-  return `term-${nextTerminalID++}`
-}
-
 export function ensureTerminalRuntime(
   runtimeMap: Map<string, TerminalInstanceRuntime>,
   id: string,

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -3,27 +3,21 @@ import {
   mountProjectConversationTerminal,
 } from './project-conversation-terminal-panel-helpers'
 import { createTerminalConnectionHelpers } from './terminal-manager-connection'
+import { createTerminalManagerPanelState } from './terminal-manager-panel-state.svelte'
 import {
   TERMINAL_RECONNECT_ATTEMPT_LIMIT,
   clearTerminalReconnectTimer,
   ensureTerminalRuntime,
   forgetTerminalRuntime,
-  generateTerminalManagerID,
   nextTerminalReconnectDelay,
 } from './terminal-manager-runtime'
-import type {
-  MountedTerminal,
-  TerminalInstance,
-  TerminalInstanceRuntime,
-} from './terminal-manager-types'
+import type { MountedTerminal, TerminalInstanceRuntime } from './terminal-manager-types'
 
 export function createTerminalManager(input: {
   getConversationId: () => string
   getWorkspacePath: () => string
 }) {
-  let instances = $state<TerminalInstance[]>([])
-  let activeId = $state<string>('')
-  let panelOpen = $state(false)
+  const panelState = createTerminalManagerPanelState()
 
   // Internal state per instance (not reactive, keyed by id)
   const xtermMap = new Map<string, MountedTerminal>()
@@ -32,27 +26,15 @@ export function createTerminalManager(input: {
   const resizeObserverMap = new Map<string, ResizeObserver>()
   const runtimeMap = new Map<string, TerminalInstanceRuntime>()
 
-  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
-    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
-  }
-
-  function getActiveInstance(): TerminalInstance | undefined {
-    return instances.find((i) => i.id === activeId)
-  }
-
-  function hasInstance(id: string) {
-    return instances.some((inst) => inst.id === id)
-  }
-
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
     createTerminalConnectionHelpers({
       getConversationId: input.getConversationId,
-      hasInstance,
-      listInstances: () => instances,
+      hasInstance: panelState.hasInstance,
+      listInstances: () => panelState.instances,
       runtimeMap,
       socketMap,
       scheduleReconnect,
-      updateInstance,
+      updateInstance: panelState.updateInstance,
     })
 
   async function mountTerminal(id: string, element: HTMLDivElement) {
@@ -82,7 +64,7 @@ export function createTerminalManager(input: {
     })
 
     if (
-      !hasInstance(id) ||
+      !panelState.hasInstance(id) ||
       runtimeMap.get(id)?.mountRevision !== mountRevision ||
       elementMap.get(id) !== element
     ) {
@@ -145,7 +127,11 @@ export function createTerminalManager(input: {
       runtime.session = null
     }
     if (options.updateStatus) {
-      updateInstance(id, { status: 'closed', statusMessage: 'Terminal closed.', sessionID: '' })
+      panelState.updateInstance(id, {
+        status: 'closed',
+        statusMessage: 'Terminal closed.',
+        sessionID: '',
+      })
     }
   }
 
@@ -155,7 +141,7 @@ export function createTerminalManager(input: {
       !runtime ||
       !runtime.reconnectEnabled ||
       !runtime.session ||
-      !hasInstance(id) ||
+      !panelState.hasInstance(id) ||
       !xtermMap.has(id)
     ) {
       return
@@ -163,7 +149,7 @@ export function createTerminalManager(input: {
 
     if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
       runtime.reconnectEnabled = false
-      updateInstance(id, {
+      panelState.updateInstance(id, {
         status: 'error',
         statusMessage: 'Terminal disconnected. Reconnect attempts exhausted.',
         sessionID: '',
@@ -173,14 +159,14 @@ export function createTerminalManager(input: {
 
     runtime.reconnectAttempts += 1
     const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
-    updateInstance(id, {
+    panelState.updateInstance(id, {
       status: 'connecting',
       statusMessage: `Reconnecting shell in ${label}...`,
       sessionID: '',
     })
     runtime.reconnectTimer = setTimeout(() => {
       runtime.reconnectTimer = null
-      if (!runtime.reconnectEnabled || !hasInstance(id) || !xtermMap.has(id)) {
+      if (!runtime.reconnectEnabled || !panelState.hasInstance(id) || !xtermMap.has(id)) {
         return
       }
       void connectTerminal(id, true)
@@ -192,7 +178,7 @@ export function createTerminalManager(input: {
     const workspacePath = input.getWorkspacePath()
     const runtime = ensureTerminalRuntime(runtimeMap, id)
     const entry = xtermMap.get(id)
-    if (!conversationId || !entry || !hasInstance(id)) return
+    if (!conversationId || !entry || !panelState.hasInstance(id)) return
 
     closeSocket(id, { updateStatus: false, reconnect: false, terminate: false })
     runtime.connectRevision += 1
@@ -202,7 +188,7 @@ export function createTerminalManager(input: {
     entry.fitAddon.fit()
 
     const label = workspacePath || 'workspace root'
-    updateInstance(id, { label })
+    panelState.updateInstance(id, { label })
     setConnectingStatus(id, label, isReconnect)
 
     const session = await resolveTerminalSession({
@@ -222,7 +208,7 @@ export function createTerminalManager(input: {
     }
 
     runtime.session = session
-    updateInstance(id, { sessionID: session.id })
+    panelState.updateInstance(id, { sessionID: session.id })
     attachSocket({
       id,
       session,
@@ -233,62 +219,16 @@ export function createTerminalManager(input: {
     })
   }
 
-  function createInstance(): string {
-    const id = generateTerminalManagerID()
-    const index = instances.length + 1
-    instances = [
-      ...instances,
-      {
-        id,
-        label: `Terminal ${index}`,
-        status: 'idle',
-        statusMessage: 'Connecting...',
-        sessionID: '',
-      },
-    ]
-    activeId = id
-    return id
-  }
-
   function removeInstance(id: string) {
-    const closingIndex = instances.findIndex((inst) => inst.id === id)
     unmountTerminal(id, true)
-    instances = instances.filter((i) => i.id !== id)
-    if (activeId === id) {
-      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
-      activeId = nextActive?.id ?? ''
-    }
-    if (instances.length === 0) {
-      panelOpen = false
-    }
-  }
-
-  function openPanel() {
-    panelOpen = true
-    if (instances.length === 0) {
-      createInstance()
-    }
-  }
-
-  function togglePanel() {
-    if (panelOpen) {
-      panelOpen = false
-    } else {
-      openPanel()
-    }
-  }
-
-  function closePanel() {
-    panelOpen = false
+    panelState.removeInstance(id)
   }
 
   function disposeAll() {
-    for (const inst of instances) {
+    for (const inst of panelState.instances) {
       unmountTerminal(inst.id, true)
     }
-    instances = []
-    activeId = ''
-    panelOpen = false
+    panelState.reset()
   }
 
   /** Refits all visible terminals (call after panel resize). */
@@ -300,25 +240,25 @@ export function createTerminalManager(input: {
 
   return {
     get instances() {
-      return instances
+      return panelState.instances
     },
     get activeId() {
-      return activeId
+      return panelState.activeId
     },
     set activeId(id: string) {
-      activeId = id
+      panelState.activeId = id
     },
     get panelOpen() {
-      return panelOpen
+      return panelState.panelOpen
     },
-    getActiveInstance,
+    getActiveInstance: panelState.getActiveInstance,
     mountTerminal,
     connectTerminal,
-    createInstance,
+    createInstance: panelState.createInstance,
     removeInstance,
-    openPanel,
-    togglePanel,
-    closePanel,
+    openPanel: panelState.openPanel,
+    togglePanel: panelState.togglePanel,
+    closePanel: panelState.closePanel,
     disposeAll,
     refitAll,
   }


### PR DESCRIPTION
## Summary
- extract small helper modules for workspace browser session, file editor selected actions, and terminal panel state so the chat state stores stay maintainable
- shrink the remaining oversized chat state modules below the formal `featureStateModule` threshold and drop the temporary 350-line bypass
- update the shared file-budget config and README so the enforced `lib/features/**/*.svelte.{ts,js}` hard limit is now 325

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run ci`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/chat/terminal-manager.test.ts src/lib/features/chat/project-conversation-workspace-browser-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout-refresh.test.ts`
- GitHub Actions PR checks: `Frontend Checks`, `Frontend API Audit Check`, and `Desktop Checks` all passed on PR #772

Closes ASE-330.
