### PR TITLE
refactor(chat): split workspace browser state slices

### DIFF
--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -1,16 +1,8 @@
-import {
-  type ProjectConversationWorkspaceDiff,
-  type ProjectConversationWorkspaceGitGraph,
-  type ProjectConversationWorkspaceMetadata,
-  type ProjectConversationWorkspaceRepoRefs,
-} from '$lib/api/chat'
+import { type ProjectConversationWorkspaceDiff } from '$lib/api/chat'
 import { buildProjectConversationWorkspaceBrowserStateView } from './workspace-browser-state-view'
-import {
-  readWorkspaceAutosavePreference,
-  storeWorkspaceAutosavePreference,
-} from './workspace-browser-autosave'
 import { createWorkspaceBrowserTreeState } from './workspace-browser-tree-state.svelte'
 import { createWorkspaceBrowserTabs } from './workspace-browser-tabs.svelte'
+import { createWorkspaceBrowserSessionState } from './workspace-browser-session-state.svelte'
 import { createWorkspaceFileEditorStore } from './project-conversation-workspace-file-editor-state.svelte'
 import { createWorkspaceBrowserActions } from './project-conversation-workspace-browser-actions'
 import { createWorkspaceBrowserLoaders } from './project-conversation-workspace-browser-loaders'
@@ -20,7 +12,6 @@ import {
   workspaceSelectedChangedFiles,
 } from './project-conversation-workspace-browser-file-ops'
 import {
-  areWorkspaceMetadataEqual,
   workspaceTabKey,
   type WorkspaceRecentFile,
   type WorkspaceTab,
@@ -37,20 +28,9 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   getWorkspaceDiff?: () => ProjectConversationWorkspaceDiff | null
   onWorkspaceDiffUpdated?: (workspaceDiff: ProjectConversationWorkspaceDiff | null) => void
 }) {
-  let metadata = $state<ProjectConversationWorkspaceMetadata | null>(null)
-  let metadataLoading = $state(false)
-  let metadataError = $state('')
+  const session = createWorkspaceBrowserSessionState()
   const tree = createWorkspaceBrowserTreeState()
-  let autosaveEnabled = $state(readWorkspaceAutosavePreference())
   let loadRequestID = 0
-  let repoRefs = $state<ProjectConversationWorkspaceRepoRefs | null>(null)
-  let repoRefsLoading = $state(false)
-  let repoRefsError = $state('')
-  let gitGraph = $state<ProjectConversationWorkspaceGitGraph | null>(null)
-  let gitGraphLoading = $state(false)
-  let gitGraphError = $state('')
-  let selectedGitCommitID = $state('')
-  let detailMode = $state<'file' | 'git_graph'>('file')
 
   function loadFile(repoPath: string, filePath: string, options: { silent?: boolean } = {}) {
     return loadWorkspaceFile(
@@ -80,12 +60,11 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   function getActiveTabFileState(): WorkspaceTabFileState {
     return tabs.getActiveTabFileState()
   }
+
   function currentWorkspaceDiff() {
     return input.getWorkspaceDiff?.() ?? null
   }
-  function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
-    if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) metadata = nextMetadata
-  }
+
   const {
     refreshWorkspaceDiff,
     refreshRepoGitContext,
@@ -104,42 +83,20 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getTreeNodes: () => tree.treeNodes,
     getExpandedDirs: () => tree.expandedDirs,
     getOpenTabs: () => tabs.openTabs,
-    setMetadataLoading: (loading) => {
-      metadataLoading = loading
-    },
-    setMetadataError: (error) => {
-      metadataError = error
-    },
-    setMetadata,
-    clearMetadata: () => {
-      metadata = null
-    },
-    resetTreeState: () => {
-      tree.reset()
-    },
+    setMetadataLoading: session.setMetadataLoading,
+    setMetadataError: session.setMetadataError,
+    setMetadata: session.setMetadata,
+    clearMetadata: session.clearMetadata,
+    resetTreeState: tree.reset,
     closeAllTabs: tabs.closeAllTabs,
-    setRepoRefsLoading: (loading) => {
-      repoRefsLoading = loading
-    },
-    setRepoRefsError: (error) => {
-      repoRefsError = error
-    },
-    setRepoRefs: (value) => {
-      repoRefs = value
-    },
-    setGitGraphLoading: (loading) => {
-      gitGraphLoading = loading
-    },
-    setGitGraphError: (error) => {
-      gitGraphError = error
-    },
-    setGitGraph: (value) => {
-      gitGraph = value
-    },
-    getSelectedGitCommitID: () => selectedGitCommitID,
-    setSelectedGitCommitID: (commitId) => {
-      selectedGitCommitID = commitId
-    },
+    setRepoRefsLoading: session.setRepoRefsLoading,
+    setRepoRefsError: session.setRepoRefsError,
+    setRepoRefs: session.setRepoRefs,
+    setGitGraphLoading: session.setGitGraphLoading,
+    setGitGraphError: session.setGitGraphError,
+    setGitGraph: session.setGitGraph,
+    getSelectedGitCommitID: () => session.selectedGitCommitID,
+    setSelectedGitCommitID: session.setSelectedGitCommitID,
     setDirLoading: tree.setDirLoading,
     setTreeEntries: tree.setTreeEntries,
     setDirExpanded: tree.setDirExpanded,
@@ -150,7 +107,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getSelectedRepoPath: () => getActiveTab()?.repoPath ?? '',
     getSelectedFilePath: () => getActiveTab()?.filePath ?? '',
     getRepoRefCacheKey: (repoPath) =>
-      metadata?.repos.find((repo) => repo.path === repoPath)?.currentRef.cacheKey ?? '',
+      session.metadata?.repos.find((repo) => repo.path === repoPath)?.currentRef.cacheKey ?? '',
     getPreview: (repoPath, filePath) => {
       const key = workspaceTabKey({ repoPath, filePath })
       return tabs.tabFileStates.get(key)?.preview ?? null
@@ -163,31 +120,22 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       if (repoPath && filePath) await loadFile(repoPath, filePath, { silent: true })
     },
     refreshWorkspaceDiff,
-    getAutosaveEnabled: () => autosaveEnabled,
+    getAutosaveEnabled: () => session.autosaveEnabled,
   })
 
   function reset() {
-    metadata = null
-    metadataLoading = false
-    metadataError = ''
     tree.reset()
     tabs.resetSelection()
-    repoRefs = null
-    repoRefsLoading = false
-    repoRefsError = ''
-    gitGraph = null
-    gitGraphLoading = false
-    gitGraphError = ''
-    selectedGitCommitID = ''
-    detailMode = 'file'
+    session.reset()
     editorStore.reset()
   }
+
   const workspaceActions = createWorkspaceBrowserActions({
     getConversationId: input.getConversationId,
     currentWorkspaceDiff,
-    getMetadata: () => metadata,
-    setMetadata,
-    getRepoRefs: () => repoRefs,
+    getMetadata: () => session.metadata,
+    setMetadata: session.setMetadata,
+    getRepoRefs: () => session.repoRefs,
     getTreeRepoPath: () => tabs.treeRepoPath,
     setTreeRepoPath: tabs.setTreeRepoPath,
     resetTree: tree.reset,
@@ -195,9 +143,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getActiveFilePath: () => tabs.activeFilePath(tabs.treeRepoPath),
     getActiveTabKey: () => tabs.activeTabKey,
     reserveRequestID: () => ++loadRequestID,
-    setDetailMode: (mode) => {
-      detailMode = mode
-    },
+    setDetailMode: session.setDetailMode,
     revealFileInTree,
     refreshRepoGitContext,
     refreshRepoGitContextAfterCheckout: async (repoPath) => {
@@ -226,17 +172,15 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     selectPreviousChangedFile,
     reviewPatch,
   } = workspaceActions
-  function setAutosaveEnabled(enabled: boolean) {
-    autosaveEnabled = enabled
-    storeWorkspaceAutosavePreference(enabled)
-  }
+
   function activeFilePath() {
     return tabs.activeFilePath(tabs.treeRepoPath)
   }
+
   return buildProjectConversationWorkspaceBrowserStateView({
-    getMetadata: () => metadata,
-    getMetadataLoading: () => metadataLoading,
-    getMetadataError: () => metadataError,
+    getMetadata: () => session.metadata,
+    getMetadataLoading: () => session.metadataLoading,
+    getMetadataError: () => session.metadataError,
     getTreeNodes: () => tree.treeNodes,
     getExpandedDirs: () => tree.expandedDirs,
     getLoadingDirs: () => tree.loadingDirs,
@@ -244,16 +188,17 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     getActiveTabKey: () => tabs.activeTabKey,
     getTabFileStates: () => tabs.tabFileStates,
     getRecentFiles: () => tabs.recentFiles,
-    getAutosaveEnabled: () => autosaveEnabled,
-    getDetailMode: () => detailMode,
-    getRepoRefs: () => repoRefs,
-    getRepoRefsLoading: () => repoRefsLoading,
-    getRepoRefsError: () => repoRefsError,
-    getGitGraph: () => gitGraph,
-    getGitGraphLoading: () => gitGraphLoading,
-    getGitGraphError: () => gitGraphError,
+    getAutosaveEnabled: () => session.autosaveEnabled,
+    getDetailMode: () => session.detailMode,
+    getRepoRefs: () => session.repoRefs,
+    getRepoRefsLoading: () => session.repoRefsLoading,
+    getRepoRefsError: () => session.repoRefsError,
+    getGitGraph: () => session.gitGraph,
+    getGitGraphLoading: () => session.gitGraphLoading,
+    getGitGraphError: () => session.gitGraphError,
     getSelectedGitCommit: () =>
-      gitGraph?.commits.find((commit) => commit.commitId === selectedGitCommitID) ?? null,
+      session.gitGraph?.commits.find((commit) => commit.commitId === session.selectedGitCommitID) ??
+      null,
     getHasDirtyTabs: () =>
       tabs.openTabs.some(
         (tab) => editorStore.getEditorState(tab.repoPath, tab.filePath)?.dirty === true,
@@ -287,11 +232,11 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     toggleDir,
     openRepo,
     selectFile,
-    selectGitCommit: (commitId: string) => (selectedGitCommitID = commitId),
-    setDetailMode: (mode: 'file' | 'git_graph') => (detailMode = mode),
+    selectGitCommit: session.setSelectedGitCommitID,
+    setDetailMode: session.setDetailMode,
     searchPaths,
     openTab: (repoPath: string, filePath: string) => {
-      detailMode = 'file'
+      session.setDetailMode('file')
       tabs.openTab(repoPath, filePath)
     },
     closeTab: tabs.closeTab,
@@ -303,7 +248,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     refreshWorkspaceDiff,
     checkoutBlockers,
     checkoutBranch,
-    setAutosaveEnabled,
+    setAutosaveEnabled: session.setAutosaveEnabled,
     selectNextChangedFile,
     selectPreviousChangedFile,
     reviewPatch,

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-registry.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-registry.svelte.ts
@@ -1,0 +1,132 @@
+import {
+  deletePersistedWorkspaceFileDraft,
+  loadPersistedWorkspaceFileDraft,
+  savePersistedWorkspaceFileDraft,
+  workspaceFileDraftStorageKey,
+} from './project-conversation-workspace-file-drafts'
+import type { WorkspaceFileEditorState } from './project-conversation-workspace-browser-state-helpers'
+
+const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
+
+export function createWorkspaceFileEditorRegistry(input: {
+  getConversationId: () => string
+  getRepoRefCacheKey?: (repoPath: string) => string
+  shouldAutosave: (
+    repoPath: string,
+    filePath: string,
+    editorState: WorkspaceFileEditorState,
+  ) => boolean
+  onAutosave: (repoPath: string, filePath: string) => void
+}) {
+  let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
+  const autosaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  function fileStorageKey(repoPath: string, filePath: string) {
+    return workspaceFileDraftStorageKey({
+      conversationId: input.getConversationId(),
+      repoPath,
+      refCacheKey: input.getRepoRefCacheKey?.(repoPath) ?? '',
+      filePath,
+    })
+  }
+
+  function cancelAutosave(key: string) {
+    const existing = autosaveTimers.get(key)
+    if (!existing) {
+      return
+    }
+    clearTimeout(existing)
+    autosaveTimers.delete(key)
+  }
+
+  function scheduleAutosave(
+    repoPath: string,
+    filePath: string,
+    editorState: WorkspaceFileEditorState,
+  ) {
+    const key = fileStorageKey(repoPath, filePath)
+    cancelAutosave(key)
+    if (!input.shouldAutosave(repoPath, filePath, editorState)) {
+      return
+    }
+    autosaveTimers.set(
+      key,
+      setTimeout(() => {
+        autosaveTimers.delete(key)
+        input.onAutosave(repoPath, filePath)
+      }, WORKSPACE_AUTOSAVE_DELAY_MS),
+    )
+  }
+
+  function getEditorState(repoPath?: string, filePath?: string) {
+    if (!repoPath || !filePath) {
+      return null
+    }
+    return editorStates.get(fileStorageKey(repoPath, filePath)) ?? null
+  }
+
+  function setEditorState(
+    repoPath: string,
+    filePath: string,
+    nextState: WorkspaceFileEditorState | null,
+  ) {
+    const key = fileStorageKey(repoPath, filePath)
+    const nextEditorStates = new Map(editorStates)
+    if (nextState) {
+      nextEditorStates.set(key, nextState)
+      if (nextState.dirty) {
+        savePersistedWorkspaceFileDraft(key, {
+          draftContent: nextState.draftContent,
+          baseSavedContent: nextState.baseSavedContent,
+          baseSavedRevision: nextState.baseSavedRevision,
+          encoding: nextState.encoding,
+          lineEnding: nextState.lineEnding,
+          updatedAt: new Date().toISOString(),
+        })
+      } else {
+        deletePersistedWorkspaceFileDraft(key)
+      }
+      scheduleAutosave(repoPath, filePath, nextState)
+    } else {
+      cancelAutosave(key)
+      nextEditorStates.delete(key)
+      deletePersistedWorkspaceFileDraft(key)
+    }
+    editorStates = nextEditorStates
+  }
+
+  function renameFileState(repoPath: string, fromPath: string, toPath: string) {
+    const fromKey = fileStorageKey(repoPath, fromPath)
+    const toKey = fileStorageKey(repoPath, toPath)
+    const editor = editorStates.get(fromKey)
+    const persisted = loadPersistedWorkspaceFileDraft(fromKey)
+    const nextStates = new Map(editorStates)
+    cancelAutosave(fromKey)
+    if (editor) {
+      nextStates.delete(fromKey)
+      nextStates.set(toKey, editor)
+    }
+    editorStates = nextStates
+    if (persisted) {
+      savePersistedWorkspaceFileDraft(toKey, persisted)
+      deletePersistedWorkspaceFileDraft(fromKey)
+    }
+  }
+
+  function reset() {
+    for (const key of autosaveTimers.keys()) {
+      cancelAutosave(key)
+    }
+    editorStates = new Map()
+  }
+
+  return {
+    fileStorageKey,
+    getEditorState,
+    setEditorState,
+    renameFileState,
+    readPersistedDraft: (repoPath: string, filePath: string) =>
+      loadPersistedWorkspaceFileDraft(fileStorageKey(repoPath, filePath)),
+    reset,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -1,18 +1,11 @@
 import { type ChatDiffPayload, type ProjectConversationWorkspaceFilePreview } from '$lib/api/chat'
 import { saveWorkspaceFile } from './workspace-file-editor-save'
 import {
-  deletePersistedWorkspaceFileDraft,
-  loadPersistedWorkspaceFileDraft,
-  savePersistedWorkspaceFileDraft,
-  workspaceFileDraftStorageKey,
-} from './project-conversation-workspace-file-drafts'
-import {
   buildWorkspaceWorkingSet,
   type WorkspaceSelectionInput,
 } from './project-conversation-workspace-editor-helpers'
 import {
   computeDraftLineDiff,
-  type WorkspaceFileEditorState,
   type WorkspaceFileLineDiffMarkers,
   type WorkspaceRecentFile,
 } from './project-conversation-workspace-browser-state-helpers'
@@ -27,9 +20,9 @@ import {
   updateWorkspaceEditorDraft,
   updateWorkspaceEditorSelection,
 } from './project-conversation-workspace-file-editor-state-transforms'
+import { createWorkspaceFileEditorRegistry } from './project-conversation-workspace-file-editor-registry.svelte'
 import { createWorkspaceFileEditorStoreApi } from './project-conversation-workspace-file-editor-store-api'
 
-const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
 export function createWorkspaceFileEditorStore(input: {
   getConversationId: () => string
   getSelectedRepoPath: () => string
@@ -45,237 +38,185 @@ export function createWorkspaceFileEditorStore(input: {
   refreshWorkspaceDiff?: () => Promise<void>
   getAutosaveEnabled?: () => boolean
 }) {
-  let editorStates = $state<Map<string, WorkspaceFileEditorState>>(new Map())
-  const autosaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  function selectedFileStorageKey(
-    repoPath = input.getSelectedRepoPath(),
-    filePath = input.getSelectedFilePath(),
-  ) {
-    return workspaceFileDraftStorageKey({
-      conversationId: input.getConversationId(),
-      repoPath,
-      refCacheKey: input.getRepoRefCacheKey?.(repoPath) ?? '',
-      filePath,
-    })
-  }
-  function cancelAutosave(key: string) {
-    const existing = autosaveTimers.get(key)
-    if (!existing) {
-      return
-    }
-    clearTimeout(existing)
-    autosaveTimers.delete(key)
-  }
-  function getEditorState(
-    repoPath = input.getSelectedRepoPath(),
-    filePath = input.getSelectedFilePath(),
-  ) {
-    if (!repoPath || !filePath) {
+  const registry = createWorkspaceFileEditorRegistry({
+    getConversationId: input.getConversationId,
+    getRepoRefCacheKey: input.getRepoRefCacheKey,
+    shouldAutosave: (repoPath, filePath, editorState) =>
+      input.getAutosaveEnabled?.() === true &&
+      editorState.dirty &&
+      editorState.savePhase !== 'saving' &&
+      editorState.savePhase !== 'conflict' &&
+      !editorState.externalChange &&
+      input.getPreview(repoPath, filePath)?.writable === true,
+    onAutosave: (repoPath, filePath) => {
+      void saveFile(repoPath, filePath)
+    },
+  })
+
+  function getSelectedEditorContext() {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    const editor = registry.getEditorState(repoPath, filePath)
+    if (!editor || !repoPath || !filePath) {
       return null
     }
-    return editorStates.get(selectedFileStorageKey(repoPath, filePath)) ?? null
+    return { repoPath, filePath, editor }
   }
-  function setEditorState(
-    repoPath: string,
-    filePath: string,
-    nextState: WorkspaceFileEditorState | null,
-  ) {
-    const key = selectedFileStorageKey(repoPath, filePath)
-    const nextEditorStates = new Map(editorStates)
-    if (nextState) {
-      nextEditorStates.set(key, nextState)
-      if (nextState.dirty) {
-        savePersistedWorkspaceFileDraft(key, {
-          draftContent: nextState.draftContent,
-          baseSavedContent: nextState.baseSavedContent,
-          baseSavedRevision: nextState.baseSavedRevision,
-          encoding: nextState.encoding,
-          lineEnding: nextState.lineEnding,
-          updatedAt: new Date().toISOString(),
-        })
-      } else {
-        deletePersistedWorkspaceFileDraft(key)
-      }
-      scheduleAutosave(repoPath, filePath, nextState)
-    } else {
-      cancelAutosave(key)
-      nextEditorStates.delete(key)
-      deletePersistedWorkspaceFileDraft(key)
-    }
-    editorStates = nextEditorStates
-  }
-  function scheduleAutosave(
-    repoPath: string,
-    filePath: string,
-    editorState: WorkspaceFileEditorState,
-  ) {
-    const key = selectedFileStorageKey(repoPath, filePath)
-    cancelAutosave(key)
-    if (
-      !input.getAutosaveEnabled?.() ||
-      !editorState.dirty ||
-      editorState.savePhase === 'saving' ||
-      editorState.savePhase === 'conflict' ||
-      editorState.externalChange ||
-      input.getPreview(repoPath, filePath)?.writable !== true
-    ) {
-      return
-    }
-    autosaveTimers.set(
-      key,
-      setTimeout(() => {
-        autosaveTimers.delete(key)
-        void saveFile(repoPath, filePath)
-      }, WORKSPACE_AUTOSAVE_DELAY_MS),
-    )
-  }
+
   function syncFromPreview(
     repoPath: string,
     filePath: string,
     nextPreview: ProjectConversationWorkspaceFilePreview,
   ) {
-    const key = selectedFileStorageKey(repoPath, filePath)
-    setEditorState(
+    registry.setEditorState(
       repoPath,
       filePath,
       syncWorkspaceEditorStateFromPreview({
-        existing: editorStates.get(key) ?? null,
-        persisted: loadPersistedWorkspaceFileDraft(key),
+        existing: registry.getEditorState(repoPath, filePath),
+        persisted: registry.readPersistedDraft(repoPath, filePath),
         nextPreview,
       }),
     )
   }
+
   function reset() {
-    for (const key of autosaveTimers.keys()) {
-      cancelAutosave(key)
-    }
-    editorStates = new Map()
+    registry.reset()
   }
+
   function updateSelectedDraft(nextDraftContent: string) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return
     }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
+    registry.setEditorState(
+      selected.repoPath,
+      selected.filePath,
+      updateWorkspaceEditorDraft(selected.editor, nextDraftContent),
+    )
   }
+
   function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return
     }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
+    registry.setEditorState(
+      selected.repoPath,
+      selected.filePath,
+      updateWorkspaceEditorSelection(selected.editor, selection),
+    )
   }
+
   function revertSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return
     }
-    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
+    registry.setEditorState(
+      selected.repoPath,
+      selected.filePath,
+      revertWorkspaceEditorDraft(selected.editor),
+    )
   }
+
   function keepSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return
     }
-    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
+    registry.setEditorState(
+      selected.repoPath,
+      selected.filePath,
+      keepWorkspaceEditorDraft(selected.editor),
+    )
   }
+
   function discardSelectedDraft() {
     const repoPath = input.getSelectedRepoPath()
     const filePath = input.getSelectedFilePath()
     if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
+    registry.setEditorState(repoPath, filePath, null)
   }
+
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
+    registry.setEditorState(repoPath, filePath, null)
   }
+
   function reloadSelectedSavedVersion() {
     revertSelectedDraft()
   }
+
   function reviewPatch(repoPath: string, filePath: string, diff: ChatDiffPayload) {
-    const editor = getEditorState(repoPath, filePath)
+    const editor = registry.getEditorState(repoPath, filePath)
     if (!editor) {
       return false
     }
     const result = reviewWorkspaceEditorPatch({ editor, diff })
-    setEditorState(repoPath, filePath, result.nextState)
+    registry.setEditorState(repoPath, filePath, result.nextState)
     return result.ok
   }
+
   function applyPendingPatch(repoPath: string, filePath: string) {
-    const editor = getEditorState(repoPath, filePath)
+    const editor = registry.getEditorState(repoPath, filePath)
     if (!editor) {
       return false
     }
     const result = applyWorkspaceEditorPendingPatch(editor)
-    setEditorState(repoPath, filePath, result.nextState)
+    registry.setEditorState(repoPath, filePath, result.nextState)
     return result.ok
   }
+
   function discardPendingPatch(
     repoPath = input.getSelectedRepoPath(),
     filePath = input.getSelectedFilePath(),
   ) {
-    const editor = getEditorState(repoPath, filePath)
+    const editor = registry.getEditorState(repoPath, filePath)
     if (!editor || !repoPath || !filePath) {
       return
     }
-    setEditorState(repoPath, filePath, {
+    registry.setEditorState(repoPath, filePath, {
       ...editor,
       pendingPatch: null,
       errorMessage: '',
     })
   }
+
   function formatSelectedDocument() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return false
     }
-    const result = formatWorkspaceEditorDocument({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
+    const result = formatWorkspaceEditorDocument({
+      filePath: selected.filePath,
+      editor: selected.editor,
+    })
+    registry.setEditorState(selected.repoPath, selected.filePath, result.nextState)
     return result.ok
   }
+
   function formatSelectedSelection() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
+    const selected = getSelectedEditorContext()
+    if (!selected) {
       return false
     }
-    const result = formatWorkspaceEditorSelection({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
+    const result = formatWorkspaceEditorSelection({
+      filePath: selected.filePath,
+      editor: selected.editor,
+    })
+    registry.setEditorState(selected.repoPath, selected.filePath, result.nextState)
     return result.ok
   }
+
   function renameFileState(repoPath: string, fromPath: string, toPath: string) {
-    const fromKey = selectedFileStorageKey(repoPath, fromPath)
-    const toKey = selectedFileStorageKey(repoPath, toPath)
-    const editor = editorStates.get(fromKey)
-    const nextStates = new Map(editorStates)
-    const persisted = loadPersistedWorkspaceFileDraft(fromKey)
-    cancelAutosave(fromKey)
-    if (editor) {
-      nextStates.delete(fromKey)
-      nextStates.set(toKey, editor)
-    }
-    editorStates = nextStates
-    if (persisted) {
-      savePersistedWorkspaceFileDraft(toKey, persisted)
-      deletePersistedWorkspaceFileDraft(fromKey)
-    }
+    registry.renameFileState(repoPath, fromPath, toPath)
   }
+
   function buildWorkingSet(recentFiles: WorkspaceRecentFile[]) {
     return buildWorkspaceWorkingSet(
       recentFiles
         .map((item) => {
-          const editor = getEditorState(item.repoPath, item.filePath)
+          const editor = registry.getEditorState(item.repoPath, item.filePath)
           const preview = input.getPreview(item.repoPath, item.filePath)
           const content = editor?.draftContent ?? preview?.content ?? ''
           if (!content) {
@@ -295,7 +236,7 @@ export function createWorkspaceFileEditorStore(input: {
   async function saveFile(repoPath: string, filePath: string): Promise<boolean> {
     const conversationId = input.getConversationId()
     const preview = input.getPreview(repoPath, filePath)
-    const editor = getEditorState(repoPath, filePath)
+    const editor = registry.getEditorState(repoPath, filePath)
     if (!conversationId || !repoPath || !filePath || !editor) {
       return false
     }
@@ -305,8 +246,8 @@ export function createWorkspaceFileEditorStore(input: {
       filePath,
       preview,
       editor,
-      getEditorState,
-      setEditorState,
+      getEditorState: registry.getEditorState,
+      setEditorState: registry.setEditorState,
       reloadSelectedFile: input.reloadSelectedFile,
       refreshWorkspaceDiff: input.refreshWorkspaceDiff,
       setPreview: input.setPreview,
@@ -316,15 +257,14 @@ export function createWorkspaceFileEditorStore(input: {
     return saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
   }
   return createWorkspaceFileEditorStoreApi({
-    getSelectedEditorState: () => getEditorState(),
+    getSelectedEditorState: () =>
+      registry.getEditorState(input.getSelectedRepoPath(), input.getSelectedFilePath()),
     getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
-      const repoPath = input.getSelectedRepoPath()
-      const filePath = input.getSelectedFilePath()
-      const editor = getEditorState(repoPath, filePath)
-      if (!editor || !filePath) return null
-      return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
+      const selected = getSelectedEditorContext()
+      if (!selected) return null
+      return computeDraftLineDiff(selected.editor.latestSavedContent, selected.editor.draftContent)
     },
-    getEditorState,
+    getEditorState: registry.getEditorState,
     reset,
     syncFromPreview,
     updateSelectedDraft,

--- a/web/src/lib/features/chat/workspace-browser-session-state.svelte.ts
+++ b/web/src/lib/features/chat/workspace-browser-session-state.svelte.ts
@@ -1,0 +1,134 @@
+import type {
+  ProjectConversationWorkspaceGitGraph,
+  ProjectConversationWorkspaceMetadata,
+  ProjectConversationWorkspaceRepoRefs,
+} from '$lib/api/chat'
+import { areWorkspaceMetadataEqual } from './project-conversation-workspace-browser-state-helpers'
+import {
+  readWorkspaceAutosavePreference,
+  storeWorkspaceAutosavePreference,
+} from './workspace-browser-autosave'
+
+export function createWorkspaceBrowserSessionState() {
+  let metadata = $state<ProjectConversationWorkspaceMetadata | null>(null)
+  let metadataLoading = $state(false)
+  let metadataError = $state('')
+  let autosaveEnabled = $state(readWorkspaceAutosavePreference())
+  let repoRefs = $state<ProjectConversationWorkspaceRepoRefs | null>(null)
+  let repoRefsLoading = $state(false)
+  let repoRefsError = $state('')
+  let gitGraph = $state<ProjectConversationWorkspaceGitGraph | null>(null)
+  let gitGraphLoading = $state(false)
+  let gitGraphError = $state('')
+  let selectedGitCommitID = $state('')
+  let detailMode = $state<'file' | 'git_graph'>('file')
+
+  function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
+    if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) {
+      metadata = nextMetadata
+    }
+  }
+
+  function clearGitContext() {
+    repoRefs = null
+    repoRefsError = ''
+    gitGraph = null
+    gitGraphError = ''
+    selectedGitCommitID = ''
+  }
+
+  function reset() {
+    metadata = null
+    metadataLoading = false
+    metadataError = ''
+    repoRefs = null
+    repoRefsLoading = false
+    repoRefsError = ''
+    gitGraph = null
+    gitGraphLoading = false
+    gitGraphError = ''
+    selectedGitCommitID = ''
+    detailMode = 'file'
+  }
+
+  function setAutosaveEnabled(enabled: boolean) {
+    autosaveEnabled = enabled
+    storeWorkspaceAutosavePreference(enabled)
+  }
+
+  return {
+    get metadata() {
+      return metadata
+    },
+    get metadataLoading() {
+      return metadataLoading
+    },
+    get metadataError() {
+      return metadataError
+    },
+    get autosaveEnabled() {
+      return autosaveEnabled
+    },
+    get repoRefs() {
+      return repoRefs
+    },
+    get repoRefsLoading() {
+      return repoRefsLoading
+    },
+    get repoRefsError() {
+      return repoRefsError
+    },
+    get gitGraph() {
+      return gitGraph
+    },
+    get gitGraphLoading() {
+      return gitGraphLoading
+    },
+    get gitGraphError() {
+      return gitGraphError
+    },
+    get selectedGitCommitID() {
+      return selectedGitCommitID
+    },
+    get detailMode() {
+      return detailMode
+    },
+    setMetadataLoading: (loading: boolean) => {
+      metadataLoading = loading
+    },
+    setMetadataError: (error: string) => {
+      metadataError = error
+    },
+    setMetadata,
+    clearMetadata: () => {
+      metadata = null
+    },
+    setRepoRefsLoading: (loading: boolean) => {
+      repoRefsLoading = loading
+    },
+    setRepoRefsError: (error: string) => {
+      repoRefsError = error
+    },
+    setRepoRefs: (value: ProjectConversationWorkspaceRepoRefs | null) => {
+      repoRefs = value
+    },
+    setGitGraphLoading: (loading: boolean) => {
+      gitGraphLoading = loading
+    },
+    setGitGraphError: (error: string) => {
+      gitGraphError = error
+    },
+    setGitGraph: (value: ProjectConversationWorkspaceGitGraph | null) => {
+      gitGraph = value
+    },
+    setSelectedGitCommitID: (commitId: string) => {
+      selectedGitCommitID = commitId
+    },
+    setDetailMode: (mode: 'file' | 'git_graph') => {
+      detailMode = mode
+    },
+    setAutosaveEnabled,
+    clearGitContext,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary
- extract workspace file-editor draft persistence and autosave scheduling into a dedicated registry slice
- extract workspace browser metadata/git/autosave state into a dedicated session-state slice
- keep the existing workspace browser public API stable while shrinking the prior state hotspots

## Validation
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web install --frozen-lockfile
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run --reporter=dot src/lib/features/chat/project-conversation-workspace-browser-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout.test.ts src/lib/features/chat/project-conversation-workspace-browser-git-checkout-refresh.test.ts
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec eslint --quiet src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts src/lib/features/chat/project-conversation-workspace-file-editor-registry.svelte.ts src/lib/features/chat/workspace-browser-session-state.svelte.ts
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec prettier --check src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts src/lib/features/chat/project-conversation-workspace-file-editor-registry.svelte.ts src/lib/features/chat/workspace-browser-session-state.svelte.ts
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run lint:structure
- PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web run check -- --output machine --threshold error (0 errors, 1 pre-existing warning in security-settings-human-auth-disabled-setup-draft-form.svelte)

## Ticket
- ASE-376
