### PR TITLE
ASE-392: upgrade @xmldom/xmldom to 0.8.13

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,6 +10,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@xmldom/xmldom": "0.8.13",
       "axios": "^1.15.0",
       "follow-redirects": "^1.16.0"
     },

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@xmldom/xmldom': 0.8.13
   axios: ^1.15.0
   follow-redirects: ^1.16.0
 
@@ -343,8 +344,8 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   abbrev@3.0.1:
@@ -2104,7 +2105,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@3.0.1: {}
 
@@ -3136,7 +3137,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary
- add a desktop-level pnpm override to force `@xmldom/xmldom` to the patched `0.8.13` release
- refresh `desktop/pnpm-lock.yaml` so the only resolved `@xmldom/xmldom` version is `0.8.13`
- keep the change scoped to the transitive `plist` dependency chain used by desktop packaging

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm --dir desktop why @xmldom/xmldom`
- `XDG_CONFIG_HOME=$(mktemp -d /tmp/ase392-xdg.XXXXXX) PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-validate`
