### PR TITLE
ASE-393: patch @xmldom/xmldom to 0.8.13

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,8 @@
   "pnpm": {
     "overrides": {
       "axios": "^1.15.0",
-      "follow-redirects": "^1.16.0"
+      "follow-redirects": "^1.16.0",
+      "@xmldom/xmldom": "0.8.13"
     },
     "onlyBuiltDependencies": [
       "electron",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: ^1.15.0
   follow-redirects: ^1.16.0
+  '@xmldom/xmldom': 0.8.13
 
 importers:
 
@@ -343,8 +344,8 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   abbrev@3.0.1:
@@ -2104,7 +2105,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@3.0.1: {}
 
@@ -3136,7 +3137,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary
- add a desktop pnpm override forcing `@xmldom/xmldom` to `0.8.13`
- refresh `desktop/pnpm-lock.yaml` so `plist` and the downstream desktop packaging graph resolve the patched version
- keep the change scoped to the desktop dependency metadata needed for GHSA-x6wf-f3px-wcqx / CVE-2026-41675

## Validation
- `pnpm --dir desktop install --lockfile-only`
- `pnpm --dir desktop why @xmldom/xmldom`
- `pnpm --dir desktop list @xmldom/xmldom --depth Infinity`
- `make desktop-install-browsers`
- `make desktop-validate`

## Ticket
- ASE-393
