### PR TITLE
[ASE-352] Tighten frontend state budget cleanup

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -226,13 +226,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     selectPreviousChangedFile,
     reviewPatch,
   } = workspaceActions
-  function setAutosaveEnabled(enabled: boolean) {
-    autosaveEnabled = enabled
-    storeWorkspaceAutosavePreference(enabled)
-  }
-  function activeFilePath() {
-    return tabs.activeFilePath(tabs.treeRepoPath)
-  }
+  function activeFilePath() { return tabs.activeFilePath(tabs.treeRepoPath) }
   return buildProjectConversationWorkspaceBrowserStateView({
     getMetadata: () => metadata,
     getMetadataLoading: () => metadataLoading,
@@ -303,7 +297,10 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     refreshWorkspaceDiff,
     checkoutBlockers,
     checkoutBranch,
-    setAutosaveEnabled,
+    setAutosaveEnabled: (enabled: boolean) => {
+      autosaveEnabled = enabled
+      storeWorkspaceAutosavePreference(enabled)
+    },
     selectNextChangedFile,
     selectPreviousChangedFile,
     reviewPatch,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -226,7 +226,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     selectPreviousChangedFile,
     reviewPatch,
   } = workspaceActions
-  function activeFilePath() { return tabs.activeFilePath(tabs.treeRepoPath) }
+  const activeFilePath = () => tabs.activeFilePath(tabs.treeRepoPath)
   return buildProjectConversationWorkspaceBrowserStateView({
     getMetadata: () => metadata,
     getMetadataLoading: () => metadataLoading,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-runtime.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-runtime.ts
@@ -1,0 +1,48 @@
+import type { ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
+import { buildWorkspaceWorkingSet } from './project-conversation-workspace-editor-helpers'
+import type {
+  WorkspaceFileEditorState,
+  WorkspaceRecentFile,
+} from './project-conversation-workspace-browser-state-helpers'
+
+export function shouldAutosaveWorkspaceFileEditor(args: {
+  autosaveEnabled: boolean | undefined
+  editorState: WorkspaceFileEditorState
+  preview: ProjectConversationWorkspaceFilePreview | null
+}) {
+  return Boolean(
+    args.autosaveEnabled &&
+      args.editorState.dirty &&
+      args.editorState.savePhase !== 'saving' &&
+      args.editorState.savePhase !== 'conflict' &&
+      !args.editorState.externalChange &&
+      args.preview?.writable === true,
+  )
+}
+
+export function buildWorkspaceFileEditorWorkingSet(args: {
+  recentFiles: WorkspaceRecentFile[]
+  getEditorState: (repoPath: string, filePath: string) => WorkspaceFileEditorState | null
+  getPreview: (
+    repoPath: string,
+    filePath: string,
+  ) => ProjectConversationWorkspaceFilePreview | null
+}) {
+  return buildWorkspaceWorkingSet(
+    args.recentFiles.flatMap((item) => {
+      const editor = args.getEditorState(item.repoPath, item.filePath)
+      const preview = args.getPreview(item.repoPath, item.filePath)
+      const content = editor?.draftContent ?? preview?.content ?? ''
+      if (!content) {
+        return []
+      }
+      return [
+        {
+          filePath: item.filePath,
+          content,
+          dirty: editor?.dirty ?? false,
+        },
+      ]
+    }),
+  )
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-runtime.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state-runtime.ts
@@ -12,21 +12,18 @@ export function shouldAutosaveWorkspaceFileEditor(args: {
 }) {
   return Boolean(
     args.autosaveEnabled &&
-      args.editorState.dirty &&
-      args.editorState.savePhase !== 'saving' &&
-      args.editorState.savePhase !== 'conflict' &&
-      !args.editorState.externalChange &&
-      args.preview?.writable === true,
+    args.editorState.dirty &&
+    args.editorState.savePhase !== 'saving' &&
+    args.editorState.savePhase !== 'conflict' &&
+    !args.editorState.externalChange &&
+    args.preview?.writable === true,
   )
 }
 
 export function buildWorkspaceFileEditorWorkingSet(args: {
   recentFiles: WorkspaceRecentFile[]
   getEditorState: (repoPath: string, filePath: string) => WorkspaceFileEditorState | null
-  getPreview: (
-    repoPath: string,
-    filePath: string,
-  ) => ProjectConversationWorkspaceFilePreview | null
+  getPreview: (repoPath: string, filePath: string) => ProjectConversationWorkspaceFilePreview | null
 }) {
   return buildWorkspaceWorkingSet(
     args.recentFiles.flatMap((item) => {

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -7,7 +7,6 @@ import {
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
 import {
-  buildWorkspaceWorkingSet,
   type WorkspaceSelectionInput,
 } from './project-conversation-workspace-editor-helpers'
 import {
@@ -27,6 +26,10 @@ import {
   updateWorkspaceEditorDraft,
   updateWorkspaceEditorSelection,
 } from './project-conversation-workspace-file-editor-state-transforms'
+import {
+  buildWorkspaceFileEditorWorkingSet,
+  shouldAutosaveWorkspaceFileEditor,
+} from './project-conversation-workspace-file-editor-state-runtime'
 import { createWorkspaceFileEditorStoreApi } from './project-conversation-workspace-file-editor-store-api'
 
 const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
@@ -112,12 +115,11 @@ export function createWorkspaceFileEditorStore(input: {
     const key = selectedFileStorageKey(repoPath, filePath)
     cancelAutosave(key)
     if (
-      !input.getAutosaveEnabled?.() ||
-      !editorState.dirty ||
-      editorState.savePhase === 'saving' ||
-      editorState.savePhase === 'conflict' ||
-      editorState.externalChange ||
-      input.getPreview(repoPath, filePath)?.writable !== true
+      !shouldAutosaveWorkspaceFileEditor({
+        autosaveEnabled: input.getAutosaveEnabled?.(),
+        editorState,
+        preview: input.getPreview(repoPath, filePath),
+      })
     ) {
       return
     }
@@ -151,55 +153,37 @@ export function createWorkspaceFileEditorStore(input: {
     }
     editorStates = new Map()
   }
-  function updateSelectedDraft(nextDraftContent: string) {
+  function updateSelectedEditorState(
+    update: (editor: WorkspaceFileEditorState, filePath: string) => WorkspaceFileEditorState,
+  ) {
     const repoPath = input.getSelectedRepoPath()
     const filePath = input.getSelectedFilePath()
     const editor = getEditorState(repoPath, filePath)
     if (!editor || !repoPath || !filePath) {
-      return
+      return null
     }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
+    const nextState = update(editor, filePath)
+    setEditorState(repoPath, filePath, nextState)
+    return nextState
+  }
+  function updateSelectedDraft(nextDraftContent: string) {
+    updateSelectedEditorState((editor) => updateWorkspaceEditorDraft(editor, nextDraftContent))
   }
   function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
+    updateSelectedEditorState((editor) => updateWorkspaceEditorSelection(editor, selection))
   }
   function revertSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
+    updateSelectedEditorState((editor) => revertWorkspaceEditorDraft(editor))
   }
   function keepSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
+    updateSelectedEditorState((editor) => keepWorkspaceEditorDraft(editor))
   }
-  function discardSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
-  }
+  function discardSelectedDraft() { discardDraft(input.getSelectedRepoPath(), input.getSelectedFilePath()) }
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
     setEditorState(repoPath, filePath, null)
   }
-  function reloadSelectedSavedVersion() {
-    revertSelectedDraft()
-  }
+  function reloadSelectedSavedVersion() { revertSelectedDraft() }
   function reviewPatch(repoPath: string, filePath: string, diff: ChatDiffPayload) {
     const editor = getEditorState(repoPath, filePath)
     if (!editor) {
@@ -272,25 +256,11 @@ export function createWorkspaceFileEditorStore(input: {
     }
   }
   function buildWorkingSet(recentFiles: WorkspaceRecentFile[]) {
-    return buildWorkspaceWorkingSet(
-      recentFiles
-        .map((item) => {
-          const editor = getEditorState(item.repoPath, item.filePath)
-          const preview = input.getPreview(item.repoPath, item.filePath)
-          const content = editor?.draftContent ?? preview?.content ?? ''
-          if (!content) {
-            return null
-          }
-          return {
-            filePath: item.filePath,
-            content,
-            dirty: editor?.dirty ?? false,
-          }
-        })
-        .filter(
-          (item): item is { filePath: string; content: string; dirty: boolean } => item != null,
-        ),
-    )
+    return buildWorkspaceFileEditorWorkingSet({
+      recentFiles,
+      getEditorState,
+      getPreview: input.getPreview,
+    })
   }
   async function saveFile(repoPath: string, filePath: string): Promise<boolean> {
     const conversationId = input.getConversationId()

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -6,9 +6,7 @@ import {
   savePersistedWorkspaceFileDraft,
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
-import {
-  type WorkspaceSelectionInput,
-} from './project-conversation-workspace-editor-helpers'
+import { type WorkspaceSelectionInput } from './project-conversation-workspace-editor-helpers'
 import {
   computeDraftLineDiff,
   type WorkspaceFileEditorState,
@@ -178,12 +176,16 @@ export function createWorkspaceFileEditorStore(input: {
   function keepSelectedDraft() {
     updateSelectedEditorState((editor) => keepWorkspaceEditorDraft(editor))
   }
-  function discardSelectedDraft() { discardDraft(input.getSelectedRepoPath(), input.getSelectedFilePath()) }
+  function discardSelectedDraft() {
+    discardDraft(input.getSelectedRepoPath(), input.getSelectedFilePath())
+  }
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
     setEditorState(repoPath, filePath, null)
   }
-  function reloadSelectedSavedVersion() { revertSelectedDraft() }
+  function reloadSelectedSavedVersion() {
+    revertSelectedDraft()
+  }
   function reviewPatch(repoPath: string, filePath: string, diff: ChatDiffPayload) {
     const editor = getEditorState(repoPath, filePath)
     if (!editor) {

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -264,9 +264,7 @@ export function createTerminalManager(input: {
   }
   function openPanel() {
     panelOpen = true
-    if (instances.length === 0) {
-      createInstance()
-    }
+    if (instances.length === 0) createInstance()
   }
 
   function togglePanel() {
@@ -277,7 +275,9 @@ export function createTerminalManager(input: {
     openPanel()
   }
 
-  function closePanel() { panelOpen = false }
+  function closePanel() {
+    panelOpen = false
+  }
 
   function disposeAll() {
     for (const inst of instances) {

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -262,7 +262,6 @@ export function createTerminalManager(input: {
       panelOpen = false
     }
   }
-
   function openPanel() {
     panelOpen = true
     if (instances.length === 0) {
@@ -273,14 +272,12 @@ export function createTerminalManager(input: {
   function togglePanel() {
     if (panelOpen) {
       panelOpen = false
-    } else {
-      openPanel()
+      return
     }
+    openPanel()
   }
 
-  function closePanel() {
-    panelOpen = false
-  }
+  function closePanel() { panelOpen = false }
 
   function disposeAll() {
     for (const inst of instances) {


### PR DESCRIPTION
## What changed
- tighten the `featureStateModule` hard budget from 350 to 325 lines so the temporary looser state-module allowance no longer acts as a standing bypass
- extract shared workspace file-editor runtime helpers for autosave gating and working-set construction
- trim the chat workspace browser and terminal manager state modules so the affected `.svelte.ts` files fit the formalized budget without changing behavior

## Why
`project-conversation-workspace-file-editor-state.svelte.ts`, `project-conversation-workspace-browser-state.svelte.ts`, and `terminal-manager.svelte.ts` had been relying on the more permissive feature-state budget. This PR replaces that temporary slack with smaller dedicated helpers so the budget becomes enforceable again.

## Impact
- no intended product behavior change
- workspace editor autosave and working-set logic now live behind explicit reusable helpers
- chat workspace state modules are back under the tightened budget threshold

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/chat/project-conversation-workspace-browser-state.test.ts src/lib/features/chat/terminal-manager.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci`

Closes ASE-352.
