### PR TITLE
ASE-385: add gpt-5.5 as default Codex model

### DIFF
--- a/internal/domain/catalog/builtin_agent_providers.go
+++ b/internal/domain/catalog/builtin_agent_providers.go
@@ -23,7 +23,7 @@ func BuiltinAgentProviderTemplates() []BuiltinAgentProviderTemplate {
 			Name:        "OpenAI Codex",
 			Command:     "codex",
 			AdapterType: AgentProviderAdapterTypeCodexAppServer,
-			ModelName:   "gpt-5.4",
+			ModelName:   "gpt-5.5",
 			CliArgs:     []string{"app-server", "--listen", "stdio://"},
 		},
 		{

--- a/internal/domain/catalog/coverage_test.go
+++ b/internal/domain/catalog/coverage_test.go
@@ -1966,6 +1966,9 @@ func TestCatalogEnvironmentProvisioningHelpers(t *testing.T) {
 	if len(templates) != 3 || templates[1].AdapterType != AgentProviderAdapterTypeCodexAppServer || !reflect.DeepEqual(templates[1].CliArgs, []string{"app-server", "--listen", "stdio://"}) {
 		t.Fatalf("BuiltinAgentProviderTemplates() = %+v", templates)
 	}
+	if templates[1].ModelName != "gpt-5.5" {
+		t.Fatalf("BuiltinAgentProviderTemplates() codex model = %q, want gpt-5.5", templates[1].ModelName)
+	}
 
 	auditPlan := MachineEnvironmentProvisioningPlan{}
 	auditPlan.appendAuditIssues(storedFullAudit{

--- a/internal/domain/catalog/provider_model_pricing.go
+++ b/internal/domain/catalog/provider_model_pricing.go
@@ -6,10 +6,14 @@ import (
 	"github.com/BetterAndBetterII/openase/internal/domain/pricing"
 )
 
-const builtinPricingVerifiedAt = "2026-04-01"
+const (
+	builtinPricingVerifiedAt       = "2026-04-01"
+	builtinOpenAIPricingVerifiedAt = "2026-04-29"
+)
 
 var builtinAgentProviderPricingConfigs = map[AgentProviderAdapterType]map[string]pricing.ProviderModelPricingConfig{
 	AgentProviderAdapterTypeCodexAppServer: {
+		"gpt-5.5":            openAIPricingConfig("gpt-5.5", 5.00, 30.00, 0.50),
 		"gpt-5.4":            openAIPricingConfig("gpt-5.4", 2.50, 15.00, 0.25),
 		"gpt-5.4-mini":       openAIPricingConfig("gpt-5.4-mini", 0.75, 4.50, 0.075),
 		"gpt-5.3-codex":      openAIPricingConfig("gpt-5.3-codex", 1.75, 14.00, 0.175),
@@ -148,15 +152,15 @@ func openAIPricingConfig(
 	cachedInputUSDPerMillion float64,
 ) pricing.ProviderModelPricingConfig {
 	return pricing.ProviderModelPricingConfig{
-		Version:          builtinPricingVerifiedAt,
+		Version:          builtinOpenAIPricingVerifiedAt,
 		SourceKind:       pricing.PricingSourceKindOfficial,
 		PricingMode:      pricing.PricingModeFlat,
 		Provider:         "openai",
 		ModelID:          modelID,
-		SourceURL:        "https://platform.openai.com/docs/pricing/",
-		SourceVerifiedAt: builtinPricingVerifiedAt,
+		SourceURL:        "https://openai.com/api/pricing/",
+		SourceVerifiedAt: builtinOpenAIPricingVerifiedAt,
 		Notes: []string{
-			"Official OpenAI API pricing defaults.",
+			"Official OpenAI API pricing defaults verified against the API pricing page.",
 		},
 		Rates: pricing.ProviderModelPricingRates{
 			InputPerToken:           usdPerMillion(inputUSDPerMillion),

--- a/internal/domain/catalog/provider_model_pricing_test.go
+++ b/internal/domain/catalog/provider_model_pricing_test.go
@@ -9,7 +9,7 @@ import (
 func TestBuiltinAgentProviderPricingConfigReturnsClone(t *testing.T) {
 	t.Parallel()
 
-	config, ok := BuiltinAgentProviderPricingConfig(AgentProviderAdapterTypeCodexAppServer, " gpt-5.4 ")
+	config, ok := BuiltinAgentProviderPricingConfig(AgentProviderAdapterTypeCodexAppServer, " gpt-5.5 ")
 	if !ok {
 		t.Fatal("expected builtin codex pricing config")
 	}
@@ -18,12 +18,20 @@ func TestBuiltinAgentProviderPricingConfigReturnsClone(t *testing.T) {
 	}
 
 	config.Notes[0] = "changed"
-	fresh, ok := BuiltinAgentProviderPricingConfig(AgentProviderAdapterTypeCodexAppServer, "gpt-5.4")
+	fresh, ok := BuiltinAgentProviderPricingConfig(AgentProviderAdapterTypeCodexAppServer, "gpt-5.5")
 	if !ok {
 		t.Fatal("expected fresh builtin codex pricing config")
 	}
 	if fresh.Notes[0] == "changed" {
 		t.Fatalf("expected builtin pricing lookup to return clone, got %+v", fresh)
+	}
+	if fresh.ModelID != "gpt-5.5" || fresh.SourceURL != "https://openai.com/api/pricing/" || fresh.SourceVerifiedAt != builtinOpenAIPricingVerifiedAt {
+		t.Fatalf("expected refreshed gpt-5.5 pricing metadata, got %+v", fresh)
+	}
+	if fresh.Rates.InputPerToken != usdPerMillion(5.00) ||
+		fresh.Rates.CachedInputReadPerToken != usdPerMillion(0.50) ||
+		fresh.Rates.OutputPerToken != usdPerMillion(30.00) {
+		t.Fatalf("expected official gpt-5.5 pricing rates, got %+v", fresh.Rates)
 	}
 
 	if _, ok := BuiltinAgentProviderPricingConfig(AgentProviderAdapterType("unknown"), "gpt-5.4"); ok {
@@ -47,7 +55,7 @@ func TestResolveAgentProviderPricingConfig(t *testing.T) {
 	}
 	custom := ResolveAgentProviderPricingConfig(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		0,
 		0,
 		rawCustom,
@@ -58,12 +66,12 @@ func TestResolveAgentProviderPricingConfig(t *testing.T) {
 
 	builtin := ResolveAgentProviderPricingConfig(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		0,
 		0,
 		map[string]any{"rates": map[string]any{"input_per_token": -1}},
 	)
-	if builtin.SourceKind != pricing.PricingSourceKindOfficial || builtin.ModelID != "gpt-5.4" {
+	if builtin.SourceKind != pricing.PricingSourceKindOfficial || builtin.ModelID != "gpt-5.5" {
 		t.Fatalf("expected builtin fallback pricing config, got %+v", builtin)
 	}
 
@@ -97,7 +105,7 @@ func TestDeriveAgentProviderPricing(t *testing.T) {
 
 	derived := DeriveAgentProviderPricing(AgentProvider{
 		AdapterType: AgentProviderAdapterTypeCodexAppServer,
-		ModelName:   "gpt-5.4",
+		ModelName:   "gpt-5.5",
 	})
 	if derived.PricingConfig.SourceKind != pricing.PricingSourceKindOfficial {
 		t.Fatalf("expected official derived pricing config, got %+v", derived.PricingConfig)

--- a/internal/domain/catalog/provider_models.go
+++ b/internal/domain/catalog/provider_models.go
@@ -21,10 +21,23 @@ var builtinAgentProviderModelOptionAdapters = []AgentProviderAdapterType{
 var builtinAgentProviderModelOptions = map[AgentProviderAdapterType][]AgentProviderModelOption{
 	AgentProviderAdapterTypeCodexAppServer: {
 		{
+			ID:          "gpt-5.5",
+			Label:       "gpt-5.5",
+			Description: "Default flagship model for complex reasoning and coding.",
+			Recommended: true,
+			PricingConfig: builtinPricingConfigPointer(
+				AgentProviderAdapterTypeCodexAppServer,
+				"gpt-5.5",
+			),
+			Reasoning: builtinModelReasoningCapabilityPointer(
+				AgentProviderAdapterTypeCodexAppServer,
+				"gpt-5.5",
+			),
+		},
+		{
 			ID:          "gpt-5.4",
 			Label:       "gpt-5.4",
-			Description: "Latest frontier agentic coding model.",
-			Recommended: true,
+			Description: "Prior flagship coding model.",
 			PricingConfig: builtinPricingConfigPointer(
 				AgentProviderAdapterTypeCodexAppServer,
 				"gpt-5.4",

--- a/internal/domain/catalog/provider_models_test.go
+++ b/internal/domain/catalog/provider_models_test.go
@@ -4,11 +4,14 @@ import "testing"
 
 func TestBuiltinAgentProviderModelOptionsCodex(t *testing.T) {
 	options := BuiltinAgentProviderModelOptions(AgentProviderAdapterTypeCodexAppServer)
-	if len(options) != 8 {
-		t.Fatalf("BuiltinAgentProviderModelOptions(codex) count = %d, want 8", len(options))
+	if len(options) != 9 {
+		t.Fatalf("BuiltinAgentProviderModelOptions(codex) count = %d, want 9", len(options))
 	}
-	if options[0].ID != "gpt-5.4" || !options[0].Recommended {
-		t.Fatalf("first codex option = %+v, want recommended gpt-5.4", options[0])
+	if options[0].ID != "gpt-5.5" || !options[0].Recommended {
+		t.Fatalf("first codex option = %+v, want recommended gpt-5.5", options[0])
+	}
+	if options[1].ID != "gpt-5.4" || options[1].Recommended {
+		t.Fatalf("second codex option = %+v, want retained non-recommended gpt-5.4", options[1])
 	}
 	if options[len(options)-1].ID != "gpt-5.1-codex-mini" {
 		t.Fatalf("last codex option = %+v, want gpt-5.1-codex-mini", options[len(options)-1])
@@ -57,7 +60,7 @@ func TestBuiltinAgentProviderModelOptionsReturnsClone(t *testing.T) {
 	options[0].Reasoning.SupportedEfforts[0] = AgentProviderReasoningEffortMinimal
 
 	fresh := BuiltinAgentProviderModelOptions(AgentProviderAdapterTypeCodexAppServer)
-	if fresh[0].ID != "gpt-5.4" {
+	if fresh[0].ID != "gpt-5.5" {
 		t.Fatalf("BuiltinAgentProviderModelOptions() did not return a clone: %+v", fresh[0])
 	}
 	if fresh[0].PricingConfig == nil || fresh[0].PricingConfig.Rates.InputPerToken == 123 {
@@ -92,9 +95,9 @@ func TestBuiltinAgentProviderAdaptersWithModelOptionsReturnsClone(t *testing.T) 
 }
 
 func TestBuiltinPricingConfigPointer(t *testing.T) {
-	ptr := builtinPricingConfigPointer(AgentProviderAdapterTypeCodexAppServer, "gpt-5.4")
-	if ptr == nil || ptr.ModelID != "gpt-5.4" {
-		t.Fatalf("builtinPricingConfigPointer() = %+v, want gpt-5.4 pricing config", ptr)
+	ptr := builtinPricingConfigPointer(AgentProviderAdapterTypeCodexAppServer, "gpt-5.5")
+	if ptr == nil || ptr.ModelID != "gpt-5.5" {
+		t.Fatalf("builtinPricingConfigPointer() = %+v, want gpt-5.5 pricing config", ptr)
 	}
 	if builtinPricingConfigPointer(AgentProviderAdapterTypeCodexAppServer, "unknown") != nil {
 		t.Fatal("builtinPricingConfigPointer() expected nil for unknown model")

--- a/internal/domain/catalog/provider_reasoning.go
+++ b/internal/domain/catalog/provider_reasoning.go
@@ -41,6 +41,12 @@ type AgentProviderModelReasoningCapability struct {
 
 var builtinAgentProviderModelReasoning = map[AgentProviderAdapterType]map[string]AgentProviderModelReasoningCapability{
 	AgentProviderAdapterTypeCodexAppServer: {
+		"gpt-5.5": {
+			State:                  AgentProviderCapabilityStateAvailable,
+			SupportedEfforts:       newReasoningEffortSlice(AgentProviderReasoningEffortLow, AgentProviderReasoningEffortMedium, AgentProviderReasoningEffortHigh, AgentProviderReasoningEffortXHigh),
+			DefaultEffort:          reasoningEffortPointer(AgentProviderReasoningEffortMedium),
+			SupportsProviderPreset: true,
+		},
 		"gpt-5.4": {
 			State:                  AgentProviderCapabilityStateAvailable,
 			SupportedEfforts:       newReasoningEffortSlice(AgentProviderReasoningEffortLow, AgentProviderReasoningEffortMedium, AgentProviderReasoningEffortHigh, AgentProviderReasoningEffortXHigh),

--- a/internal/domain/catalog/provider_reasoning_test.go
+++ b/internal/domain/catalog/provider_reasoning_test.go
@@ -10,7 +10,7 @@ import (
 func TestBuiltinAgentProviderModelReasoningCapabilityCodex(t *testing.T) {
 	capability := BuiltinAgentProviderModelReasoningCapability(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 	)
 	if capability.State != AgentProviderCapabilityStateAvailable {
 		t.Fatalf("capability state = %q, want available", capability.State)
@@ -69,7 +69,7 @@ func TestParseAgentProviderReasoningEffort(t *testing.T) {
 	raw := " high "
 	parsed, err := parseAgentProviderReasoningEffort(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		&raw,
 	)
 	if err != nil {
@@ -84,7 +84,7 @@ func TestParseAgentProviderReasoningEffortRejectsUnsupportedCombination(t *testi
 	raw := "max"
 	if _, err := parseAgentProviderReasoningEffort(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		&raw,
 	); err == nil || !strings.Contains(err.Error(), `allowed values: low, medium, high, xhigh`) {
 		t.Fatalf("parseAgentProviderReasoningEffort() error = %v", err)
@@ -94,7 +94,7 @@ func TestParseAgentProviderReasoningEffortRejectsUnsupportedCombination(t *testi
 func TestParseAgentProviderReasoningEffortHandlesEmptyInput(t *testing.T) {
 	if got, err := parseAgentProviderReasoningEffort(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		nil,
 	); err != nil || got != nil {
 		t.Fatalf("parseAgentProviderReasoningEffort(nil) = (%v, %v), want (nil, nil)", got, err)
@@ -103,7 +103,7 @@ func TestParseAgentProviderReasoningEffortHandlesEmptyInput(t *testing.T) {
 	raw := "   "
 	if got, err := parseAgentProviderReasoningEffort(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		&raw,
 	); err != nil || got != nil {
 		t.Fatalf("parseAgentProviderReasoningEffort(blank) = (%v, %v), want (nil, nil)", got, err)
@@ -114,7 +114,7 @@ func TestParseAgentProviderReasoningEffortRejectsInvalidValue(t *testing.T) {
 	raw := "turbo"
 	if _, err := parseAgentProviderReasoningEffort(
 		AgentProviderAdapterTypeCodexAppServer,
-		"gpt-5.4",
+		"gpt-5.5",
 		&raw,
 	); err == nil || !strings.Contains(err.Error(), "reasoning_effort must be one of minimal, low, medium, high, xhigh, max") {
 		t.Fatalf("parseAgentProviderReasoningEffort() error = %v", err)

--- a/internal/httpapi/agent_catalog_test.go
+++ b/internal/httpapi/agent_catalog_test.go
@@ -1158,14 +1158,32 @@ func TestAgentCatalogRouteErrorMappingsAndHelpers(t *testing.T) {
 	if modelOptionsRec.Code != http.StatusOK {
 		t.Fatalf("provider model options status = %d, body=%s", modelOptionsRec.Code, modelOptionsRec.Body.String())
 	}
-	if !strings.Contains(modelOptionsRec.Body.String(), `"adapter_type":"codex-app-server"`) {
-		t.Fatalf("provider model options body missing codex adapter: %s", modelOptionsRec.Body.String())
+
+	var modelOptionsPayload struct {
+		AdapterModelOptions []agentProviderModelCatalogEntryResponse `json:"adapter_model_options"`
 	}
-	if !strings.Contains(modelOptionsRec.Body.String(), `"id":"gpt-5.4"`) {
-		t.Fatalf("provider model options body missing codex model: %s", modelOptionsRec.Body.String())
+	decodeResponse(t, modelOptionsRec, &modelOptionsPayload)
+
+	codexIndex := slices.IndexFunc(modelOptionsPayload.AdapterModelOptions, func(entry agentProviderModelCatalogEntryResponse) bool {
+		return entry.AdapterType == string(domain.AgentProviderAdapterTypeCodexAppServer)
+	})
+	if codexIndex < 0 {
+		t.Fatalf("provider model options missing codex adapter: %+v", modelOptionsPayload.AdapterModelOptions)
 	}
-	if !strings.Contains(modelOptionsRec.Body.String(), `"supported_efforts":["low","medium","high","xhigh"]`) {
-		t.Fatalf("provider model options body missing reasoning efforts: %s", modelOptionsRec.Body.String())
+	codexOptions := modelOptionsPayload.AdapterModelOptions[codexIndex].Options
+	if len(codexOptions) == 0 {
+		t.Fatalf("provider model options missing codex models: %+v", modelOptionsPayload.AdapterModelOptions[codexIndex])
+	}
+	if codexOptions[0].ID != "gpt-5.5" || !codexOptions[0].Recommended {
+		t.Fatalf("first codex model option = %+v, want recommended gpt-5.5", codexOptions[0])
+	}
+	if codexOptions[0].PricingConfig == nil ||
+		codexOptions[0].PricingConfig.ModelID != "gpt-5.5" ||
+		codexOptions[0].PricingConfig.SourceURL != "https://openai.com/api/pricing/" {
+		t.Fatalf("first codex model pricing = %+v, want refreshed gpt-5.5 pricing", codexOptions[0].PricingConfig)
+	}
+	if codexOptions[0].Reasoning == nil || !slices.Equal(codexOptions[0].Reasoning.SupportedEfforts, []string{"low", "medium", "high", "xhigh"}) {
+		t.Fatalf("first codex model reasoning = %+v, want [low medium high xhigh]", codexOptions[0].Reasoning)
 	}
 
 	mappedProvider := mapAgentProviderResponse(service.providers[providerOneID])

--- a/web/src/lib/features/agents/provider-model-options.test.ts
+++ b/web/src/lib/features/agents/provider-model-options.test.ts
@@ -13,10 +13,26 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
     adapter_type: 'codex-app-server',
     options: [
       {
+        id: 'gpt-5.5',
+        label: 'gpt-5.5',
+        description: 'Default flagship model for complex reasoning and coding.',
+        recommended: true,
+        preview: false,
+        pricing_config: null,
+        reasoning: {
+          state: 'available',
+          reason: null,
+          supported_efforts: ['low', 'medium', 'high', 'xhigh'],
+          default_effort: 'medium',
+          supports_provider_preset: true,
+          supports_model_override: false,
+        },
+      },
+      {
         id: 'gpt-5.4',
         label: 'gpt-5.4',
-        description: 'Latest frontier agentic coding model.',
-        recommended: true,
+        description: 'Prior flagship coding model.',
+        recommended: false,
         preview: false,
         pricing_config: null,
         reasoning: {
@@ -141,7 +157,7 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
 describe('provider model options', () => {
   it('returns the recommended model id for an adapter', () => {
     expect(recommendedProviderModelId(providerModelCatalogFixture, 'codex-app-server')).toBe(
-      'gpt-5.4',
+      'gpt-5.5',
     )
   })
 
@@ -175,7 +191,7 @@ describe('provider model options', () => {
 
   it('falls back to the recommended model when the adapter changes', () => {
     expect(
-      splitProviderModelSelection(providerModelCatalogFixture, 'gemini-cli', 'gpt-5.4', false),
+      splitProviderModelSelection(providerModelCatalogFixture, 'gemini-cli', 'gpt-5.5', false),
     ).toEqual({
       baseModelId: 'auto-gemini-2.5',
       customModelId: '',
@@ -184,7 +200,7 @@ describe('provider model options', () => {
 
   it('derives reasoning capability for known and unknown models', () => {
     expect(
-      providerModelReasoningCapability(providerModelCatalogFixture, 'codex-app-server', 'gpt-5.4'),
+      providerModelReasoningCapability(providerModelCatalogFixture, 'codex-app-server', 'gpt-5.5'),
     ).toEqual(
       expect.objectContaining({
         state: 'available',

--- a/web/src/lib/features/agents/provider-pricing.test.ts
+++ b/web/src/lib/features/agents/provider-pricing.test.ts
@@ -8,9 +8,9 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
     adapter_type: 'codex-app-server',
     options: [
       {
-        id: 'gpt-5.4',
-        label: 'gpt-5.4',
-        description: 'Latest frontier agentic coding model.',
+        id: 'gpt-5.5',
+        label: 'gpt-5.5',
+        description: 'Default flagship model for complex reasoning and coding.',
         recommended: true,
         preview: false,
         reasoning: null,
@@ -18,17 +18,17 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
           source_kind: 'official',
           pricing_mode: 'flat',
           provider: 'openai',
-          model_id: 'gpt-5.4',
-          source_url: 'https://platform.openai.com/docs/pricing/',
-          source_verified_at: '2026-04-01',
+          model_id: 'gpt-5.5',
+          source_url: 'https://openai.com/api/pricing/',
+          source_verified_at: '2026-04-29',
           rates: {
-            input_per_token: 0.0000025,
-            output_per_token: 0.000015,
-            cached_input_read_per_token: 0.00000025,
+            input_per_token: 0.000005,
+            output_per_token: 0.00003,
+            cached_input_read_per_token: 0.0000005,
           },
           notes: [],
           tiers: [],
-          version: '2026-04-01',
+          version: '2026-04-29',
         },
       },
     ],
@@ -66,7 +66,7 @@ describe('provider pricing draft suggestions', () => {
       suggestPricingDraftValues({
         modelCatalog: providerModelCatalogFixture,
         adapterType: 'codex-app-server',
-        modelName: 'gpt-5.4',
+        modelName: 'gpt-5.5',
         currentPricingConfig: null,
         currentCostPerInputToken: '0',
         currentCostPerOutputToken: '0',
@@ -74,10 +74,10 @@ describe('provider pricing draft suggestions', () => {
     ).toEqual({
       pricingConfig: expect.objectContaining({
         source_kind: 'official',
-        model_id: 'gpt-5.4',
+        model_id: 'gpt-5.5',
       }),
-      costPerInputToken: '2.5',
-      costPerOutputToken: '15',
+      costPerInputToken: '5',
+      costPerOutputToken: '30',
     })
   })
 
@@ -86,7 +86,7 @@ describe('provider pricing draft suggestions', () => {
       suggestPricingDraftValues({
         modelCatalog: providerModelCatalogFixture,
         adapterType: 'codex-app-server',
-        modelName: 'gpt-5.4',
+        modelName: 'gpt-5.5',
         currentPricingConfig: createCustomFlatPricingConfig(0.000003, 0.000015),
         currentCostPerInputToken: '3',
         currentCostPerOutputToken: '15',
@@ -119,22 +119,22 @@ describe('provider pricing draft suggestions', () => {
       suggestPricingDraftValues({
         modelCatalog: providerModelCatalogFixture,
         adapterType: 'codex-app-server',
-        modelName: 'gpt-5.4-experimental',
+        modelName: 'gpt-5.5-experimental',
         currentPricingConfig: providerModelCatalogFixture[0].options[0].pricing_config,
-        currentCostPerInputToken: '2.5',
-        currentCostPerOutputToken: '15',
+        currentCostPerInputToken: '5',
+        currentCostPerOutputToken: '30',
       }),
     ).toEqual({
       pricingConfig: {
         source_kind: 'custom',
         pricing_mode: 'flat',
         rates: {
-          input_per_token: 0.0000025,
-          output_per_token: 0.000015,
+          input_per_token: 0.000005,
+          output_per_token: 0.00003,
         },
       },
-      costPerInputToken: '2.5',
-      costPerOutputToken: '15',
+      costPerInputToken: '5',
+      costPerOutputToken: '30',
     })
   })
 })

--- a/web/src/lib/features/onboarding/provider-guide-data.test.ts
+++ b/web/src/lib/features/onboarding/provider-guide-data.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { guideText } from './provider-guide-data'
+
+describe('provider guide data', () => {
+  it('surfaces gpt-5.5 as the Codex recommended model', () => {
+    expect(guideText('codex', 'recommendedModel')).toBe('gpt-5.5')
+  })
+})

--- a/web/src/lib/features/onboarding/provider-guide-data.ts
+++ b/web/src/lib/features/onboarding/provider-guide-data.ts
@@ -54,7 +54,7 @@ const guideCopy: Record<string, GuideCopyEntry> = {
     fallback: 'Codex CLI official docs',
   },
   'codex.recommendedModel': {
-    fallback: 'gpt-5.4',
+    fallback: 'gpt-5.5',
   },
   'codex.install.global': {
     translationKey: 'onboarding.providerGuide.codex.install.global',


### PR DESCRIPTION
## What changed
- add `gpt-5.5` to the built-in Codex model catalog, pricing config, and reasoning capability map
- make `gpt-5.5` the recommended/default Codex model for new built-in providers and surfaced model options
- refresh focused backend and web tests, including onboarding guide copy for the recommended Codex model

## Validation
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/domain/catalog ./internal/httpapi`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir web exec vitest run src/lib/features/agents/provider-model-options.test.ts src/lib/features/agents/provider-pricing.test.ts src/lib/features/onboarding/provider-guide-data.test.ts`

## Notes
- `pnpm --dir web exec vitest run src/lib/features/onboarding/components/step-provider.test.ts` currently fails on this branch because the suite expects older onboarding copy/actions (`No providers registered yet`, `Guide`, `Use this provider`) that no longer match the rendered UI. This drift is unrelated to the `gpt-5.5` model update.
