### PR TITLE
chore: upgrade desktop ip-address resolution

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,8 @@
   "pnpm": {
     "overrides": {
       "axios": "^1.15.0",
-      "follow-redirects": "^1.16.0"
+      "follow-redirects": "^1.16.0",
+      "ip-address": "10.2.0"
     },
     "onlyBuiltDependencies": [
       "electron",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: ^1.15.0
   follow-redirects: ^1.16.0
+  ip-address: 10.2.0
 
 importers:
 
@@ -915,8 +916,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-fullwidth-code-point@3.0.0:
@@ -2804,7 +2805,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -3311,7 +3312,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -20,12 +20,15 @@ describe('desktop dependency security guardrails', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
     expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
     expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
+    expect(pkg.pnpm?.overrides?.['ip-address']).toBe('10.2.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
     expect(lockfile).not.toContain('axios@1.14.0')
     expect(lockfile).toMatch(/axios@1\.15\./)
     expect(lockfile).not.toContain('follow-redirects@1.15.')
     expect(lockfile).toMatch(/follow-redirects@1\.16\./)
+    expect(lockfile).not.toContain('ip-address@10.1.0')
+    expect(lockfile).toContain('ip-address@10.2.0')
   })
 
   it('keeps desktop-owned code paths off custom axios redirect flows', () => {
@@ -39,6 +42,7 @@ describe('desktop dependency security guardrails', () => {
         const source = fs.readFileSync(file, 'utf8')
         expect(source).not.toMatch(/\b(?:require\(|from\s+)['"]axios['"]/)
         expect(source).not.toMatch(/\b(?:require\(|from\s+)['"]follow-redirects['"]/)
+        expect(source).not.toMatch(/\b(?:require\(|from\s+)['"]ip-address['"]/)
       }
     }
   })


### PR DESCRIPTION
## Summary
- pin the desktop transitive `ip-address` resolution to a patched release via `pnpm.overrides`
- regenerate `desktop/pnpm-lock.yaml` so `socks` no longer resolves `ip-address@10.1.0`
- extend the desktop dependency security test to guard the patched version and ensure desktop-owned runtime code does not import `ip-address`

## Validation
- `make desktop-install`
- `make desktop-install-browsers`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH make desktop-validate`

## Ticket
- ASE-475
