### PR TITLE
ASE-390 chore(web): upgrade uuid override to 14.0.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -92,7 +92,8 @@
     "overrides": {
       "cookie": "0.7.2",
       "dompurify": "3.4.0",
-      "lodash-es": "4.18.1"
+      "lodash-es": "4.18.1",
+      "uuid": "14.0.0"
     }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   cookie: 0.7.2
   dompurify: 3.4.0
   lodash-es: 4.18.1
+  uuid: 14.0.0
 
 importers:
   .:
@@ -5871,10 +5872,10 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
-  uuid@11.1.0:
+  uuid@14.0.0:
     resolution:
       {
-        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
+        integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==,
       }
     hasBin: true
 
@@ -8896,7 +8897,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -10041,7 +10042,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -6,7 +6,14 @@ const packageJsonPath = path.join(repoRoot, 'package.json')
 const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml')
 
 const requiredOverrides = {
-  'lodash-es': '4.18.1',
+  'lodash-es': {
+    requiredVersion: '4.18.1',
+    staleVersion: '4.17.23',
+  },
+  uuid: {
+    requiredVersion: '14.0.0',
+    staleVersion: '11.1.0',
+  },
 }
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
@@ -14,7 +21,8 @@ const packageOverrides = packageJson.pnpm?.overrides ?? {}
 const lockfile = fs.readFileSync(lockfilePath, 'utf8')
 const problems = []
 
-for (const [packageName, requiredVersion] of Object.entries(requiredOverrides)) {
+for (const [packageName, config] of Object.entries(requiredOverrides)) {
+  const { requiredVersion, staleVersion } = config
   const packageOverride = packageOverrides[packageName]
   if (packageOverride !== requiredVersion) {
     problems.push(
@@ -31,11 +39,11 @@ for (const [packageName, requiredVersion] of Object.entries(requiredOverrides)) 
   }
 
   const staleVersionPattern = new RegExp(
-    `${escapeRegExp(packageName)}(?::|@)\\s*4\\.17\\.23\\b|${escapeRegExp(packageName)}@4\\.17\\.23:`,
+    `${escapeRegExp(packageName)}(?::|@)\\s*${escapeRegExp(staleVersion)}\\b|${escapeRegExp(packageName)}@${escapeRegExp(staleVersion)}:`,
     'm',
   )
   if (staleVersionPattern.test(lockfile)) {
-    problems.push(`pnpm-lock.yaml still references stale ${packageName} 4.17.23 entries`)
+    problems.push(`pnpm-lock.yaml still references stale ${packageName} ${staleVersion} entries`)
   }
 
   const resolvedVersionPattern = new RegExp(


### PR DESCRIPTION
## Summary
- pin `uuid` to `14.0.0` via `pnpm.overrides` in `web/package.json`
- refresh `web/pnpm-lock.yaml` so the `web` graph resolves only `uuid@14.0.0`
- extend `web/scripts/check-security-overrides.mjs` to guard both the required override and stale-version detection for `uuid`

## Validation
- `pnpm install --frozen-lockfile --reporter=append-only`
- `pnpm why uuid`
- `pnpm run check:security-overrides`
- `pnpm run lint:deps`
- `pnpm exec playwright install chromium`
- `pnpm run ci`

Relates to ASE-390.
