### PR TITLE
[ASE-497] Upgrade desktop axios past patched floor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:22-alpine AS web-builder
 WORKDIR /src
 
 COPY web/package.json web/pnpm-lock.yaml ./web/
-RUN corepack enable && corepack pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
+RUN corepack enable && cd /src/web && pnpm install --frozen-lockfile --reporter=append-only
 
 COPY web ./web
 RUN mkdir -p /src/internal/webui/static
-RUN corepack pnpm --dir /src/web run build
+RUN cd /src/web && pnpm run build
 
 FROM golang:1.26.1-alpine AS go-builder
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ WEB_DIR := web
 DESKTOP_DIR := desktop
 GO ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/go" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/go"; elif command -v go >/dev/null 2>&1; then command -v go; else printf '%s' "go"; fi)
 GOFMT ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/gofmt" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/gofmt"; elif command -v gofmt >/dev/null 2>&1; then command -v gofmt; else printf '%s' "gofmt"; fi)
-PNPM ?= corepack pnpm
+# Prefer a PATH-installed pnpm in CI and fall back to corepack for local bootstrap.
+PNPM ?= $(shell if command -v pnpm >/dev/null 2>&1; then printf '%s' 'pnpm'; else printf '%s' 'corepack pnpm'; fi)
 LINT_SCRIPT := ./scripts/ci/lint.sh
 OPENASE_MAIN := ./cmd/openase
 OPENASE_BIN := ./bin/openase

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "^1.15.0",
+      "axios": "^1.15.1",
       "follow-redirects": "^1.16.0"
     },
     "onlyBuiltDependencies": [

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.15.0
+  axios: ^1.15.1
   follow-redirects: ^1.16.0
 
 importers:
@@ -418,8 +418,8 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2194,7 +2194,7 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -3504,7 +3504,7 @@ snapshots:
 
   wait-on@9.0.5:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -4,6 +4,27 @@ const path = require('node:path')
 const desktopRoot = path.resolve(__dirname, '../..')
 const runtimeRoots = ['main', 'preload', 'scripts']
 
+function compareSemver(left, right) {
+  const leftParts = left.split('.').map(Number)
+  const rightParts = right.split('.').map(Number)
+
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const leftPart = leftParts[index] ?? 0
+    const rightPart = rightParts[index] ?? 0
+    if (leftPart !== rightPart) {
+      return leftPart - rightPart
+    }
+  }
+
+  return 0
+}
+
+function resolvedPackageVersions(lockfile, packageName) {
+  return [...lockfile.matchAll(new RegExp(`\\n  ${packageName}@(\\d+\\.\\d+\\.\\d+):`, 'g'))].map(
+    ([, version]) => version
+  )
+}
+
 function listFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true })
   return entries.flatMap((entry) => {
@@ -18,12 +39,13 @@ function listFiles(dir) {
 describe('desktop dependency security guardrails', () => {
   it('pins redirect-following dependencies to patched versions', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
-    expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
+    expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.1')
     expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
-    expect(lockfile).not.toContain('axios@1.14.0')
-    expect(lockfile).toMatch(/axios@1\.15\./)
+    const axiosVersions = resolvedPackageVersions(lockfile, 'axios')
+    expect(axiosVersions.length).toBeGreaterThan(0)
+    expect(axiosVersions.every((version) => compareSemver(version, '1.15.1') >= 0)).toBe(true)
     expect(lockfile).not.toContain('follow-redirects@1.15.')
     expect(lockfile).toMatch(/follow-redirects@1\.16\./)
   })


### PR DESCRIPTION
## Summary
- bump the desktop `axios` override from `^1.15.0` to `^1.15.1`
- regenerate `desktop/pnpm-lock.yaml`, which now resolves `axios` to `1.16.0`
- strengthen the desktop dependency security guard so it rejects any resolved `axios` version below `1.15.1`
- make repo `make` targets prefer an already-installed `pnpm` binary so GitHub Actions uses the pinned 10.32.1 toolchain instead of `corepack`'s pnpm 11

## Validation
- `make desktop-install`
- `make desktop-install-browsers`
- `PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-validate`
- `PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make openapi-check-ci`

## Ticket
- ASE-497
