### PR TITLE
[ASE-498] Upgrade desktop axios past patched floor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM node:22-alpine AS web-builder
 WORKDIR /src
 
 COPY web/package.json web/pnpm-lock.yaml ./web/
-RUN corepack enable && corepack pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
+RUN corepack enable \
+    && corepack prepare "$(node -p "require('/src/web/package.json').packageManager")" --activate \
+    && pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
 
 COPY web ./web
 RUN mkdir -p /src/internal/webui/static
-RUN corepack pnpm --dir /src/web run build
+RUN pnpm --dir /src/web run build
 
 FROM golang:1.26.1-alpine AS go-builder
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ WEB_DIR := web
 DESKTOP_DIR := desktop
 GO ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/go" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/go"; elif command -v go >/dev/null 2>&1; then command -v go; else printf '%s' "go"; fi)
 GOFMT ?= $(shell if [ -x "$(CURDIR)/.tooling/go/bin/gofmt" ]; then printf '%s' "$(CURDIR)/.tooling/go/bin/gofmt"; elif command -v gofmt >/dev/null 2>&1; then command -v gofmt; else printf '%s' "gofmt"; fi)
-PNPM ?= corepack pnpm
+PNPM ?= pnpm
 LINT_SCRIPT := ./scripts/ci/lint.sh
 OPENASE_MAIN := ./cmd/openase
 OPENASE_BIN := ./bin/openase
@@ -124,7 +124,7 @@ hooks-run:
 
 openapi-generate: web-install
 	$(GO) run $(OPENASE_MAIN) openapi generate --output api/openapi.json
-	$(PNPM) --dir $(WEB_DIR) run api:generate
+	$(FRONTEND_PNPM) --dir $(WEB_DIR) run api:generate
 
 openapi-check: openapi-generate
 	git diff --exit-code -- api/openapi.json web/src/lib/api/generated/openapi.d.ts
@@ -134,7 +134,7 @@ openapi-check-ci:
 	@tmp_dir="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp_dir"' EXIT; \
 	printf '{ "private": true }\n' > "$$tmp_dir/package.json"; \
-	$(PNPM) --dir "$$tmp_dir" add --save-dev --ignore-scripts --reporter=append-only openapi-typescript@7.13.0 prettier@3.8.1; \
+	$(FRONTEND_PNPM) --dir "$$tmp_dir" add --save-dev --ignore-scripts --reporter=append-only openapi-typescript@7.13.0 prettier@3.8.1; \
 	"$$tmp_dir/node_modules/.bin/openapi-typescript" "$(CURDIR)/api/openapi.json" -o "$(CURDIR)/web/src/lib/api/generated/openapi.d.ts"; \
 	node "$$tmp_dir/node_modules/prettier/bin/prettier.cjs" \
 		--log-level warn \

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "^1.15.0",
+      "axios": "^1.15.1",
       "follow-redirects": "^1.16.0"
     },
     "onlyBuiltDependencies": [

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.15.0
+  axios: ^1.15.1
   follow-redirects: ^1.16.0
 
 importers:
@@ -346,6 +346,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -418,8 +419,8 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2194,7 +2195,7 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -3504,7 +3505,7 @@ snapshots:
 
   wait-on@9.0.5:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8

--- a/desktop/scripts/package-desktop.mjs
+++ b/desktop/scripts/package-desktop.mjs
@@ -23,7 +23,8 @@ if (prepare.status !== 0) {
   throw new Error('desktop bundle preparation failed')
 }
 
-const result = spawnSync('corepack', builderArgs, {
+const { command, args } = resolvePnpm(builderArgs)
+const result = spawnSync(command, args, {
   cwd: desktopRoot,
   stdio: 'inherit',
   env: process.env,
@@ -31,4 +32,17 @@ const result = spawnSync('corepack', builderArgs, {
 
 if (result.status !== 0) {
   throw new Error(`electron-builder failed with exit code ${result.status}`)
+}
+
+function resolvePnpm(args) {
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  const pnpmCheck = spawnSync(pnpmCommand, ['--version'], { stdio: 'ignore', env: process.env })
+  if (pnpmCheck.status === 0) {
+    return { command: pnpmCommand, args }
+  }
+
+  return {
+    command: process.platform === 'win32' ? 'corepack.cmd' : 'corepack',
+    args: ['pnpm', ...args],
+  }
 }

--- a/desktop/scripts/run-desktop-ci.mjs
+++ b/desktop/scripts/run-desktop-ci.mjs
@@ -1,19 +1,36 @@
 import { spawnSync } from 'node:child_process'
 
-run('corepack', ['pnpm', 'run', 'test:unit'])
+runPnpm(['run', 'test:unit'])
 runPlaywright()
-run('corepack', ['pnpm', 'run', 'package:smoke'])
+runPnpm(['run', 'package:smoke'])
 
 function runPlaywright() {
   if (process.platform === 'linux' && !process.env.DISPLAY) {
     const xvfbCheck = spawnSync('sh', ['-lc', 'command -v xvfb-run >/dev/null 2>&1'])
     if (xvfbCheck.status === 0) {
-      run('xvfb-run', ['-a', 'corepack', 'pnpm', 'run', 'test:e2e'])
+      const { command, args } = resolvePnpm(['run', 'test:e2e'])
+      run('xvfb-run', ['-a', command, ...args])
       return
     }
   }
 
-  run('corepack', ['pnpm', 'run', 'test:e2e'])
+  runPnpm(['run', 'test:e2e'])
+}
+
+function runPnpm(args) {
+  const { command, args: resolvedArgs } = resolvePnpm(args)
+  run(command, resolvedArgs)
+}
+
+function resolvePnpm(args) {
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  const pnpmCheck = spawnSync(pnpmCommand, ['--version'], { stdio: 'ignore', env: process.env })
+  if (pnpmCheck.status === 0) {
+    return { command: pnpmCommand, args }
+  }
+
+  const corepackCommand = process.platform === 'win32' ? 'corepack.cmd' : 'corepack'
+  return { command: corepackCommand, args: ['pnpm', ...args] }
 }
 
 function run(command, args) {

--- a/desktop/tests/unit/dependency-security.test.js
+++ b/desktop/tests/unit/dependency-security.test.js
@@ -4,6 +4,27 @@ const path = require('node:path')
 const desktopRoot = path.resolve(__dirname, '../..')
 const runtimeRoots = ['main', 'preload', 'scripts']
 
+function compareSemver(left, right) {
+  const leftParts = left.split('.').map(Number)
+  const rightParts = right.split('.').map(Number)
+
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const leftPart = leftParts[index] ?? 0
+    const rightPart = rightParts[index] ?? 0
+    if (leftPart !== rightPart) {
+      return leftPart - rightPart
+    }
+  }
+
+  return 0
+}
+
+function resolvedPackageVersions(lockfile, packageName) {
+  return [...lockfile.matchAll(new RegExp(`\\n  ${packageName}@(\\d+\\.\\d+\\.\\d+):`, 'g'))].map(
+    ([, version]) => version
+  )
+}
+
 function listFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true })
   return entries.flatMap((entry) => {
@@ -18,12 +39,13 @@ function listFiles(dir) {
 describe('desktop dependency security guardrails', () => {
   it('pins redirect-following dependencies to patched versions', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(desktopRoot, 'package.json'), 'utf8'))
-    expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.0')
+    expect(pkg.pnpm?.overrides?.axios).toBe('^1.15.1')
     expect(pkg.pnpm?.overrides?.['follow-redirects']).toBe('^1.16.0')
 
     const lockfile = fs.readFileSync(path.join(desktopRoot, 'pnpm-lock.yaml'), 'utf8')
-    expect(lockfile).not.toContain('axios@1.14.0')
-    expect(lockfile).toMatch(/axios@1\.15\./)
+    const axiosVersions = resolvedPackageVersions(lockfile, 'axios')
+    expect(axiosVersions.length).toBeGreaterThan(0)
+    expect(axiosVersions.every((version) => compareSemver(version, '1.15.1') >= 0)).toBe(true)
     expect(lockfile).not.toContain('follow-redirects@1.15.')
     expect(lockfile).toMatch(/follow-redirects@1\.16\./)
   })


### PR DESCRIPTION
## Summary
- bump the desktop `axios` override from `^1.15.0` to the patched floor `^1.15.1`
- regenerate `desktop/pnpm-lock.yaml`, which now resolves the desktop tree to `axios@1.16.0`
- strengthen the desktop dependency security guardrail so any future resolved `axios` version below `1.15.1` fails tests
- prefer direct `pnpm` in the desktop validation and packaging flows so GitHub Actions uses the repo-pinned `pnpm@10.32.1` instead of the runner's `corepack` default

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-install`
- `PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make openapi-check-ci`
- `PATH=$HOME/.local/go1.26.1/bin:$HOME/.nvm/versions/node/v22.22.1/bin:$PATH make desktop-validate`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir desktop why axios`

## Ticket
- Resolves `ASE-498`
