### PR TITLE
ASE-362 Formalize workspace editor budget cleanup

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -71,18 +71,11 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     renameEditorFileState: (repoPath, fromPath, toPath) =>
       editorStore.renameFileState(repoPath, fromPath, toPath),
   })
-  function patchTabFileState(key: string, patch: Partial<WorkspaceTabFileState>) {
+  const patchTabFileState = (key: string, patch: Partial<WorkspaceTabFileState>) =>
     tabs.patchTabFileState(key, patch)
-  }
-  function getActiveTab(): WorkspaceTab | null {
-    return tabs.getActiveTab()
-  }
-  function getActiveTabFileState(): WorkspaceTabFileState {
-    return tabs.getActiveTabFileState()
-  }
-  function currentWorkspaceDiff() {
-    return input.getWorkspaceDiff?.() ?? null
-  }
+  const getActiveTab = (): WorkspaceTab | null => tabs.getActiveTab()
+  const getActiveTabFileState = (): WorkspaceTabFileState => tabs.getActiveTabFileState()
+  const currentWorkspaceDiff = () => input.getWorkspaceDiff?.() ?? null
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
     if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) metadata = nextMetadata
   }
@@ -230,9 +223,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     autosaveEnabled = enabled
     storeWorkspaceAutosavePreference(enabled)
   }
-  function activeFilePath() {
-    return tabs.activeFilePath(tabs.treeRepoPath)
-  }
+  const activeFilePath = () => tabs.activeFilePath(tabs.treeRepoPath)
   return buildProjectConversationWorkspaceBrowserStateView({
     getMetadata: () => metadata,
     getMetadataLoading: () => metadataLoading,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
+import type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state-helpers'
+import {
+  buildWorkspaceEditorWorkingSet,
+  getSelectedWorkspaceDraftLineDiff,
+} from './project-conversation-workspace-file-editor-derived'
+
+function buildPreview(
+  overrides: Partial<ProjectConversationWorkspaceFilePreview> = {},
+): ProjectConversationWorkspaceFilePreview {
+  return {
+    conversationId: 'conversation-1',
+    repoPath: 'services/openase',
+    path: 'README.md',
+    sizeBytes: 12,
+    mediaType: 'text/plain',
+    previewKind: 'text',
+    truncated: false,
+    content: 'preview content',
+    revision: 'rev-1',
+    writable: true,
+    readOnlyReason: '',
+    encoding: 'utf-8',
+    lineEnding: 'lf',
+    ...overrides,
+  }
+}
+
+function buildEditorState(
+  overrides: Partial<WorkspaceFileEditorState> = {},
+): WorkspaceFileEditorState {
+  return {
+    baseSavedContent: 'line one\nline two\n',
+    baseSavedRevision: 'rev-1',
+    latestSavedContent: 'line one\nline two\n',
+    latestSavedRevision: 'rev-1',
+    draftContent: 'line one\nline two\n',
+    dirty: false,
+    savePhase: 'idle',
+    externalChange: false,
+    errorMessage: '',
+    encoding: 'utf-8',
+    lineEnding: 'lf',
+    lastSavedAt: '',
+    selection: null,
+    pendingPatch: null,
+    ...overrides,
+  }
+}
+
+describe('buildWorkspaceEditorWorkingSet', () => {
+  it('prefers draft content, falls back to preview content, and skips empty files', () => {
+    const previews = new Map<string, ProjectConversationWorkspaceFilePreview>([
+      ['services/openase::README.md', buildPreview({ path: 'README.md', content: 'preview readme' })],
+      ['services/openase::docs/guide.md', buildPreview({ path: 'docs/guide.md', content: 'guide preview' })],
+      ['services/openase::EMPTY.md', buildPreview({ path: 'EMPTY.md', content: '' })],
+    ])
+    const editors = new Map<string, WorkspaceFileEditorState>([
+      [
+        'services/openase::README.md',
+        buildEditorState({ draftContent: 'draft readme', dirty: true }),
+      ],
+    ])
+
+    const workingSet = buildWorkspaceEditorWorkingSet({
+      recentFiles: [
+        { repoPath: 'services/openase', filePath: 'README.md' },
+        { repoPath: 'services/openase', filePath: 'docs/guide.md' },
+        { repoPath: 'services/openase', filePath: 'EMPTY.md' },
+      ],
+      getEditorState: (repoPath, filePath) =>
+        editors.get(`${repoPath ?? ''}::${filePath ?? ''}`) ?? null,
+      getPreview: (repoPath, filePath) => previews.get(`${repoPath}::${filePath}`) ?? null,
+    })
+
+    expect(workingSet).toEqual([
+      {
+        filePath: 'README.md',
+        contentExcerpt: 'draft readme',
+        dirty: true,
+        truncated: false,
+      },
+      {
+        filePath: 'docs/guide.md',
+        contentExcerpt: 'guide preview',
+        dirty: false,
+        truncated: false,
+      },
+    ])
+  })
+})
+
+describe('getSelectedWorkspaceDraftLineDiff', () => {
+  it('returns null when no file is selected or no editor state exists', () => {
+    expect(
+      getSelectedWorkspaceDraftLineDiff({
+        repoPath: 'services/openase',
+        filePath: '',
+        getEditorState: () => null,
+      }),
+    ).toBeNull()
+
+    expect(
+      getSelectedWorkspaceDraftLineDiff({
+        repoPath: 'services/openase',
+        filePath: 'README.md',
+        getEditorState: () => null,
+      }),
+    ).toBeNull()
+  })
+
+  it('derives line diff markers from the selected editor draft', () => {
+    const editor = buildEditorState({
+      latestSavedContent: 'alpha\nbeta\ngamma\n',
+      draftContent: 'alpha\nbeta changed\ngamma\nextra\n',
+    })
+
+    expect(
+      getSelectedWorkspaceDraftLineDiff({
+        repoPath: 'services/openase',
+        filePath: 'README.md',
+        getEditorState: () => editor,
+      }),
+    ).toEqual({
+      added: [4],
+      modified: [2],
+      deletionAbove: [],
+      deletionAtEnd: false,
+    })
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.test.ts
@@ -53,8 +53,14 @@ function buildEditorState(
 describe('buildWorkspaceEditorWorkingSet', () => {
   it('prefers draft content, falls back to preview content, and skips empty files', () => {
     const previews = new Map<string, ProjectConversationWorkspaceFilePreview>([
-      ['services/openase::README.md', buildPreview({ path: 'README.md', content: 'preview readme' })],
-      ['services/openase::docs/guide.md', buildPreview({ path: 'docs/guide.md', content: 'guide preview' })],
+      [
+        'services/openase::README.md',
+        buildPreview({ path: 'README.md', content: 'preview readme' }),
+      ],
+      [
+        'services/openase::docs/guide.md',
+        buildPreview({ path: 'docs/guide.md', content: 'guide preview' }),
+      ],
       ['services/openase::EMPTY.md', buildPreview({ path: 'EMPTY.md', content: '' })],
     ])
     const editors = new Map<string, WorkspaceFileEditorState>([

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-derived.ts
@@ -1,0 +1,62 @@
+import type { ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
+import {
+  computeDraftLineDiff,
+  type WorkspaceFileEditorState,
+  type WorkspaceFileLineDiffMarkers,
+  type WorkspaceRecentFile,
+} from './project-conversation-workspace-browser-state-helpers'
+import {
+  buildWorkspaceWorkingSet,
+  type WorkspaceWorkingSetEntry,
+} from './project-conversation-workspace-editor-helpers'
+
+type WorkspaceEditorGetter = (
+  repoPath?: string,
+  filePath?: string,
+) => WorkspaceFileEditorState | null
+
+type WorkspacePreviewGetter = (
+  repoPath: string,
+  filePath: string,
+) => ProjectConversationWorkspaceFilePreview | null
+
+export function buildWorkspaceEditorWorkingSet(input: {
+  recentFiles: WorkspaceRecentFile[]
+  getEditorState: WorkspaceEditorGetter
+  getPreview: WorkspacePreviewGetter
+}): WorkspaceWorkingSetEntry[] {
+  return buildWorkspaceWorkingSet(
+    input.recentFiles
+      .map((item) => {
+        const editor = input.getEditorState(item.repoPath, item.filePath)
+        const preview = input.getPreview(item.repoPath, item.filePath)
+        const content = editor?.draftContent ?? preview?.content ?? ''
+        if (!content) {
+          return null
+        }
+        return {
+          filePath: item.filePath,
+          content,
+          dirty: editor?.dirty ?? false,
+        }
+      })
+      .filter(
+        (item): item is { filePath: string; content: string; dirty: boolean } => item != null,
+      ),
+  )
+}
+
+export function getSelectedWorkspaceDraftLineDiff(input: {
+  repoPath: string
+  filePath: string
+  getEditorState: WorkspaceEditorGetter
+}): WorkspaceFileLineDiffMarkers | null {
+  if (!input.filePath) {
+    return null
+  }
+  const editor = input.getEditorState(input.repoPath, input.filePath)
+  if (!editor) {
+    return null
+  }
+  return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -6,16 +6,16 @@ import {
   savePersistedWorkspaceFileDraft,
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
+import { type WorkspaceSelectionInput } from './project-conversation-workspace-editor-helpers'
 import {
-  buildWorkspaceWorkingSet,
-  type WorkspaceSelectionInput,
-} from './project-conversation-workspace-editor-helpers'
-import {
-  computeDraftLineDiff,
   type WorkspaceFileEditorState,
   type WorkspaceFileLineDiffMarkers,
   type WorkspaceRecentFile,
 } from './project-conversation-workspace-browser-state-helpers'
+import {
+  buildWorkspaceEditorWorkingSet,
+  getSelectedWorkspaceDraftLineDiff,
+} from './project-conversation-workspace-file-editor-derived'
 import {
   applyWorkspaceEditorPendingPatch,
   formatWorkspaceEditorDocument,
@@ -151,47 +151,43 @@ export function createWorkspaceFileEditorStore(input: {
     }
     editorStates = new Map()
   }
-  function updateSelectedDraft(nextDraftContent: string) {
+  function withSelectedEditor<TResult>(
+    fallback: TResult,
+    run: (repoPath: string, filePath: string, editor: WorkspaceFileEditorState) => TResult,
+  ): TResult {
     const repoPath = input.getSelectedRepoPath()
     const filePath = input.getSelectedFilePath()
     const editor = getEditorState(repoPath, filePath)
     if (!editor || !repoPath || !filePath) {
-      return
+      return fallback
     }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
+    return run(repoPath, filePath, editor)
+  }
+  function updateSelectedEditor(
+    transform: (editor: WorkspaceFileEditorState) => WorkspaceFileEditorState | null,
+  ) {
+    withSelectedEditor(undefined, (repoPath, filePath, editor) => {
+      setEditorState(repoPath, filePath, transform(editor))
+      return undefined
+    })
+  }
+  function updateSelectedDraft(nextDraftContent: string) {
+    updateSelectedEditor((editor) => updateWorkspaceEditorDraft(editor, nextDraftContent))
   }
   function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
+    updateSelectedEditor((editor) => updateWorkspaceEditorSelection(editor, selection))
   }
   function revertSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
+    updateSelectedEditor(revertWorkspaceEditorDraft)
   }
   function keepSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
+    updateSelectedEditor(keepWorkspaceEditorDraft)
   }
   function discardSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
+    withSelectedEditor(undefined, (repoPath, filePath) => {
+      setEditorState(repoPath, filePath, null)
+      return undefined
+    })
   }
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
@@ -233,26 +229,18 @@ export function createWorkspaceFileEditorStore(input: {
     })
   }
   function formatSelectedDocument() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorDocument({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
+    return withSelectedEditor(false, (repoPath, filePath, editor) => {
+      const result = formatWorkspaceEditorDocument({ filePath, editor })
+      setEditorState(repoPath, filePath, result.nextState)
+      return result.ok
+    })
   }
   function formatSelectedSelection() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorSelection({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
+    return withSelectedEditor(false, (repoPath, filePath, editor) => {
+      const result = formatWorkspaceEditorSelection({ filePath, editor })
+      setEditorState(repoPath, filePath, result.nextState)
+      return result.ok
+    })
   }
   function renameFileState(repoPath: string, fromPath: string, toPath: string) {
     const fromKey = selectedFileStorageKey(repoPath, fromPath)
@@ -272,25 +260,11 @@ export function createWorkspaceFileEditorStore(input: {
     }
   }
   function buildWorkingSet(recentFiles: WorkspaceRecentFile[]) {
-    return buildWorkspaceWorkingSet(
-      recentFiles
-        .map((item) => {
-          const editor = getEditorState(item.repoPath, item.filePath)
-          const preview = input.getPreview(item.repoPath, item.filePath)
-          const content = editor?.draftContent ?? preview?.content ?? ''
-          if (!content) {
-            return null
-          }
-          return {
-            filePath: item.filePath,
-            content,
-            dirty: editor?.dirty ?? false,
-          }
-        })
-        .filter(
-          (item): item is { filePath: string; content: string; dirty: boolean } => item != null,
-        ),
-    )
+    return buildWorkspaceEditorWorkingSet({
+      recentFiles,
+      getEditorState,
+      getPreview: input.getPreview,
+    })
   }
   async function saveFile(repoPath: string, filePath: string): Promise<boolean> {
     const conversationId = input.getConversationId()
@@ -317,13 +291,12 @@ export function createWorkspaceFileEditorStore(input: {
   }
   return createWorkspaceFileEditorStoreApi({
     getSelectedEditorState: () => getEditorState(),
-    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
-      const repoPath = input.getSelectedRepoPath()
-      const filePath = input.getSelectedFilePath()
-      const editor = getEditorState(repoPath, filePath)
-      if (!editor || !filePath) return null
-      return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
-    },
+    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null =>
+      getSelectedWorkspaceDraftLineDiff({
+        repoPath: input.getSelectedRepoPath(),
+        filePath: input.getSelectedFilePath(),
+        getEditorState,
+      }),
     getEditorState,
     reset,
     syncFromPreview,

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -37,11 +37,10 @@ export function createTerminalManager(input: {
   }
 
   function getActiveInstance(): TerminalInstance | undefined {
-    return instances.find((i) => i.id === activeId)
+    return instances.find((instance) => instance.id === activeId)
   }
-
   function hasInstance(id: string) {
-    return instances.some((inst) => inst.id === id)
+    return instances.some((instance) => instance.id === id)
   }
 
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
@@ -258,9 +257,7 @@ export function createTerminalManager(input: {
       const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
       activeId = nextActive?.id ?? ''
     }
-    if (instances.length === 0) {
-      panelOpen = false
-    }
+    if (instances.length === 0) panelOpen = false
   }
 
   function openPanel() {


### PR DESCRIPTION
## What changed
- extracted workspace file-editor derived helpers for selected draft diff and working-set assembly
- consolidated repeated selected-editor update paths in the file editor store
- restored the shared `lib/features/**/*.svelte.{ts,js}` hard budget from 350 back to 325 and updated the frontend README table

## Why
The chat workspace file editor had grown beyond the state-module budget, and the budget was temporarily relaxed just to keep CI green. This change replaces that temporary bypass with a maintainable split so the shared budget can stay strict.

## Impact
- no intended user-facing behavior change in the project conversation workspace browser/editor
- future state-module budget pressure now has a dedicated derived helper seam instead of another budget waiver
- adds focused unit coverage around the extracted helper behavior

## Root cause
Repeated selected-editor access and inline working-set/diff derivation lived directly inside `project-conversation-workspace-file-editor-state.svelte.ts`, which pushed the module over the hard budget and encouraged a temporary config relaxation.

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/chat/project-conversation-workspace-file-editor-derived.test.ts src/lib/features/chat/project-conversation-workspace-line-diff.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run lint:structure`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run lint`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run lint:deps`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run build`
