### PR TITLE
ASE-391: upgrade desktop postcss

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,8 @@
   "pnpm": {
     "overrides": {
       "axios": "^1.15.0",
-      "follow-redirects": "^1.16.0"
+      "follow-redirects": "^1.16.0",
+      "postcss": "^8.5.10"
     },
     "onlyBuiltDependencies": [
       "electron",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: ^1.15.0
   follow-redirects: ^1.16.0
+  postcss: ^8.5.10
 
 importers:
 
@@ -1290,8 +1291,8 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -3140,7 +3141,7 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  postcss@8.5.9:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3464,7 +3465,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.12
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary
- add a desktop pnpm override so the transitive `vite` dependency resolves `postcss` to a patched 8.5.x release
- refresh `desktop/pnpm-lock.yaml` so the desktop dependency graph resolves `postcss@8.5.12`
- keep the remediation scoped to the desktop dependency graph only

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd desktop && pnpm list postcss --depth 10`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd desktop && pnpm why postcss`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd desktop && corepack pnpm run test:unit`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH cd desktop && corepack pnpm run package:smoke`
- `gh pr checks 786`
