### PR TITLE
[ASE-382] Fix pending completion summary reconcile query

### DIFF
--- a/internal/orchestrator/run_completion_summary.go
+++ b/internal/orchestrator/run_completion_summary.go
@@ -188,6 +188,12 @@ type runCompletionSummaryContext struct {
 	workspaces   []*ent.TicketRepoWorkspace
 }
 
+type pendingRunCompletionSummary struct {
+	ID                      uuid.UUID                            `json:"id"`
+	CompletionSummaryStatus *entagentrun.CompletionSummaryStatus `json:"completion_summary_status,omitempty"`
+	TerminalAt              *time.Time                           `json:"terminal_at,omitempty"`
+}
+
 type runCompletionSummaryInputPayload struct {
 	Metadata       map[string]any                 `json:"metadata"`
 	Steps          []map[string]any               `json:"steps"`
@@ -284,25 +290,12 @@ func (c *runtimeCompletionSummaryCoordinator) reconcileRunCompletionSummaries(ct
 		return nil
 	}
 
-	runs, err := c.client.AgentRun.Query().
-		Where(
-			entagentrun.StatusIn(
-				entagentrun.StatusCompleted,
-				entagentrun.StatusErrored,
-				entagentrun.StatusInterrupted,
-				entagentrun.StatusTerminated,
-			),
-		).
-		Order(entagentrun.ByTerminalAt(sql.OrderAsc())).
-		All(ctx)
+	runs, err := c.listPendingRunCompletionSummaries(ctx)
 	if err != nil {
-		return fmt.Errorf("list pending run completion summaries: %w", err)
+		return err
 	}
 
 	for _, run := range runs {
-		if run == nil {
-			continue
-		}
 		switch {
 		case run.CompletionSummaryStatus == nil:
 			c.prepareRunCompletionSummaryBestEffort(ctx, run.ID)
@@ -312,6 +305,37 @@ func (c *runtimeCompletionSummaryCoordinator) reconcileRunCompletionSummaries(ct
 		}
 	}
 	return nil
+}
+
+func (c *runtimeCompletionSummaryCoordinator) listPendingRunCompletionSummaries(ctx context.Context) ([]pendingRunCompletionSummary, error) {
+	if c == nil || c.client == nil {
+		return nil, nil
+	}
+
+	var runs []pendingRunCompletionSummary
+	if err := c.client.AgentRun.Query().
+		Where(
+			entagentrun.StatusIn(
+				entagentrun.StatusCompleted,
+				entagentrun.StatusErrored,
+				entagentrun.StatusInterrupted,
+				entagentrun.StatusTerminated,
+			),
+			entagentrun.Or(
+				entagentrun.CompletionSummaryStatusIsNil(),
+				entagentrun.CompletionSummaryStatusEQ(entagentrun.CompletionSummaryStatusPending),
+			),
+		).
+		Order(entagentrun.ByTerminalAt(sql.OrderAsc())).
+		Select(
+			entagentrun.FieldID,
+			entagentrun.FieldCompletionSummaryStatus,
+			entagentrun.FieldTerminalAt,
+		).
+		Scan(ctx, &runs); err != nil {
+		return nil, fmt.Errorf("list pending run completion summaries: %w", err)
+	}
+	return runs, nil
 }
 
 func (c *runtimeCompletionSummaryCoordinator) prepareRunCompletionSummaryBestEffort(ctx context.Context, runID uuid.UUID) {

--- a/internal/orchestrator/run_completion_summary_test.go
+++ b/internal/orchestrator/run_completion_summary_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/BetterAndBetterII/openase/ent"
 	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
 	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
+	entticket "github.com/BetterAndBetterII/openase/ent/ticket"
+	entworkflow "github.com/BetterAndBetterII/openase/ent/workflow"
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	eventinfra "github.com/BetterAndBetterII/openase/internal/infra/event"
 	"github.com/google/uuid"
@@ -359,6 +361,123 @@ func TestBuildRunCompletionSummaryUserPromptCompactsOversizedInput(t *testing.T)
 	}
 	if !strings.Contains(prompt, "\"omitted_counts\"") {
 		t.Fatalf("expected prompt context to record omitted counts, got %q", prompt)
+	}
+}
+
+func TestListPendingRunCompletionSummariesOnlyReturnsPendingTerminalRuns(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	now := time.Date(2026, 4, 4, 9, 0, 0, 0, time.UTC)
+	fixture := seedProjectFixtureAt(ctx, t, client, now)
+
+	workflowItem, err := client.Workflow.Create().
+		SetProjectID(fixture.projectID).
+		SetName("Coding").
+		SetType(entworkflow.TypeCoding).
+		SetHarnessPath(".openase/harnesses/coding.md").
+		SetMaxConcurrent(1).
+		AddPickupStatusIDs(fixture.statusIDs["Todo"]).
+		AddFinishStatusIDs(fixture.statusIDs["Done"]).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	agentItem := fixture.createAgent(ctx, t, "coding-01", 0)
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(fixture.projectID).
+		SetIdentifier("ASE-382").
+		SetTitle("Fix reconcile query").
+		SetStatusID(fixture.statusIDs["Todo"]).
+		SetPriority(entticket.PriorityMedium).
+		SetCreatedBy("user:test").
+		SetCreatedAt(now.Add(-time.Hour)).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+
+	nilSummaryRun, err := client.AgentRun.Create().
+		SetAgentID(agentItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(ticketItem.ID).
+		SetProviderID(fixture.providerID).
+		SetStatus(entagentrun.StatusCompleted).
+		SetTerminalAt(now.Add(1 * time.Minute)).
+		SetCreatedAt(now.Add(-50 * time.Minute)).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create nil-summary run: %v", err)
+	}
+	pendingStatus := entagentrun.CompletionSummaryStatusPending
+	pendingSummaryRun, err := client.AgentRun.Create().
+		SetAgentID(agentItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(ticketItem.ID).
+		SetProviderID(fixture.providerID).
+		SetStatus(entagentrun.StatusErrored).
+		SetCompletionSummaryStatus(pendingStatus).
+		SetTerminalAt(now.Add(2 * time.Minute)).
+		SetCreatedAt(now.Add(-40 * time.Minute)).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create pending-summary run: %v", err)
+	}
+	completedStatus := entagentrun.CompletionSummaryStatusCompleted
+	if _, err := client.AgentRun.Create().
+		SetAgentID(agentItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(ticketItem.ID).
+		SetProviderID(fixture.providerID).
+		SetStatus(entagentrun.StatusCompleted).
+		SetCompletionSummaryStatus(completedStatus).
+		SetTerminalAt(now.Add(30 * time.Second)).
+		SetCreatedAt(now.Add(-30 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("create completed-summary run: %v", err)
+	}
+	if _, err := client.AgentRun.Create().
+		SetAgentID(agentItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(ticketItem.ID).
+		SetProviderID(fixture.providerID).
+		SetStatus(entagentrun.StatusExecuting).
+		SetCompletionSummaryStatus(pendingStatus).
+		SetCreatedAt(now.Add(-20 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("create non-terminal pending run: %v", err)
+	}
+	failedStatus := entagentrun.CompletionSummaryStatusFailed
+	if _, err := client.AgentRun.Create().
+		SetAgentID(agentItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetTicketID(ticketItem.ID).
+		SetProviderID(fixture.providerID).
+		SetStatus(entagentrun.StatusTerminated).
+		SetCompletionSummaryStatus(failedStatus).
+		SetTerminalAt(now.Add(3 * time.Minute)).
+		SetCreatedAt(now.Add(-10 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("create failed-summary run: %v", err)
+	}
+
+	coordinator := newRuntimeCompletionSummaryCoordinator(client, nil, nil, nil, nil, nil, nil, func() time.Time {
+		return now
+	}, 0)
+	runs, err := coordinator.listPendingRunCompletionSummaries(ctx)
+	if err != nil {
+		t.Fatalf("list pending run completion summaries: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected two pending terminal runs, got %+v", runs)
+	}
+	if runs[0].ID != nilSummaryRun.ID || runs[1].ID != pendingSummaryRun.ID {
+		t.Fatalf("unexpected pending run order: %+v", runs)
+	}
+	if runs[0].CompletionSummaryStatus != nil {
+		t.Fatalf("expected first run to keep nil completion summary status, got %+v", runs[0].CompletionSummaryStatus)
+	}
+	if runs[1].CompletionSummaryStatus == nil || *runs[1].CompletionSummaryStatus != entagentrun.CompletionSummaryStatusPending {
+		t.Fatalf("expected second run to keep pending completion summary status, got %+v", runs[1].CompletionSummaryStatus)
 	}
 }
 


### PR DESCRIPTION
## What changed
- narrow `reconcileRunCompletionSummaries` to only scan runs whose `completion_summary_status` is `NULL` or `pending`
- select only the minimal fields needed for reconciliation (`id`, `completion_summary_status`, and the ordering field)
- add a focused orchestrator test that proves only terminal pending-summary runs are returned

## Why
The reconcile loop was previously scanning all terminal runs and materializing full `AgentRun` rows even when no completion summaries were actually pending. In the current database state, where pending rows are `0`, that caused unnecessary idle work.

## Root cause
The reconcile query filtered only on terminal run status and then probed each full row in memory to decide whether to prepare or schedule a completion summary. That widened the scan and forced whole-row materialization for records that were already completed or failed.

## Impact
- pending-summary reconciliation now becomes a near no-op when there are no pending rows
- the DB query stays precise and cheaper in idle paths
- behavior for `NULL` vs `pending` summary states is preserved, but non-pending runs are no longer scanned

## Validation
- `go test ./internal/orchestrator -run 'TestListPendingRunCompletionSummariesOnlyReturnsPendingTerminalRuns|TestPublishRunCompletionSummaryEventEmitsTicketRunSummaryPayload|TestBuildRunCompletionSummary'`
- `go test ./internal/orchestrator -run '^TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync$'` (known unrelated env failure: reverse websocket runtime machine never becomes ready)
- `make check` with `OPENASE_PGTEST_SHARED_ROOT=$HOME/.cache/openase/pgtest OPENASE_GO_TEST_PROGRESS_MODE=json` (known unrelated env failures in websocket runtime coverage tests: `internal/chat TestConversationTerminalServiceSupportsWebsocketRuntime` exits 127 and `internal/orchestrator TestRuntimeLauncherLaunchesWebsocketReverseRuntimeWithHooksAndArtifactSync` leaves the reverse runtime machine offline)
