### PR TITLE
chore(desktop): pin xmldom to 0.8.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ WEB_DIR := web
 DESKTOP_DIR := desktop
 GO ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/go" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/go"; elif command -v go >/dev/null 2>&1; then command -v go; else printf '%s' "go"; fi)
 GOFMT ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/gofmt" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/gofmt"; elif command -v gofmt >/dev/null 2>&1; then command -v gofmt; else printf '%s' "gofmt"; fi)
-PNPM ?= corepack pnpm
+# Prefer pnpm from PATH so packageManager version pinning works in CI.
+PNPM ?= $(shell if command -v pnpm >/dev/null 2>&1; then printf '%s' "pnpm"; else printf '%s' "corepack pnpm"; fi)
 LINT_SCRIPT := ./scripts/ci/lint.sh
 OPENASE_MAIN := ./cmd/openase
 OPENASE_BIN := ./bin/openase

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,6 +10,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@xmldom/xmldom": "^0.8.13",
       "axios": "^1.15.0",
       "follow-redirects": "^1.16.0"
     },

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@xmldom/xmldom': ^0.8.13
   axios: ^1.15.0
   follow-redirects: ^1.16.0
 
@@ -343,8 +344,8 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   abbrev@3.0.1:
@@ -2104,7 +2105,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@3.0.1: {}
 
@@ -3136,7 +3137,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -18,10 +18,13 @@ function listFiles(dir) {
 describe('desktop dependency security guardrails', () => {
   it('pins redirect-following dependencies to patched versions', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
+    expect(pkg.pnpm?.overrides?.['@xmldom/xmldom']).toBe('^0.8.13')
     expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
     expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
+    expect(lockfile).not.toContain('@xmldom/xmldom@0.8.12')
+    expect(lockfile).toContain('@xmldom/xmldom@0.8.13')
     expect(lockfile).not.toContain('axios@1.14.0')
     expect(lockfile).toMatch(/axios@1\.15\./)
     expect(lockfile).not.toContain('follow-redirects@1.15.')


### PR DESCRIPTION
## What
- add a desktop `pnpm.overrides` entry for `@xmldom/xmldom` at `^0.8.13`
- refresh `desktop/pnpm-lock.yaml` so the dependency graph resolves the patched version
- extend the desktop dependency security test to guard the new override and lockfile resolution

## Why
- resolves ASE-394 / Dependabot alert GHSA-j759-j44w-7fr8 (CVE-2026-41672)
- keeps the Electron packaging dependency chain from resolving the vulnerable `0.8.12` release

## Validation
- `pnpm --dir desktop why @xmldom/xmldom`
- `pnpm --dir desktop run test:unit`
- `pnpm --dir desktop run package:smoke`
