### PR TITLE
ASE-335: upgrade github.com/jackc/pgx/v5 to v5.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/itchyny/gojq v0.12.17
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/lib/pq v1.10.9
 	github.com/nikolalohinski/gonja/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
## What
- upgrade `github.com/jackc/pgx/v5` from `v5.9.0` to `v5.9.2`
- refresh `go.sum` to the patched module digest
- review pgx usage for simple-protocol exposure

## Review notes
- current pgx usage is limited to `pgx.Connect(...)` in `internal/infra/event/pgnotify.go` and the `database/sql` pgx driver registration in `internal/doctor/doctor.go`
- no explicit `PreferSimpleProtocol`, `QueryExecModeSimpleProtocol`, or `default_query_exec_mode` usage was found in the repo

## Validation
- `./scripts/ci/backend_coverage.sh` (pass in plain progress mode)
- `./scripts/ci/with_clean_openase_test_env.sh go test -count=1 -timeout=20m ./internal/provider ./internal/infra/userservice ./internal/cli`
- `make lint`
- `make lint-depguard`
- `make lint-architecture`

## Notes
- `OPENASE_GO_TEST_PROGRESS_MODE=json ./scripts/ci/backend_coverage.sh` hit an existing unrelated local failure in `TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync` under `./internal/orchestrator`; the dependency bump does not touch orchestrator or runtime-launcher code.
