### PR TITLE
refactor(web): close file budget coverage bypass

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -87,20 +87,27 @@ Feature modules own their `api.ts`, `stores.ts`, `types.ts`, `mappers.ts`, and `
 
 These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint where practical.
 
-| File type                           | Soft limit | Hard limit           |
-| ----------------------------------- | ---------- | -------------------- |
-| `routes/**/+page.svelte`            | 150        | 250                  |
-| `routes/**/+layout.svelte`          | 180        | 300                  |
-| `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
-| `lib/features/**/*.svelte`          | 200        | 350                  |
-| `lib/features/**/*.{ts,js}`         | 200        | 325                  |
-| `lib/testing/**/*.{ts,js}`          | 350        | 650                  |
-| `lib/components/layout/**/*.svelte` | 200        | 300                  |
-| `lib/components/ui/**/*.svelte`     | 150        | 250                  |
-| single function                     | 40 target  | 60 warning threshold |
+| File type                                                | Soft limit | Hard limit           |
+| -------------------------------------------------------- | ---------- | -------------------- |
+| `routes/**/+page.svelte`                                 | 150        | 250                  |
+| `routes/**/+layout.svelte`                               | 180        | 300                  |
+| `routes/**/+{page,layout,server}.ts` and `src/hooks*.ts` | 80         | 160                  |
+| `lib/features/**/*.test.{ts,js}`                         | 300        | 650                  |
+| `lib/features/**/*.svelte.{ts,js}`                       | 250        | 350                  |
+| `lib/features/**/*.svelte`                               | 200        | 350                  |
+| `lib/features/**/*.{ts,js}`                              | 200        | 325                  |
+| `lib/testing/**/*.{ts,js}`                               | 350        | 650                  |
+| `lib/components/layout/**/*.svelte`                      | 200        | 300                  |
+| `lib/components/layout/**/*.{ts,js}`                     | 200        | 350                  |
+| `lib/components/ui/**/*.svelte`                          | 150        | 250                  |
+| `lib/components/**/*.svelte` (non-layout/ui)             | 250        | 800                  |
+| `lib/stores/**/*.{ts,js}`                                | 250        | 350                  |
+| `lib/api/**/*.{ts,js}`                                   | 500        | 2500                 |
+| `lib/**/*.{ts,js}` shared support modules                | 200        | 325                  |
+| `src/test/**/*.{ts,js}`                                  | 150        | 250                  |
+| single function                                          | 40 target  | 60 warning threshold |
 
-There are no per-file budget waivers. Budgets live in one shared category definition that drives both `lint:structure` and the mirrored ESLint `max-lines` rules, so any recurring exception should be promoted into a named category instead of growing an allowlist.
+There are no per-file budget waivers. Budgets live in one shared category definition that drives both `lint:structure` and the mirrored ESLint `max-lines` rules, so any recurring exception should be promoted into a named category instead of growing an allowlist. `lint:structure` now also fails when a tracked frontend source file does not match any category, which closes the old "unbudgeted file family" bypass. Ambient declaration files (`*.d.ts`) stay outside the line-budget system because they are type metadata rather than runtime source.
 
 ## Quality Gates
 
@@ -118,7 +125,7 @@ pnpm run ci
 - `pnpm run lint`: ESLint with complexity, file-size, and cycle checks.
 - `pnpm run lint:i18n`: fails on newly introduced hardcoded user-visible strings that do not go through the shared i18n layer.
 - `pnpm run lint:mobile`: validates that every project route declares a mobile support policy and that responsive routes wire into the mobile regression templates.
-- `pnpm run lint:structure`: custom file budget enforcement with first-class categories for routes, feature tests, testing support modules, state modules, and UI layers.
+- `pnpm run lint:structure`: custom file budget enforcement with first-class categories for routes, stores, shared modules, API boundaries, testing support modules, and UI layers; it also rejects uncovered tracked source files.
 - `pnpm run lint:deps`: dependency boundary enforcement for `ui -> layout -> features -> routes` with no waiver path.
 - `pnpm run check`: `svelte-check` type validation.
 - `pnpm run ci`: unified local and CI entrypoint for the frontend gate.

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -1,16 +1,63 @@
+/**
+ * @typedef {(filePath: string) => boolean} FileBudgetMatcher
+ * @typedef {{
+ *   key: string
+ *   name: string
+ *   softLimit: number
+ *   hardLimit: number
+ *   match: FileBudgetMatcher
+ *   eslintFiles: string[]
+ *   eslintIgnores?: string[]
+ * }} FileBudgetCategoryInput
+ * @typedef {{
+ *   key: string
+ *   name: string
+ *   softLimit: number
+ *   hardLimit: number
+ *   match: FileBudgetMatcher
+ *   eslintFiles: string[]
+ *   eslintIgnores: string[]
+ * }} FileBudgetCategory
+ */
+
+/**
+ * @param {RegExp} pattern
+ * @returns {FileBudgetMatcher}
+ */
 function matchesPattern(pattern) {
   return (filePath) => pattern.test(filePath)
 }
 
-function defineBudgetCategory({
-  key,
-  name,
-  softLimit,
-  hardLimit,
-  match,
-  eslintFiles,
-  eslintIgnores = [],
-}) {
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isDeclarationFile(filePath) {
+  return filePath.endsWith('.d.ts')
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isScriptModule(filePath) {
+  return /\.(ts|js|mjs|cjs)$/.test(filePath) && !isDeclarationFile(filePath)
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isSvelteComponent(filePath) {
+  return filePath.endsWith('.svelte')
+}
+
+/**
+ * @param {FileBudgetCategoryInput} input
+ * @returns {FileBudgetCategory}
+ */
+function defineBudgetCategory(input) {
+  const { key, name, softLimit, hardLimit, match, eslintFiles, eslintIgnores = [] } = input
   return { key, name, softLimit, hardLimit, match, eslintFiles, eslintIgnores }
 }
 
@@ -20,14 +67,95 @@ const isRoutePage = matchesPattern(
 const isRouteLayout = matchesPattern(
   /^src\/routes\/.+\/\+layout\.svelte$|^src\/routes\/\+layout\.svelte$/,
 )
-const isFeatureTestModule = matchesPattern(/^src\/lib\/features\/.+\.test\.(ts|js|mjs|cjs)$/)
-const isFeatureStateModule = matchesPattern(/^src\/lib\/features\/.+\.svelte\.(ts|js)$/)
-const isFeatureComponent = matchesPattern(/^src\/lib\/features\/.+\.svelte$/)
-const isFeatureModule = matchesPattern(/^src\/lib\/features\/.+\.(ts|js|mjs|cjs)$/)
-const isTestingSupportModule = matchesPattern(/^src\/lib\/testing\/.+\.(ts|js|mjs|cjs)$/)
-const isLayoutComponent = matchesPattern(/^src\/lib\/components\/layout\/.+\.svelte$/)
-const isUiPrimitive = matchesPattern(/^src\/lib\/components\/ui\/.+\.svelte$/)
+/** @type {FileBudgetMatcher} */
+const isRouteModule = (filePath) =>
+  isScriptModule(filePath) &&
+  (matchesPattern(/^src\/routes\/.+\/\+(page|layout|server)\.(ts|js)$/)(filePath) ||
+    matchesPattern(/^src\/routes\/\+(page|layout|server)\.(ts|js)$/)(filePath) ||
+    matchesPattern(/^src\/hooks(\.server|\.client)?\.(ts|js)$/)(filePath))
+/** @type {FileBudgetMatcher} */
+const isFeatureTestModule = (filePath) =>
+  isScriptModule(filePath) &&
+  matchesPattern(/^src\/lib\/features\/.+\.test\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isFeatureStateModule = (filePath) =>
+  !isDeclarationFile(filePath) &&
+  matchesPattern(/^src\/lib\/features\/.+\.svelte\.(ts|js)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isFeatureComponent = (filePath) =>
+  isSvelteComponent(filePath) && matchesPattern(/^src\/lib\/features\/.+\.svelte$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isFeatureModule = (filePath) =>
+  isScriptModule(filePath) && matchesPattern(/^src\/lib\/features\/.+\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isTestingSupportModule = (filePath) =>
+  isScriptModule(filePath) && matchesPattern(/^src\/lib\/testing\/.+\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isLayoutComponent = (filePath) =>
+  isSvelteComponent(filePath) &&
+  matchesPattern(/^src\/lib\/components\/layout\/.+\.svelte$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isLayoutSupportModule = (filePath) =>
+  isScriptModule(filePath) &&
+  matchesPattern(/^src\/lib\/components\/layout\/.+\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isUiPrimitive = (filePath) =>
+  isSvelteComponent(filePath) && matchesPattern(/^src\/lib\/components\/ui\/.+\.svelte$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isSharedComponent = (filePath) =>
+  isSvelteComponent(filePath) &&
+  matchesPattern(/^src\/lib\/components\/.+\.svelte$/)(filePath) &&
+  !isLayoutComponent(filePath) &&
+  !isUiPrimitive(filePath)
+/** @type {FileBudgetMatcher} */
+const isStoreModule = (filePath) =>
+  isScriptModule(filePath) && matchesPattern(/^src\/lib\/stores\/.+\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isApiModule = (filePath) =>
+  isScriptModule(filePath) && matchesPattern(/^src\/lib\/api\/.+\.(ts|js|mjs|cjs)$/)(filePath)
+/** @type {FileBudgetMatcher} */
+const isSharedLibraryModule = (filePath) =>
+  isScriptModule(filePath) &&
+  matchesPattern(/^src\/lib\/.+\.(ts|js|mjs|cjs)$/)(filePath) &&
+  !isFeatureModule(filePath) &&
+  !isFeatureTestModule(filePath) &&
+  !isFeatureStateModule(filePath) &&
+  !isTestingSupportModule(filePath) &&
+  !isLayoutSupportModule(filePath) &&
+  !isStoreModule(filePath) &&
+  !isApiModule(filePath)
+/** @type {FileBudgetMatcher} */
+const isTestHarnessModule = (filePath) =>
+  isScriptModule(filePath) && matchesPattern(/^src\/test\/.+\.(ts|js|mjs|cjs)$/)(filePath)
 
+/** @type {Array<{ name: string; match: FileBudgetMatcher }>} */
+export const fileBudgetCoverageIgnoreRules = [
+  {
+    name: 'Type declarations',
+    match: isDeclarationFile,
+  },
+]
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isBudgetCoverageIgnoredFile(filePath) {
+  return fileBudgetCoverageIgnoreRules.some((rule) => rule.match(filePath))
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isBudgetTrackedSourceFile(filePath) {
+  return (
+    !isBudgetCoverageIgnoredFile(filePath) &&
+    (isScriptModule(filePath) || isSvelteComponent(filePath))
+  )
+}
+
+/** @type {FileBudgetCategory[]} */
 export const fileBudgetCategories = [
   defineBudgetCategory({
     key: 'routePage',
@@ -44,6 +172,15 @@ export const fileBudgetCategories = [
     hardLimit: 300,
     match: isRouteLayout,
     eslintFiles: ['src/routes/**/+layout.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'routeModule',
+    name: 'Route runtime modules',
+    softLimit: 80,
+    hardLimit: 160,
+    match: isRouteModule,
+    eslintFiles: ['src/routes/**/*.{js,ts,mjs,cjs}', 'src/hooks*.{js,ts,mjs,cjs}'],
+    eslintIgnores: ['**/*.d.ts'],
   }),
   defineBudgetCategory({
     key: 'featureTest',
@@ -101,12 +238,73 @@ export const fileBudgetCategories = [
     eslintFiles: ['src/lib/components/layout/**/*.svelte'],
   }),
   defineBudgetCategory({
+    key: 'layoutSupportModule',
+    name: 'Layout support modules',
+    softLimit: 200,
+    hardLimit: 350,
+    match: isLayoutSupportModule,
+    eslintFiles: ['src/lib/components/layout/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: ['**/*.d.ts'],
+  }),
+  defineBudgetCategory({
     key: 'uiPrimitive',
     name: 'UI primitives',
     softLimit: 150,
     hardLimit: 250,
     match: isUiPrimitive,
     eslintFiles: ['src/lib/components/ui/**/*.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'sharedComponent',
+    name: 'Shared components',
+    softLimit: 250,
+    hardLimit: 800,
+    match: isSharedComponent,
+    eslintFiles: ['src/lib/components/**/*.svelte'],
+    eslintIgnores: ['src/lib/components/layout/**/*.svelte', 'src/lib/components/ui/**/*.svelte'],
+  }),
+  defineBudgetCategory({
+    key: 'storeModule',
+    name: 'Store modules',
+    softLimit: 250,
+    hardLimit: 350,
+    match: isStoreModule,
+    eslintFiles: ['src/lib/stores/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: ['**/*.d.ts'],
+  }),
+  defineBudgetCategory({
+    key: 'apiModule',
+    name: 'API boundary modules',
+    softLimit: 500,
+    hardLimit: 2500,
+    match: isApiModule,
+    eslintFiles: ['src/lib/api/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: ['src/lib/api/generated/**', '**/*.d.ts'],
+  }),
+  defineBudgetCategory({
+    key: 'sharedLibraryModule',
+    name: 'Shared library modules',
+    softLimit: 200,
+    hardLimit: 325,
+    match: isSharedLibraryModule,
+    eslintFiles: ['src/lib/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: [
+      'src/lib/features/**/*.{js,ts,mjs,cjs}',
+      'src/lib/testing/**/*.{js,ts,mjs,cjs}',
+      'src/lib/components/layout/**/*.{js,ts,mjs,cjs}',
+      'src/lib/stores/**/*.{js,ts,mjs,cjs}',
+      'src/lib/api/**/*.{js,ts,mjs,cjs}',
+      '**/*.d.ts',
+    ],
+  }),
+  defineBudgetCategory({
+    key: 'testHarnessModule',
+    name: 'Test harness modules',
+    softLimit: 150,
+    hardLimit: 250,
+    match: isTestHarnessModule,
+    eslintFiles: ['src/test/**/*.{js,ts,mjs,cjs}'],
+    eslintIgnores: ['**/*.d.ts'],
   }),
 ]
 

--- a/web/scripts/check-file-budgets.mjs
+++ b/web/scripts/check-file-budgets.mjs
@@ -1,7 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { fileBudgetRules } from '../file-budgets.config.mjs'
+import {
+  fileBudgetRules,
+  isBudgetCoverageIgnoredFile,
+  isBudgetTrackedSourceFile,
+} from '../file-budgets.config.mjs'
 
 const repoRoot = process.cwd()
 const sourceRoot = path.join(repoRoot, 'src')
@@ -12,8 +16,16 @@ const failures = []
 
 for (const absoluteFile of files) {
   const relativeFile = toRepoPath(absoluteFile)
+  if (isBudgetCoverageIgnoredFile(relativeFile) || !isBudgetTrackedSourceFile(relativeFile)) {
+    continue
+  }
+
   const budget = fileBudgetRules.find((rule) => rule.match(relativeFile))
   if (!budget) {
+    failures.push({
+      file: relativeFile,
+      reason: 'No file budget category matched this source file.',
+    })
     continue
   }
 
@@ -39,6 +51,10 @@ if (warnings.length > 0) {
 if (failures.length > 0) {
   console.error('File budget violations:')
   for (const item of failures) {
+    if (item.reason) {
+      console.error(`  - ${item.file}: ${item.reason}`)
+      continue
+    }
     console.error(`  - ${item.file}: ${item.lineCount} lines (hard limit ${item.budget.hardLimit})`)
   }
   process.exit(1)

--- a/web/src/test/file-budgets.config.test.ts
+++ b/web/src/test/file-budgets.config.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  fileBudgetRules,
+  isBudgetCoverageIgnoredFile,
+  isBudgetTrackedSourceFile,
+} from '../../file-budgets.config.mjs'
+
+const webRoot = path.resolve(import.meta.dirname, '../..')
+const sourceRoot = path.join(webRoot, 'src')
+
+describe('file budget coverage', () => {
+  it('covers every tracked frontend source file or explicitly ignores it', () => {
+    const uncovered = walkFiles(sourceRoot)
+      .map(toRepoPath)
+      .filter((filePath) => isBudgetTrackedSourceFile(filePath))
+      .filter((filePath) => !fileBudgetRules.some((rule) => rule.match(filePath)))
+
+    expect(uncovered).toEqual([])
+  })
+
+  it('keeps declaration files outside the tracked runtime budgets', () => {
+    expect(isBudgetCoverageIgnoredFile('src/lib/api/generated/openapi.d.ts')).toBe(true)
+    expect(isBudgetTrackedSourceFile('src/lib/api/generated/openapi.d.ts')).toBe(false)
+  })
+
+  it('tracks the file families that used to bypass lint:structure', () => {
+    for (const filePath of [
+      'src/hooks.server.ts',
+      'src/lib/api/openase.ts',
+      'src/lib/components/code/code-editor.svelte',
+      'src/lib/stores/app.svelte.ts',
+      'src/test/setup.ts',
+    ]) {
+      expect(isBudgetTrackedSourceFile(filePath)).toBe(true)
+      expect(fileBudgetRules.some((rule) => rule.match(filePath))).toBe(true)
+    }
+  })
+})
+
+function walkFiles(directoryPath: string): string[] {
+  if (!fs.existsSync(directoryPath)) {
+    return []
+  }
+
+  return fs.readdirSync(directoryPath, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directoryPath, entry.name)
+    if (entry.isDirectory()) {
+      return walkFiles(entryPath)
+    }
+    return entry.isFile() ? [entryPath] : []
+  })
+}
+
+function toRepoPath(filePath: string): string {
+  return path.relative(webRoot, filePath).split(path.sep).join('/')
+}


### PR DESCRIPTION
## Summary
- replace the old file-budget blind spot with first-class categories for route runtime modules, shared components, stores, API modules, layout helpers, shared library modules, and test harness files
- make `lint:structure` fail when a tracked frontend source file is not covered by any budget category, while keeping `*.d.ts` outside runtime budgets
- add a Vitest coverage test and document the budget model so future exceptions become categories instead of waivers

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run format:check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:eslint`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:i18n`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/test/file-budgets.config.test.ts --reporter=dot`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check:security-overrides`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run build`

## Ticket
- ASE-440
