### PR TITLE
ASE-383 Fix duplicate local machines causing monitor probe churn

### DIFF
--- a/internal/domain/catalog/machine_lifecycle.go
+++ b/internal/domain/catalog/machine_lifecycle.go
@@ -1,5 +1,9 @@
 package catalog
 
+func IsLocalMachineIdentity(name, host string, mode MachineConnectionMode) bool {
+	return name == LocalMachineName && host == LocalMachineHost && mode == MachineConnectionModeLocal
+}
+
 // DefaultMachineStatus returns the stored machine status to use when the
 // caller does not provide one explicitly. Remote machines begin offline until
 // connectivity or health checks prove they are schedulable; maintenance is

--- a/internal/orchestrator/machine_monitor.go
+++ b/internal/orchestrator/machine_monitor.go
@@ -72,6 +72,19 @@ type MachineMonitor struct {
 	now       func() time.Time
 }
 
+type localMachineProbeFanoutState struct {
+	level2Due bool
+	level3Due bool
+
+	systemLoaded bool
+	systemResult domain.MachineSystemResources
+	systemErr    error
+
+	gpuLoaded bool
+	gpuResult domain.MachineGPUResources
+	gpuErr    error
+}
+
 func NewMachineMonitor(client *ent.Client, logger *slog.Logger, collector MachineMonitorCollector) *MachineMonitor {
 	if logger == nil {
 		logger = slog.Default()
@@ -109,11 +122,14 @@ func (m *MachineMonitor) RunTick(ctx context.Context) (MachineMonitorReport, err
 	}
 
 	now := m.now().UTC()
+	machines := make([]monitoredMachine, 0, len(items))
 	for _, item := range items {
 		report.MachinesScanned++
-
-		current := mapMachineEntity(item)
-		updated, changed := m.runMachineTick(ctx, current, now, &report)
+		machines = append(machines, mapMachineEntity(item))
+	}
+	localFanout := planLocalMachineProbeFanout(machines, now)
+	for _, current := range machines {
+		updated, changed := m.runMachineTick(ctx, current, now, &report, localFanout[localMachineProbeFanoutKey(current)])
 		if !changed {
 			continue
 		}
@@ -191,12 +207,22 @@ func (m monitoredMachine) toDomain() domain.Machine {
 	}
 }
 
-func (m *MachineMonitor) runMachineTick(ctx context.Context, machine monitoredMachine, now time.Time, report *MachineMonitorReport) (monitoredMachine, bool) {
+func (m *MachineMonitor) runMachineTick(
+	ctx context.Context,
+	machine monitoredMachine,
+	now time.Time,
+	report *MachineMonitorReport,
+	localFanout *localMachineProbeFanoutState,
+) (monitoredMachine, bool) {
 	level1Due := machineMonitorDue(machine.Resources, "l1", now, machineMonitorLevel1Interval)
 	level2Due := machineMonitorDue(machine.Resources, "l2", now, machineMonitorLevel2Interval)
 	level3Due := machineMonitorDue(machine.Resources, "l3", now, machineMonitorLevel3Interval)
 	level4Due := machineMonitorDue(machine.Resources, "l4", now, machineMonitorLevel4Interval)
 	level5Due := machineMonitorDue(machine.Resources, "l5", now, machineMonitorLevel5Interval)
+	if localFanout != nil {
+		level2Due = level2Due || localFanout.level2Due
+		level3Due = level3Due || localFanout.level3Due
+	}
 	logger := m.machineLogger(machine)
 	if !level1Due && !level2Due && !level3Due && !level4Due && !level5Due {
 		return machine, false
@@ -263,8 +289,7 @@ func (m *MachineMonitor) runMachineTick(ctx context.Context, machine monitoredMa
 	}
 
 	if level2Due && !softReachabilityFailure && !hardReachabilityFailure && !isWebsocketMachine {
-		report.L2Checks++
-		systemResources, err := m.collector.CollectSystemResources(ctx, domainMachine)
+		systemResources, err := m.collectSystemResources(ctx, domainMachine, report, localFanout)
 		if err != nil {
 			systemProbeFailure = true
 			setMachineMonitorError(resources, "l2", err.Error())
@@ -285,8 +310,7 @@ func (m *MachineMonitor) runMachineTick(ctx context.Context, machine monitoredMa
 	}
 
 	if level3Due && !softReachabilityFailure && !hardReachabilityFailure && !isWebsocketMachine {
-		report.L3Checks++
-		gpuResources, err := m.collector.CollectGPUResources(ctx, domainMachine)
+		gpuResources, err := m.collectGPUResources(ctx, domainMachine, report, localFanout)
 		if err != nil {
 			setMachineMonitorError(resources, "l3", err.Error())
 			logger.Warn("machine monitor l3 gpu probe failed", "error", err)
@@ -481,6 +505,68 @@ func (m *MachineMonitor) runMachineTick(ctx context.Context, machine monitoredMa
 		LastHeartbeatAt:    lastHeartbeatAt,
 		Resources:          resources,
 	}, true
+}
+
+func (m *MachineMonitor) collectSystemResources(
+	ctx context.Context,
+	machine domain.Machine,
+	report *MachineMonitorReport,
+	localFanout *localMachineProbeFanoutState,
+) (domain.MachineSystemResources, error) {
+	if localFanout == nil {
+		report.L2Checks++
+		return m.collector.CollectSystemResources(ctx, machine)
+	}
+	if !localFanout.systemLoaded {
+		report.L2Checks++
+		localFanout.systemResult, localFanout.systemErr = m.collector.CollectSystemResources(ctx, machine)
+		localFanout.systemLoaded = true
+	}
+	return localFanout.systemResult, localFanout.systemErr
+}
+
+func (m *MachineMonitor) collectGPUResources(
+	ctx context.Context,
+	machine domain.Machine,
+	report *MachineMonitorReport,
+	localFanout *localMachineProbeFanoutState,
+) (domain.MachineGPUResources, error) {
+	if localFanout == nil {
+		report.L3Checks++
+		return m.collector.CollectGPUResources(ctx, machine)
+	}
+	if !localFanout.gpuLoaded {
+		report.L3Checks++
+		localFanout.gpuResult, localFanout.gpuErr = m.collector.CollectGPUResources(ctx, machine)
+		localFanout.gpuLoaded = true
+	}
+	return localFanout.gpuResult, localFanout.gpuErr
+}
+
+func planLocalMachineProbeFanout(machines []monitoredMachine, now time.Time) map[string]*localMachineProbeFanoutState {
+	states := map[string]*localMachineProbeFanoutState{}
+	for _, machine := range machines {
+		key := localMachineProbeFanoutKey(machine)
+		if key == "" {
+			continue
+		}
+		state := states[key]
+		if state == nil {
+			state = &localMachineProbeFanoutState{}
+			states[key] = state
+		}
+		state.level2Due = state.level2Due || machineMonitorDue(machine.Resources, "l2", now, machineMonitorLevel2Interval)
+		state.level3Due = state.level3Due || machineMonitorDue(machine.Resources, "l3", now, machineMonitorLevel3Interval)
+	}
+	return states
+}
+
+func localMachineProbeFanoutKey(machine monitoredMachine) string {
+	connectionMode, _, _ := resolveMonitoredMachineTransport(machine)
+	if !domain.IsLocalMachineIdentity(machine.Name, machine.Host, connectionMode) {
+		return ""
+	}
+	return string(connectionMode) + "|" + machine.Name + "|" + machine.Host
 }
 
 func (m *MachineMonitor) publishRuntimeEvents(

--- a/internal/orchestrator/machine_monitor_test.go
+++ b/internal/orchestrator/machine_monitor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,6 +79,99 @@ func TestMachineMonitorRunTickCollectsSingleLocalMachine(t *testing.T) {
 	}
 	if collector.reachabilityCalls != 1 || collector.systemCalls != 1 || collector.gpuCalls != 1 || collector.agentEnvCalls != 1 || collector.fullAuditCalls != 1 {
 		t.Fatalf("expected collector to run for local machine, got %+v", collector)
+	}
+}
+
+func TestMachineMonitorRunTickFansOutLocalL2AndL3AcrossDuplicateRows(t *testing.T) {
+	ctx := context.Background()
+	client := openTestEntClient(t)
+	orgOneID := createMachineMonitorOrg(ctx, t, client)
+	orgTwoID := createMachineMonitorOrg(ctx, t, client)
+
+	if _, err := client.Machine.Create().
+		SetOrganizationID(orgOneID).
+		SetName(domain.LocalMachineName).
+		SetHost(domain.LocalMachineHost).
+		SetPort(22).
+		SetStatus(entmachine.StatusOnline).
+		SetResources(map[string]any{}).
+		Save(ctx); err != nil {
+		t.Fatalf("create first local machine: %v", err)
+	}
+
+	secondItem, err := client.Machine.Create().
+		SetOrganizationID(orgTwoID).
+		SetName(domain.LocalMachineName).
+		SetHost(domain.LocalMachineHost).
+		SetPort(22).
+		SetStatus(entmachine.StatusOnline).
+		SetResources(map[string]any{
+			"cpu_cores": 1,
+			"gpu":       []map[string]any{{"index": 0, "name": "old"}},
+			"monitor": map[string]any{
+				"l2": map[string]any{"checked_at": time.Date(2026, 3, 20, 14, 0, 0, 0, time.UTC).Format(time.RFC3339)},
+				"l3": map[string]any{"checked_at": time.Date(2026, 3, 20, 14, 0, 0, 0, time.UTC).Format(time.RFC3339)},
+			},
+		}).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create second local machine: %v", err)
+	}
+
+	now := time.Date(2026, 3, 20, 14, 0, 30, 0, time.UTC)
+	collector := &fakeMachineMonitorCollector{
+		now: func() time.Time { return now },
+		systemResources: domain.MachineSystemResources{
+			CollectedAt:            now,
+			CPUCores:               16,
+			CPUUsagePercent:        12.5,
+			MemoryTotalGB:          64,
+			MemoryUsedGB:           20,
+			MemoryAvailableGB:      44,
+			MemoryAvailablePercent: 68.75,
+			DiskTotalGB:            500,
+			DiskAvailableGB:        320,
+			DiskAvailablePercent:   64,
+		},
+		gpuResources: domain.MachineGPUResources{
+			CollectedAt: now,
+			Available:   true,
+			GPUs: []domain.MachineGPU{
+				{Index: 0, Name: "RTX 4090", MemoryTotalGB: 24, MemoryUsedGB: 4, UtilizationPercent: 22},
+			},
+		},
+	}
+	monitor := NewMachineMonitor(client, slog.New(slog.NewTextHandler(io.Discard, nil)), collector)
+	monitor.now = func() time.Time { return now }
+
+	report, err := monitor.RunTick(ctx)
+	if err != nil {
+		t.Fatalf("run tick: %v", err)
+	}
+	if report.MachinesScanned != 2 || report.L2Checks != 1 || report.L3Checks != 1 {
+		t.Fatalf("expected shared local L2/L3 probes, got %+v", report)
+	}
+	if collector.systemCalls != 1 || collector.gpuCalls != 1 {
+		t.Fatalf("expected one shared L2/L3 probe, got %+v", collector)
+	}
+
+	secondAfter, err := client.Machine.Get(ctx, secondItem.ID)
+	if err != nil {
+		t.Fatalf("reload second local machine: %v", err)
+	}
+	if secondAfter.Resources["cpu_cores"] != float64(16) {
+		t.Fatalf("expected fanout system resources, got %+v", secondAfter.Resources)
+	}
+	if secondAfter.Resources["collected_at"] != now.Format(time.RFC3339) {
+		t.Fatalf("expected shared collected_at on duplicate local machine, got %+v", secondAfter.Resources["collected_at"])
+	}
+	gpuItems, ok := secondAfter.Resources["gpu"].([]interface{})
+	if !ok || len(gpuItems) != 1 {
+		t.Fatalf("expected shared gpu resources on duplicate local machine, got %+v", secondAfter.Resources["gpu"])
+	}
+	firstGPU := gpuItems[0].(map[string]any)
+	if firstGPU["name"] != "RTX 4090" {
+		t.Fatalf("expected shared gpu snapshot, got %+v", gpuItems)
 	}
 }
 
@@ -577,9 +671,10 @@ func TestMachineMonitorRunTickPublishesMachineAndProviderRuntimeEvents(t *testin
 
 func createMachineMonitorOrg(ctx context.Context, t *testing.T, client *ent.Client) uuid.UUID {
 	t.Helper()
+	suffix := strings.ToLower(strings.ReplaceAll(uuid.NewString(), "-", ""))
 	org, err := client.Organization.Create().
 		SetName("Better And Better").
-		SetSlug("better-and-better-machine-monitor").
+		SetSlug("better-and-better-machine-monitor-" + suffix).
 		Save(ctx)
 	if err != nil {
 		t.Fatalf("create organization: %v", err)

--- a/internal/service/catalog/agent_catalog_test.go
+++ b/internal/service/catalog/agent_catalog_test.go
@@ -1108,10 +1108,12 @@ type stubRepository struct {
 	updatedAgent           *domain.UpdateAgent
 	updatedRuntimeControl  *domain.UpdateAgentRuntimeControlState
 	updatedOrganization    *domain.UpdateOrganization
+	createdMachineInput    *domain.CreateMachine
 	archivedOrganizationID uuid.UUID
 	createdOrganization    domain.Organization
 	createdProject         domain.Project
 	organizations          []domain.Organization
+	listedMachines         []domain.Machine
 	projects               []domain.Project
 	projectRepos           []domain.ProjectRepo
 	agents                 []domain.Agent
@@ -1125,6 +1127,8 @@ type stubRepository struct {
 	provider               domain.AgentProvider
 	agent                  domain.Agent
 	machine                domain.Machine
+	createdMachine         domain.Machine
+	createMachineErr       error
 	recordedMachineProbe   *domain.RecordMachineProbe
 }
 
@@ -1162,11 +1166,12 @@ func (r *stubRepository) ListProjects(context.Context, uuid.UUID) ([]domain.Proj
 }
 
 func (r *stubRepository) ListMachines(context.Context, uuid.UUID) ([]domain.Machine, error) {
-	return nil, nil
+	return append([]domain.Machine(nil), r.listedMachines...), nil
 }
 
-func (r *stubRepository) CreateMachine(context.Context, domain.CreateMachine) (domain.Machine, error) {
-	return domain.Machine{}, nil
+func (r *stubRepository) CreateMachine(_ context.Context, input domain.CreateMachine) (domain.Machine, error) {
+	r.createdMachineInput = &input
+	return r.createdMachine, r.createMachineErr
 }
 
 func (r *stubRepository) GetMachine(context.Context, uuid.UUID) (domain.Machine, error) {

--- a/internal/service/catalog/coverage_test.go
+++ b/internal/service/catalog/coverage_test.go
@@ -192,6 +192,82 @@ func TestServiceMachineProbePathsAndHelpers(t *testing.T) {
 	}
 }
 
+func TestServiceCreateMachineReusesExistingLocalMachineIdentity(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	existing := domain.Machine{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		Name:           domain.LocalMachineName,
+		Host:           domain.LocalMachineHost,
+		ConnectionMode: domain.MachineConnectionModeLocal,
+		Status:         domain.MachineStatusOnline,
+	}
+	repo := &stubRepository{
+		listedMachines: []domain.Machine{
+			existing,
+			{
+				ID:             uuid.New(),
+				OrganizationID: orgID,
+				Name:           "gpu-01",
+				Host:           "10.0.0.10",
+				ConnectionMode: domain.MachineConnectionModeSSH,
+			},
+		},
+	}
+	svc := New(repo, nil, nil)
+
+	item, err := svc.CreateMachine(context.Background(), domain.CreateMachine{
+		OrganizationID: orgID,
+		Name:           domain.LocalMachineName,
+		Host:           domain.LocalMachineHost,
+		ConnectionMode: domain.MachineConnectionModeLocal,
+	})
+	if err != nil {
+		t.Fatalf("CreateMachine(local) error = %v", err)
+	}
+	if item.ID != existing.ID {
+		t.Fatalf("CreateMachine(local) = %+v, want existing %+v", item, existing)
+	}
+	if repo.createdMachineInput != nil {
+		t.Fatalf("CreateMachine(local) should not create a duplicate row: %+v", repo.createdMachineInput)
+	}
+}
+
+func TestServiceCreateMachineFallsBackToCreateForRemoteOrMissingLocalMachine(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	created := domain.Machine{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		Name:           "builder-01",
+		Host:           "10.0.0.15",
+		ConnectionMode: domain.MachineConnectionModeSSH,
+	}
+	repo := &stubRepository{
+		createdMachine: created,
+	}
+	svc := New(repo, nil, nil)
+
+	item, err := svc.CreateMachine(context.Background(), domain.CreateMachine{
+		OrganizationID: orgID,
+		Name:           created.Name,
+		Host:           created.Host,
+		ConnectionMode: created.ConnectionMode,
+	})
+	if err != nil {
+		t.Fatalf("CreateMachine(remote) error = %v", err)
+	}
+	if item.ID != created.ID {
+		t.Fatalf("CreateMachine(remote) = %+v, want %+v", item, created)
+	}
+	if repo.createdMachineInput == nil || repo.createdMachineInput.Name != created.Name {
+		t.Fatalf("CreateMachine(remote) should delegate to repository create, got %+v", repo.createdMachineInput)
+	}
+}
+
 func TestServiceCreateOrganizationAndProjectFallbackPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/catalog/service.go
+++ b/internal/service/catalog/service.go
@@ -187,6 +187,12 @@ func (s *service) ListMachines(ctx context.Context, organizationID uuid.UUID) ([
 }
 
 func (s *service) CreateMachine(ctx context.Context, input domain.CreateMachine) (domain.Machine, error) {
+	if existing, ok, err := s.findExistingLocalMachine(ctx, input); err != nil {
+		return domain.Machine{}, err
+	} else if ok {
+		return existing, nil
+	}
+
 	return s.repo.CreateMachine(ctx, input)
 }
 
@@ -200,6 +206,24 @@ func (s *service) UpdateMachine(ctx context.Context, input domain.UpdateMachine)
 
 func (s *service) DeleteMachine(ctx context.Context, id uuid.UUID) (domain.Machine, error) {
 	return s.repo.DeleteMachine(ctx, id)
+}
+
+func (s *service) findExistingLocalMachine(ctx context.Context, input domain.CreateMachine) (domain.Machine, bool, error) {
+	if !domain.IsLocalMachineIdentity(input.Name, input.Host, input.ConnectionMode) {
+		return domain.Machine{}, false, nil
+	}
+
+	machines, err := s.repo.ListMachines(ctx, input.OrganizationID)
+	if err != nil {
+		return domain.Machine{}, false, err
+	}
+	for _, machine := range machines {
+		if domain.IsLocalMachineIdentity(machine.Name, machine.Host, machine.ConnectionMode) {
+			return machine, true, nil
+		}
+	}
+
+	return domain.Machine{}, false, nil
 }
 
 func (s *service) GetWorkspaceDashboardSummary(ctx context.Context) (domain.WorkspaceDashboardSummary, error) {


### PR DESCRIPTION
## Summary
- make local machine creation idempotent at the catalog service layer by reusing an existing `local|local|local` row for the organization
- aggregate local machine monitor L2/L3 probes by physical local-machine identity and fan the shared snapshot out to duplicate rows
- add focused service and monitor coverage for local registration reuse and duplicate-row probe fanout

## Testing
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/service/catalog -count=1`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/orchestrator -run 'TestMachineMonitorRunTick(CollectsSingleLocalMachine|FansOutLocalL2AndL3AcrossDuplicateRows)$' -count=1`
