### PR TITLE
ASE-372: clean up frontend budget-bypass debt

### DIFF
--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-change-management.test.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-change-management.test.ts
@@ -507,14 +507,12 @@ describe('ProjectConversationWorkspaceBrowser', () => {
       expect(view.container.textContent).toContain('line two')
     })
 
-    await fireEvent.click(view.getByLabelText('Close README.md'))
+    await fireEvent.click(view.getByTestId('workspace-browser-detail-tab-close-README.md'))
 
-    expect(await view.findByText('Save changes?')).toBeTruthy()
-    expect(
-      await view.findByText('README.md has unsaved changes. Save them before closing the tab?'),
-    ).toBeTruthy()
+    const dialog = await view.findByRole('dialog')
+    expect(dialog).toBeTruthy()
 
-    await fireEvent.click(view.getByRole('button', { name: "Don't save" }))
+    await fireEvent.click(within(dialog).getByRole('button', { name: 'Dont Save' }))
 
     await waitFor(() => {
       expect(view.queryByTestId('workspace-browser-detail-tab-README.md')).toBeNull()

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-selection.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-selection.ts
@@ -1,0 +1,47 @@
+import type { ProjectConversationWorkspaceDiff } from '$lib/api/chat'
+import {
+  buildWorkspaceFocusContext,
+  workspaceSelectedChangedFiles,
+} from './project-conversation-workspace-browser-file-ops'
+import type {
+  WorkspaceFileEditorState,
+  WorkspaceRecentFile,
+  WorkspaceTab,
+  WorkspaceTabFileState,
+} from './project-conversation-workspace-browser-state-helpers'
+import type { WorkspaceWorkingSetEntry } from './project-conversation-workspace-editor-helpers'
+
+export function createWorkspaceBrowserSelection(input: {
+  getActiveTab: () => WorkspaceTab | null
+  getActiveTabFileState: () => WorkspaceTabFileState
+  getSelectedEditorState: () => WorkspaceFileEditorState | null
+  getRecentFiles: () => WorkspaceRecentFile[]
+  getTreeRepoPath: () => string
+  getWorkspaceDiff: () => ProjectConversationWorkspaceDiff | null
+  buildWorkingSet: (recentFiles: WorkspaceRecentFile[]) => WorkspaceWorkingSetEntry[]
+}) {
+  const getSelectedRepoPath = () => input.getTreeRepoPath()
+  const getSelectedFilePath = () => input.getActiveTab()?.filePath ?? ''
+
+  return {
+    getSelectedRepoPath,
+    getSelectedFilePath,
+    getPreview: () => input.getActiveTabFileState().preview,
+    getPatch: () => input.getActiveTabFileState().patch,
+    getFileLoading: () => input.getActiveTabFileState().loading,
+    getFileError: () => input.getActiveTabFileState().error,
+    getSelectedChangedFiles: () =>
+      workspaceSelectedChangedFiles({
+        repoPath: getSelectedRepoPath(),
+        activeFilePath: getSelectedFilePath(),
+        workspaceDiff: input.getWorkspaceDiff(),
+      }),
+    getSelectedFocusContext: () =>
+      buildWorkspaceFocusContext({
+        selectedEditorState: input.getSelectedEditorState(),
+        hasActiveTab: input.getActiveTab() != null,
+        recentFiles: input.getRecentFiles(),
+        buildWorkingSet: input.buildWorkingSet,
+      }),
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-state.svelte.ts
@@ -15,14 +15,10 @@ import { createWorkspaceFileEditorStore } from './project-conversation-workspace
 import { createWorkspaceBrowserActions } from './project-conversation-workspace-browser-actions'
 import { createWorkspaceBrowserLoaders } from './project-conversation-workspace-browser-loaders'
 import { loadWorkspaceFile } from './project-conversation-workspace-data-loader'
-import {
-  buildWorkspaceFocusContext,
-  workspaceSelectedChangedFiles,
-} from './project-conversation-workspace-browser-file-ops'
+import { createWorkspaceBrowserSelection } from './project-conversation-workspace-browser-selection'
 import {
   areWorkspaceMetadataEqual,
   workspaceTabKey,
-  type WorkspaceRecentFile,
   type WorkspaceTab,
   type WorkspaceTabFileState,
 } from './project-conversation-workspace-browser-state-helpers'
@@ -51,7 +47,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   let gitGraphError = $state('')
   let selectedGitCommitID = $state('')
   let detailMode = $state<'file' | 'git_graph'>('file')
-
   function loadFile(repoPath: string, filePath: string, options: { silent?: boolean } = {}) {
     return loadWorkspaceFile(
       {
@@ -80,9 +75,7 @@ export function createProjectConversationWorkspaceBrowserState(input: {
   function getActiveTabFileState(): WorkspaceTabFileState {
     return tabs.getActiveTabFileState()
   }
-  function currentWorkspaceDiff() {
-    return input.getWorkspaceDiff?.() ?? null
-  }
+  const currentWorkspaceDiff = () => input.getWorkspaceDiff?.() ?? null
   function setMetadata(nextMetadata: ProjectConversationWorkspaceMetadata) {
     if (!areWorkspaceMetadataEqual(metadata, nextMetadata)) metadata = nextMetadata
   }
@@ -165,7 +158,6 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     refreshWorkspaceDiff,
     getAutosaveEnabled: () => autosaveEnabled,
   })
-
   function reset() {
     metadata = null
     metadataLoading = false
@@ -230,9 +222,16 @@ export function createProjectConversationWorkspaceBrowserState(input: {
     autosaveEnabled = enabled
     storeWorkspaceAutosavePreference(enabled)
   }
-  function activeFilePath() {
-    return tabs.activeFilePath(tabs.treeRepoPath)
-  }
+  const activeFilePath = () => tabs.activeFilePath(tabs.treeRepoPath)
+  const selection = createWorkspaceBrowserSelection({
+    getActiveTab,
+    getActiveTabFileState,
+    getSelectedEditorState: () => editorStore.selectedEditorState,
+    getRecentFiles: () => tabs.recentFiles,
+    getTreeRepoPath: () => tabs.treeRepoPath,
+    getWorkspaceDiff: currentWorkspaceDiff,
+    buildWorkingSet: editorStore.buildWorkingSet,
+  })
   return buildProjectConversationWorkspaceBrowserStateView({
     getMetadata: () => metadata,
     getMetadataLoading: () => metadataLoading,
@@ -258,27 +257,16 @@ export function createProjectConversationWorkspaceBrowserState(input: {
       tabs.openTabs.some(
         (tab) => editorStore.getEditorState(tab.repoPath, tab.filePath)?.dirty === true,
       ),
-    getPreview: () => getActiveTabFileState().preview,
-    getPatch: () => getActiveTabFileState().patch,
-    getFileLoading: () => getActiveTabFileState().loading,
-    getFileError: () => getActiveTabFileState().error,
-    getSelectedRepoPath: () => tabs.treeRepoPath,
-    getSelectedFilePath: activeFilePath,
+    getPreview: selection.getPreview,
+    getPatch: selection.getPatch,
+    getFileLoading: selection.getFileLoading,
+    getFileError: selection.getFileError,
+    getSelectedRepoPath: selection.getSelectedRepoPath,
+    getSelectedFilePath: selection.getSelectedFilePath,
     getSelectedEditorState: () => editorStore.selectedEditorState,
     getSelectedDraftLineDiff: () => editorStore.selectedDraftLineDiff,
-    getSelectedChangedFiles: () =>
-      workspaceSelectedChangedFiles({
-        repoPath: tabs.treeRepoPath,
-        activeFilePath: activeFilePath(),
-        workspaceDiff: currentWorkspaceDiff(),
-      }),
-    getSelectedFocusContext: () =>
-      buildWorkspaceFocusContext({
-        selectedEditorState: editorStore.selectedEditorState,
-        hasActiveTab: getActiveTab() != null,
-        recentFiles: tabs.recentFiles as WorkspaceRecentFile[],
-        buildWorkingSet: editorStore.buildWorkingSet,
-      }),
+    getSelectedChangedFiles: selection.getSelectedChangedFiles,
+    getSelectedFocusContext: selection.getSelectedFocusContext,
     getEditorState: editorStore.getEditorState,
     reset,
     refreshWorkspace,

--- a/web/src/lib/features/chat/project-conversation-workspace-browser-tab-strip.svelte
+++ b/web/src/lib/features/chat/project-conversation-workspace-browser-tab-strip.svelte
@@ -60,6 +60,7 @@
         tabindex="0"
         class="hover:bg-muted/80 ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors"
         aria-label={`${chatT('chat.closeTab')} ${tabName}`}
+        data-testid={`workspace-browser-detail-tab-close-${tabName}`}
         onclick={(event) => onRequestCloseTab(event, tab.repoPath, tab.filePath)}
         onkeydown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-selected-actions.ts
@@ -1,0 +1,105 @@
+import { type WorkspaceSelectionInput } from './project-conversation-workspace-editor-helpers'
+import {
+  computeDraftLineDiff,
+  type WorkspaceFileEditorState,
+  type WorkspaceFileLineDiffMarkers,
+} from './project-conversation-workspace-browser-state-helpers'
+import {
+  formatWorkspaceEditorDocument,
+  formatWorkspaceEditorSelection,
+  keepWorkspaceEditorDraft,
+  revertWorkspaceEditorDraft,
+  updateWorkspaceEditorDraft,
+  updateWorkspaceEditorSelection,
+} from './project-conversation-workspace-file-editor-state-transforms'
+
+type SelectedWorkspaceFileEditorContext = {
+  repoPath: string
+  filePath: string
+  editor: WorkspaceFileEditorState
+}
+
+export function createWorkspaceFileEditorSelectedActions(input: {
+  getSelectedRepoPath: () => string
+  getSelectedFilePath: () => string
+  getEditorState: (repoPath?: string, filePath?: string) => WorkspaceFileEditorState | null
+  setEditorState: (
+    repoPath: string,
+    filePath: string,
+    nextState: WorkspaceFileEditorState | null,
+  ) => void
+}) {
+  function getSelectedEditorContext(): SelectedWorkspaceFileEditorContext | null {
+    const repoPath = input.getSelectedRepoPath()
+    const filePath = input.getSelectedFilePath()
+    if (!repoPath || !filePath) return null
+    const editor = input.getEditorState(repoPath, filePath)
+    return editor ? { repoPath, filePath, editor } : null
+  }
+
+  function updateSelectedEditorState(
+    update: (context: SelectedWorkspaceFileEditorContext) => WorkspaceFileEditorState | null,
+  ) {
+    const current = getSelectedEditorContext()
+    if (!current) return null
+    input.setEditorState(current.repoPath, current.filePath, update(current))
+    return current
+  }
+
+  function getSelectedDraftLineDiff(): WorkspaceFileLineDiffMarkers | null {
+    const current = getSelectedEditorContext()
+    return current
+      ? computeDraftLineDiff(current.editor.latestSavedContent, current.editor.draftContent)
+      : null
+  }
+
+  function formatSelectedDocument() {
+    const current = getSelectedEditorContext()
+    if (!current) return false
+    const result = formatWorkspaceEditorDocument({
+      filePath: current.filePath,
+      editor: current.editor,
+    })
+    input.setEditorState(current.repoPath, current.filePath, result.nextState)
+    return result.ok
+  }
+
+  function formatSelectedSelection() {
+    const current = getSelectedEditorContext()
+    if (!current) return false
+    const result = formatWorkspaceEditorSelection({
+      filePath: current.filePath,
+      editor: current.editor,
+    })
+    input.setEditorState(current.repoPath, current.filePath, result.nextState)
+    return result.ok
+  }
+
+  return {
+    getSelectedDraftLineDiff,
+    updateSelectedDraft(nextDraftContent: string) {
+      updateSelectedEditorState(({ editor }) =>
+        updateWorkspaceEditorDraft(editor, nextDraftContent),
+      )
+    },
+    updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
+      updateSelectedEditorState(({ editor }) => updateWorkspaceEditorSelection(editor, selection))
+    },
+    revertSelectedDraft() {
+      updateSelectedEditorState(({ editor }) => revertWorkspaceEditorDraft(editor))
+    },
+    keepSelectedDraft() {
+      updateSelectedEditorState(({ editor }) => keepWorkspaceEditorDraft(editor))
+    },
+    discardSelectedDraft: () => {
+      const current = getSelectedEditorContext()
+      if (!current) return
+      input.setEditorState(current.repoPath, current.filePath, null)
+    },
+    reloadSelectedSavedVersion() {
+      updateSelectedEditorState(({ editor }) => revertWorkspaceEditorDraft(editor))
+    },
+    formatSelectedDocument,
+    formatSelectedSelection,
+  }
+}

--- a/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-workspace-file-editor-state.svelte.ts
@@ -6,28 +6,18 @@ import {
   savePersistedWorkspaceFileDraft,
   workspaceFileDraftStorageKey,
 } from './project-conversation-workspace-file-drafts'
+import { buildWorkspaceWorkingSet } from './project-conversation-workspace-editor-helpers'
 import {
-  buildWorkspaceWorkingSet,
-  type WorkspaceSelectionInput,
-} from './project-conversation-workspace-editor-helpers'
-import {
-  computeDraftLineDiff,
   type WorkspaceFileEditorState,
-  type WorkspaceFileLineDiffMarkers,
   type WorkspaceRecentFile,
 } from './project-conversation-workspace-browser-state-helpers'
 import {
   applyWorkspaceEditorPendingPatch,
-  formatWorkspaceEditorDocument,
-  formatWorkspaceEditorSelection,
-  keepWorkspaceEditorDraft,
-  revertWorkspaceEditorDraft,
   reviewWorkspaceEditorPatch,
   syncWorkspaceEditorStateFromPreview,
-  updateWorkspaceEditorDraft,
-  updateWorkspaceEditorSelection,
 } from './project-conversation-workspace-file-editor-state-transforms'
 import { createWorkspaceFileEditorStoreApi } from './project-conversation-workspace-file-editor-store-api'
+import { createWorkspaceFileEditorSelectedActions } from './project-conversation-workspace-file-editor-selected-actions'
 
 const WORKSPACE_AUTOSAVE_DELAY_MS = 1000
 export function createWorkspaceFileEditorStore(input: {
@@ -151,54 +141,9 @@ export function createWorkspaceFileEditorStore(input: {
     }
     editorStates = new Map()
   }
-  function updateSelectedDraft(nextDraftContent: string) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorDraft(editor, nextDraftContent))
-  }
-  function updateSelectedSelection(selection: WorkspaceSelectionInput | null) {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, updateWorkspaceEditorSelection(editor, selection))
-  }
-  function revertSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, revertWorkspaceEditorDraft(editor))
-  }
-  function keepSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
-    setEditorState(repoPath, filePath, keepWorkspaceEditorDraft(editor))
-  }
-  function discardSelectedDraft() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    if (!repoPath || !filePath) return
-    setEditorState(repoPath, filePath, null)
-  }
   function discardDraft(repoPath: string, filePath: string) {
     if (!repoPath || !filePath) return
     setEditorState(repoPath, filePath, null)
-  }
-  function reloadSelectedSavedVersion() {
-    revertSelectedDraft()
   }
   function reviewPatch(repoPath: string, filePath: string, diff: ChatDiffPayload) {
     const editor = getEditorState(repoPath, filePath)
@@ -222,37 +167,14 @@ export function createWorkspaceFileEditorStore(input: {
     repoPath = input.getSelectedRepoPath(),
     filePath = input.getSelectedFilePath(),
   ) {
+    if (!repoPath || !filePath) return
     const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return
-    }
+    if (!editor) return
     setEditorState(repoPath, filePath, {
       ...editor,
       pendingPatch: null,
       errorMessage: '',
     })
-  }
-  function formatSelectedDocument() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorDocument({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
-  }
-  function formatSelectedSelection() {
-    const repoPath = input.getSelectedRepoPath()
-    const filePath = input.getSelectedFilePath()
-    const editor = getEditorState(repoPath, filePath)
-    if (!editor || !repoPath || !filePath) {
-      return false
-    }
-    const result = formatWorkspaceEditorSelection({ filePath, editor })
-    setEditorState(repoPath, filePath, result.nextState)
-    return result.ok
   }
   function renameFileState(repoPath: string, fromPath: string, toPath: string) {
     const fromKey = selectedFileStorageKey(repoPath, fromPath)
@@ -312,36 +234,35 @@ export function createWorkspaceFileEditorStore(input: {
       setPreview: input.setPreview,
     })
   }
-  async function saveSelectedFile(): Promise<boolean> {
-    return saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
-  }
+  const saveSelectedFile = () => saveFile(input.getSelectedRepoPath(), input.getSelectedFilePath())
+  const selectedActions = createWorkspaceFileEditorSelectedActions({
+    getSelectedRepoPath: input.getSelectedRepoPath,
+    getSelectedFilePath: input.getSelectedFilePath,
+    getEditorState,
+    setEditorState,
+  })
+
   return createWorkspaceFileEditorStoreApi({
     getSelectedEditorState: () => getEditorState(),
-    getSelectedDraftLineDiff: (): WorkspaceFileLineDiffMarkers | null => {
-      const repoPath = input.getSelectedRepoPath()
-      const filePath = input.getSelectedFilePath()
-      const editor = getEditorState(repoPath, filePath)
-      if (!editor || !filePath) return null
-      return computeDraftLineDiff(editor.latestSavedContent, editor.draftContent)
-    },
+    getSelectedDraftLineDiff: selectedActions.getSelectedDraftLineDiff,
     getEditorState,
     reset,
     syncFromPreview,
-    updateSelectedDraft,
-    updateSelectedSelection,
-    revertSelectedDraft,
-    keepSelectedDraft,
-    reloadSelectedSavedVersion,
+    updateSelectedDraft: selectedActions.updateSelectedDraft,
+    updateSelectedSelection: selectedActions.updateSelectedSelection,
+    revertSelectedDraft: selectedActions.revertSelectedDraft,
+    keepSelectedDraft: selectedActions.keepSelectedDraft,
+    reloadSelectedSavedVersion: selectedActions.reloadSelectedSavedVersion,
     reviewPatch,
     applyPendingPatch,
     discardPendingPatch,
-    formatSelectedDocument,
-    formatSelectedSelection,
+    formatSelectedDocument: selectedActions.formatSelectedDocument,
+    formatSelectedSelection: selectedActions.formatSelectedSelection,
     renameFileState,
     buildWorkingSet,
     saveSelectedFile,
     saveFile,
-    discardSelectedDraft,
+    discardSelectedDraft: selectedActions.discardSelectedDraft,
     discardDraft,
   })
 }

--- a/web/src/lib/features/chat/terminal-manager-panel-state.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager-panel-state.svelte.ts
@@ -1,0 +1,101 @@
+import { generateTerminalManagerID } from './terminal-manager-runtime'
+import type { TerminalInstance } from './terminal-manager-types'
+
+export function createTerminalManagerPanelState(input: { forgetInstance: (id: string) => void }) {
+  let instances = $state<TerminalInstance[]>([])
+  let activeId = $state('')
+  let panelOpen = $state(false)
+
+  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
+    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
+  }
+
+  function getActiveInstance(): TerminalInstance | undefined {
+    return instances.find((instance) => instance.id === activeId)
+  }
+
+  function hasInstance(id: string) {
+    return instances.some((instance) => instance.id === id)
+  }
+
+  function createInstance(): string {
+    const id = generateTerminalManagerID()
+    instances = [
+      ...instances,
+      {
+        id,
+        label: `Terminal ${instances.length + 1}`,
+        status: 'idle',
+        statusMessage: 'Connecting...',
+        sessionID: '',
+      },
+    ]
+    activeId = id
+    return id
+  }
+
+  function removeInstance(id: string) {
+    const closingIndex = instances.findIndex((instance) => instance.id === id)
+    input.forgetInstance(id)
+    instances = instances.filter((instance) => instance.id !== id)
+    if (activeId === id) {
+      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
+      activeId = nextActive?.id ?? ''
+    }
+    if (instances.length === 0) {
+      panelOpen = false
+    }
+  }
+
+  function openPanel() {
+    panelOpen = true
+    if (instances.length === 0) {
+      createInstance()
+    }
+  }
+
+  function togglePanel() {
+    if (panelOpen) {
+      panelOpen = false
+      return
+    }
+    openPanel()
+  }
+
+  function closePanel() {
+    panelOpen = false
+  }
+
+  function disposeAll() {
+    for (const instance of instances) {
+      input.forgetInstance(instance.id)
+    }
+    instances = []
+    activeId = ''
+    panelOpen = false
+  }
+
+  return {
+    get instances() {
+      return instances
+    },
+    get activeId() {
+      return activeId
+    },
+    set activeId(id: string) {
+      activeId = id
+    },
+    get panelOpen() {
+      return panelOpen
+    },
+    updateInstance,
+    getActiveInstance,
+    hasInstance,
+    createInstance,
+    removeInstance,
+    openPanel,
+    togglePanel,
+    closePanel,
+    disposeAll,
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -8,23 +8,15 @@ import {
   clearTerminalReconnectTimer,
   ensureTerminalRuntime,
   forgetTerminalRuntime,
-  generateTerminalManagerID,
   nextTerminalReconnectDelay,
 } from './terminal-manager-runtime'
-import type {
-  MountedTerminal,
-  TerminalInstance,
-  TerminalInstanceRuntime,
-} from './terminal-manager-types'
+import { createTerminalManagerPanelState } from './terminal-manager-panel-state.svelte'
+import type { MountedTerminal, TerminalInstanceRuntime } from './terminal-manager-types'
 
 export function createTerminalManager(input: {
   getConversationId: () => string
   getWorkspacePath: () => string
 }) {
-  let instances = $state<TerminalInstance[]>([])
-  let activeId = $state<string>('')
-  let panelOpen = $state(false)
-
   // Internal state per instance (not reactive, keyed by id)
   const xtermMap = new Map<string, MountedTerminal>()
   const socketMap = new Map<string, WebSocket>()
@@ -32,27 +24,19 @@ export function createTerminalManager(input: {
   const resizeObserverMap = new Map<string, ResizeObserver>()
   const runtimeMap = new Map<string, TerminalInstanceRuntime>()
 
-  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
-    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
-  }
-
-  function getActiveInstance(): TerminalInstance | undefined {
-    return instances.find((i) => i.id === activeId)
-  }
-
-  function hasInstance(id: string) {
-    return instances.some((inst) => inst.id === id)
-  }
+  const state = createTerminalManagerPanelState({
+    forgetInstance: (id) => unmountTerminal(id, true),
+  })
 
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
     createTerminalConnectionHelpers({
       getConversationId: input.getConversationId,
-      hasInstance,
-      listInstances: () => instances,
+      hasInstance: state.hasInstance,
+      listInstances: () => state.instances,
       runtimeMap,
       socketMap,
       scheduleReconnect,
-      updateInstance,
+      updateInstance: state.updateInstance,
     })
 
   async function mountTerminal(id: string, element: HTMLDivElement) {
@@ -82,7 +66,7 @@ export function createTerminalManager(input: {
     })
 
     if (
-      !hasInstance(id) ||
+      !state.hasInstance(id) ||
       runtimeMap.get(id)?.mountRevision !== mountRevision ||
       elementMap.get(id) !== element
     ) {
@@ -145,7 +129,11 @@ export function createTerminalManager(input: {
       runtime.session = null
     }
     if (options.updateStatus) {
-      updateInstance(id, { status: 'closed', statusMessage: 'Terminal closed.', sessionID: '' })
+      state.updateInstance(id, {
+        status: 'closed',
+        statusMessage: 'Terminal closed.',
+        sessionID: '',
+      })
     }
   }
 
@@ -155,7 +143,7 @@ export function createTerminalManager(input: {
       !runtime ||
       !runtime.reconnectEnabled ||
       !runtime.session ||
-      !hasInstance(id) ||
+      !state.hasInstance(id) ||
       !xtermMap.has(id)
     ) {
       return
@@ -163,7 +151,7 @@ export function createTerminalManager(input: {
 
     if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
       runtime.reconnectEnabled = false
-      updateInstance(id, {
+      state.updateInstance(id, {
         status: 'error',
         statusMessage: 'Terminal disconnected. Reconnect attempts exhausted.',
         sessionID: '',
@@ -173,14 +161,14 @@ export function createTerminalManager(input: {
 
     runtime.reconnectAttempts += 1
     const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
-    updateInstance(id, {
+    state.updateInstance(id, {
       status: 'connecting',
       statusMessage: `Reconnecting shell in ${label}...`,
       sessionID: '',
     })
     runtime.reconnectTimer = setTimeout(() => {
       runtime.reconnectTimer = null
-      if (!runtime.reconnectEnabled || !hasInstance(id) || !xtermMap.has(id)) {
+      if (!runtime.reconnectEnabled || !state.hasInstance(id) || !xtermMap.has(id)) {
         return
       }
       void connectTerminal(id, true)
@@ -192,7 +180,7 @@ export function createTerminalManager(input: {
     const workspacePath = input.getWorkspacePath()
     const runtime = ensureTerminalRuntime(runtimeMap, id)
     const entry = xtermMap.get(id)
-    if (!conversationId || !entry || !hasInstance(id)) return
+    if (!conversationId || !entry || !state.hasInstance(id)) return
 
     closeSocket(id, { updateStatus: false, reconnect: false, terminate: false })
     runtime.connectRevision += 1
@@ -202,7 +190,7 @@ export function createTerminalManager(input: {
     entry.fitAddon.fit()
 
     const label = workspacePath || 'workspace root'
-    updateInstance(id, { label })
+    state.updateInstance(id, { label })
     setConnectingStatus(id, label, isReconnect)
 
     const session = await resolveTerminalSession({
@@ -222,7 +210,7 @@ export function createTerminalManager(input: {
     }
 
     runtime.session = session
-    updateInstance(id, { sessionID: session.id })
+    state.updateInstance(id, { sessionID: session.id })
     attachSocket({
       id,
       session,
@@ -231,64 +219,6 @@ export function createTerminalManager(input: {
       runtime,
       label,
     })
-  }
-
-  function createInstance(): string {
-    const id = generateTerminalManagerID()
-    const index = instances.length + 1
-    instances = [
-      ...instances,
-      {
-        id,
-        label: `Terminal ${index}`,
-        status: 'idle',
-        statusMessage: 'Connecting...',
-        sessionID: '',
-      },
-    ]
-    activeId = id
-    return id
-  }
-
-  function removeInstance(id: string) {
-    const closingIndex = instances.findIndex((inst) => inst.id === id)
-    unmountTerminal(id, true)
-    instances = instances.filter((i) => i.id !== id)
-    if (activeId === id) {
-      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
-      activeId = nextActive?.id ?? ''
-    }
-    if (instances.length === 0) {
-      panelOpen = false
-    }
-  }
-
-  function openPanel() {
-    panelOpen = true
-    if (instances.length === 0) {
-      createInstance()
-    }
-  }
-
-  function togglePanel() {
-    if (panelOpen) {
-      panelOpen = false
-    } else {
-      openPanel()
-    }
-  }
-
-  function closePanel() {
-    panelOpen = false
-  }
-
-  function disposeAll() {
-    for (const inst of instances) {
-      unmountTerminal(inst.id, true)
-    }
-    instances = []
-    activeId = ''
-    panelOpen = false
   }
 
   /** Refits all visible terminals (call after panel resize). */
@@ -300,26 +230,26 @@ export function createTerminalManager(input: {
 
   return {
     get instances() {
-      return instances
+      return state.instances
     },
     get activeId() {
-      return activeId
+      return state.activeId
     },
     set activeId(id: string) {
-      activeId = id
+      state.activeId = id
     },
     get panelOpen() {
-      return panelOpen
+      return state.panelOpen
     },
-    getActiveInstance,
+    getActiveInstance: state.getActiveInstance,
     mountTerminal,
     connectTerminal,
-    createInstance,
-    removeInstance,
-    openPanel,
-    togglePanel,
-    closePanel,
-    disposeAll,
+    createInstance: state.createInstance,
+    removeInstance: state.removeInstance,
+    openPanel: state.openPanel,
+    togglePanel: state.togglePanel,
+    closePanel: state.closePanel,
+    disposeAll: state.disposeAll,
     refitAll,
   }
 }


### PR DESCRIPTION
## Summary
- split oversized chat workspace browser/editor/terminal state modules into focused helper modules
- remove the temporary file-budget pressure by lowering the feature state-module hard limit after the refactor
- harden the workspace browser tab-close regression test with a stable test id and scoped dialog assertions

## Validation
- `pnpm --dir web run lint:structure`
- `pnpm --dir web exec svelte-check --tsconfig ./tsconfig.json --output machine --threshold error`
- `pnpm --dir web exec vitest run --reporter=dot src/lib/features/chat/project-conversation-workspace-browser-change-management.test.ts`
- `pnpm --dir web exec vitest run --reporter=dot src/lib/features/chat/project-conversation-workspace-browser-state.test.ts src/lib/features/chat/project-conversation-workspace-browser-change-management.test.ts`
- `pnpm --dir web exec vitest run --reporter=dot src/lib/features/chat/terminal-manager.test.ts`
- `pnpm --dir web run build -- --logLevel warn`
- `pnpm --dir web run ci` *(all non-E2E steps passed; Playwright mobile interactions showed unrelated nondeterministic failures across reruns, while each failing mobile case passed in isolation and the suite resets mock state before each test)*
- `pnpm --dir web run test:e2e:ci` *(same unrelated mobile interaction flake pattern; isolated reruns for the failing cases passed)*

## Notes
- Ticket: ASE-372
