### PR TITLE
ASE-389: upgrade postcss to 8.5.10

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -92,7 +92,8 @@
     "overrides": {
       "cookie": "0.7.2",
       "dompurify": "3.4.0",
-      "lodash-es": "4.18.1"
+      "lodash-es": "4.18.1",
+      "postcss": "8.5.10"
     }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   cookie: 0.7.2
   dompurify: 3.4.0
   lodash-es: 4.18.1
+  postcss: 8.5.10
 
 importers:
   .:
@@ -4904,17 +4905,10 @@ packages:
       }
     engines: { node: '>=4' }
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     resolution:
       {
-        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
-
-  postcss@8.5.9:
-    resolution:
-      {
-        integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==,
+        integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -8091,9 +8085,9 @@ snapshots:
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
-      postcss: 8.5.8
-      postcss-load-config: 3.1.4(postcss@8.5.8)
-      postcss-safe-parser: 7.0.1(postcss@8.5.8)
+      postcss: 8.5.10
+      postcss-load-config: 3.1.4(postcss@8.5.10)
+      postcss-safe-parser: 7.0.1(postcss@8.5.10)
       semver: 7.7.4
       svelte-eslint-parser: 1.6.0(svelte@5.54.0)
     optionalDependencies:
@@ -9301,33 +9295,27 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@3.1.4(postcss@8.5.8):
+  postcss-load-config@3.1.4(postcss@8.5.10):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
 
-  postcss-safe-parser@7.0.1(postcss@8.5.8):
+  postcss-safe-parser@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
 
-  postcss-scss@4.0.9(postcss@8.5.8):
+  postcss-scss@4.0.9(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -9797,8 +9785,8 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      postcss: 8.5.8
-      postcss-scss: 4.0.9(postcss@8.5.8)
+      postcss: 8.5.10
+      postcss-scss: 4.0.9(postcss@8.5.10)
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
@@ -10063,7 +10051,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -7,6 +7,7 @@ const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml')
 
 const requiredOverrides = {
   'lodash-es': '4.18.1',
+  postcss: '8.5.10',
 }
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))


### PR DESCRIPTION
## What changed
- pinned `postcss` to `8.5.10` via `pnpm.overrides` in `web/package.json`
- refreshed `web/pnpm-lock.yaml` so every resolved `postcss` entry is `8.5.10`
- extended `web/scripts/check-security-overrides.mjs` so future lockfile refreshes keep the patched `postcss` version in place

## Why
Dependabot reported `GHSA-qx2v-qp2m-jg93` / `CVE-2026-41305` because the `web` dependency graph still resolved vulnerable `postcss` versions below `8.5.10`.

## Root cause
The frontend lockfile had drifted to transitive `postcss@8.5.8` and `postcss@8.5.9` resolutions under the allowed semver ranges, so the runtime graph remained vulnerable even though no direct dependency declared `postcss`.

## Validation
- `pnpm --dir web install --frozen-lockfile`
- `pnpm --dir web why postcss`
- `pnpm --dir web run check:security-overrides`
- `pnpm --dir web run lint:deps`
