### PR TITLE
fix: pin desktop axios to 1.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM node:22-alpine AS web-builder
 WORKDIR /src
 
 COPY web/package.json web/pnpm-lock.yaml ./web/
-RUN corepack enable && corepack pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
+RUN corepack enable \
+    && corepack prepare "$(node -p "require('./web/package.json').packageManager")" --activate \
+    && pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
 
 COPY web ./web
 RUN mkdir -p /src/internal/webui/static
-RUN corepack pnpm --dir /src/web run build
+RUN pnpm --dir /src/web run build
 
 FROM golang:1.26.1-alpine AS go-builder
 WORKDIR /src

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
   "pnpm": {
     "overrides": {
       "@xmldom/xmldom": "^0.8.13",
-      "axios": "^1.15.0",
+      "axios": "1.15.1",
       "follow-redirects": "^1.16.0"
     },
     "onlyBuiltDependencies": [

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@xmldom/xmldom': ^0.8.13
-  axios: ^1.15.0
+  axios: 1.15.1
   follow-redirects: ^1.16.0
 
 importers:
@@ -419,8 +419,8 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.1:
+    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2195,7 +2195,7 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.15.0:
+  axios@1.15.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -3505,7 +3505,7 @@ snapshots:
 
   wait-on@9.0.5:
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.1
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -19,14 +19,14 @@ describe('desktop dependency security guardrails', () => {
   it('pins redirect-following dependencies to patched versions', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
     expect(pkg.pnpm?.overrides?.['@xmldom/xmldom']).toBe('^0.8.13')
-    expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
+    expect(pkg.pnpm?.overrides?.axios).toBe('1.15.1')
     expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
     expect(lockfile).not.toContain('@xmldom/xmldom@0.8.12')
     expect(lockfile).toContain('@xmldom/xmldom@0.8.13')
-    expect(lockfile).not.toContain('axios@1.14.0')
-    expect(lockfile).toMatch(/axios@1\.15\./)
+    expect(lockfile).not.toContain('axios@1.15.0')
+    expect(lockfile).toContain('axios@1.15.1')
     expect(lockfile).not.toContain('follow-redirects@1.15.')
     expect(lockfile).toMatch(/follow-redirects@1\.16\./)
   })


### PR DESCRIPTION
## Summary
- pin the desktop pnpm axios override to `1.15.1`
- regenerate `desktop/pnpm-lock.yaml` so `wait-on` resolves the patched axios release
- update the desktop dependency security test to assert the new axios floor

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm install --lockfile-only` (in `desktop/`)
- `PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-validate`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir desktop why axios`

## Ticket
- ASE-496
