### PR TITLE
[ASE-507] refactor(web): restore feature state budget limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM node:22-alpine AS web-builder
+ARG PNPM_VERSION=10.32.1
 WORKDIR /src
 
 COPY web/package.json web/pnpm-lock.yaml ./web/
-RUN corepack enable && corepack pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
+RUN corepack enable \
+    && corepack prepare "pnpm@${PNPM_VERSION}" --activate \
+    && pnpm --dir /src/web install --frozen-lockfile --reporter=append-only
 
 COPY web ./web
 RUN mkdir -p /src/internal/webui/static
-RUN corepack pnpm --dir /src/web run build
+RUN pnpm --dir /src/web run build
 
 FROM golang:1.26.1-alpine AS go-builder
 WORKDIR /src

--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/terminal-manager-mounting.ts
+++ b/web/src/lib/features/chat/terminal-manager-mounting.ts
@@ -1,0 +1,100 @@
+import {
+  encodeTerminalPayload,
+  mountProjectConversationTerminal,
+} from './project-conversation-terminal-panel-helpers'
+import { ensureTerminalRuntime, forgetTerminalRuntime } from './terminal-manager-runtime'
+import type { MountedTerminal, TerminalInstanceRuntime } from './terminal-manager-types'
+
+type CloseSocketOptions = {
+  updateStatus: boolean
+  reconnect: boolean
+  terminate: boolean
+}
+
+type TerminalMountMaps = {
+  xtermMap: Map<string, MountedTerminal>
+  socketMap: Map<string, WebSocket>
+  elementMap: Map<string, HTMLDivElement>
+  resizeObserverMap: Map<string, ResizeObserver>
+  runtimeMap: Map<string, TerminalInstanceRuntime>
+}
+
+export async function mountTerminalInstance(input: {
+  id: string
+  element: HTMLDivElement
+  hasInstance: (id: string) => boolean
+  closeSocket: (id: string, options: CloseSocketOptions) => void
+  maps: TerminalMountMaps
+}) {
+  if (input.maps.xtermMap.has(input.id) && input.maps.elementMap.get(input.id) === input.element) {
+    return
+  }
+
+  const runtime = ensureTerminalRuntime(input.maps.runtimeMap, input.id)
+  runtime.mountRevision += 1
+  const mountRevision = runtime.mountRevision
+
+  unmountTerminalInstance({
+    id: input.id,
+    forget: false,
+    closeSocket: input.closeSocket,
+    maps: input.maps,
+  })
+  input.maps.elementMap.set(input.id, input.element)
+
+  const mounted = await mountProjectConversationTerminal({
+    element: input.element,
+    onData: (data) => {
+      const socket = input.maps.socketMap.get(input.id)
+      if (socket?.readyState !== WebSocket.OPEN) return
+      socket.send(JSON.stringify({ type: 'input', data: encodeTerminalPayload(data) }))
+    },
+    onResize: ({ cols, rows }) => {
+      const socket = input.maps.socketMap.get(input.id)
+      if (socket?.readyState !== WebSocket.OPEN) return
+      socket.send(JSON.stringify({ type: 'resize', cols, rows }))
+    },
+  })
+
+  if (
+    !input.hasInstance(input.id) ||
+    input.maps.runtimeMap.get(input.id)?.mountRevision !== mountRevision ||
+    input.maps.elementMap.get(input.id) !== input.element
+  ) {
+    mounted.dispose()
+    return
+  }
+
+  input.maps.xtermMap.set(input.id, mounted)
+
+  const resizeObserver = new ResizeObserver(() => {
+    const entry = input.maps.xtermMap.get(input.id)
+    if (!entry) return
+    entry.fitAddon.fit()
+    const socket = input.maps.socketMap.get(input.id)
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(
+        JSON.stringify({ type: 'resize', cols: entry.terminal.cols, rows: entry.terminal.rows }),
+      )
+    }
+  })
+  resizeObserver.observe(input.element)
+  input.maps.resizeObserverMap.set(input.id, resizeObserver)
+}
+
+export function unmountTerminalInstance(input: {
+  id: string
+  forget: boolean
+  closeSocket: (id: string, options: CloseSocketOptions) => void
+  maps: TerminalMountMaps
+}) {
+  input.maps.resizeObserverMap.get(input.id)?.disconnect()
+  input.maps.resizeObserverMap.delete(input.id)
+  input.closeSocket(input.id, { updateStatus: false, reconnect: false, terminate: true })
+  input.maps.xtermMap.get(input.id)?.dispose()
+  input.maps.xtermMap.delete(input.id)
+  input.maps.elementMap.delete(input.id)
+  if (input.forget) {
+    forgetTerminalRuntime(input.maps.runtimeMap, input.id)
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -1,13 +1,9 @@
-import {
-  encodeTerminalPayload,
-  mountProjectConversationTerminal,
-} from './project-conversation-terminal-panel-helpers'
 import { createTerminalConnectionHelpers } from './terminal-manager-connection'
+import { mountTerminalInstance, unmountTerminalInstance } from './terminal-manager-mounting'
 import {
   TERMINAL_RECONNECT_ATTEMPT_LIMIT,
   clearTerminalReconnectTimer,
   ensureTerminalRuntime,
-  forgetTerminalRuntime,
   generateTerminalManagerID,
   nextTerminalReconnectDelay,
 } from './terminal-manager-runtime'
@@ -31,6 +27,7 @@ export function createTerminalManager(input: {
   const elementMap = new Map<string, HTMLDivElement>()
   const resizeObserverMap = new Map<string, ResizeObserver>()
   const runtimeMap = new Map<string, TerminalInstanceRuntime>()
+  const maps = { xtermMap, socketMap, elementMap, resizeObserverMap, runtimeMap }
 
   function updateInstance(id: string, updates: Partial<TerminalInstance>) {
     instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
@@ -56,67 +53,11 @@ export function createTerminalManager(input: {
     })
 
   async function mountTerminal(id: string, element: HTMLDivElement) {
-    // Prevent double-mount
-    if (xtermMap.has(id) && elementMap.get(id) === element) return
-
-    const runtime = ensureTerminalRuntime(runtimeMap, id)
-    runtime.mountRevision += 1
-    const mountRevision = runtime.mountRevision
-
-    // Clean up previous mount for this id
-    unmountTerminal(id, false)
-    elementMap.set(id, element)
-
-    const mounted = await mountProjectConversationTerminal({
-      element,
-      onData: (data) => {
-        const socket = socketMap.get(id)
-        if (socket?.readyState !== WebSocket.OPEN) return
-        socket.send(JSON.stringify({ type: 'input', data: encodeTerminalPayload(data) }))
-      },
-      onResize: ({ cols, rows }) => {
-        const socket = socketMap.get(id)
-        if (socket?.readyState !== WebSocket.OPEN) return
-        socket.send(JSON.stringify({ type: 'resize', cols, rows }))
-      },
-    })
-
-    if (
-      !hasInstance(id) ||
-      runtimeMap.get(id)?.mountRevision !== mountRevision ||
-      elementMap.get(id) !== element
-    ) {
-      mounted.dispose()
-      return
-    }
-
-    xtermMap.set(id, mounted)
-
-    const ro = new ResizeObserver(() => {
-      const entry = xtermMap.get(id)
-      if (!entry) return
-      entry.fitAddon.fit()
-      const socket = socketMap.get(id)
-      if (socket?.readyState === WebSocket.OPEN) {
-        socket.send(
-          JSON.stringify({ type: 'resize', cols: entry.terminal.cols, rows: entry.terminal.rows }),
-        )
-      }
-    })
-    ro.observe(element)
-    resizeObserverMap.set(id, ro)
+    await mountTerminalInstance({ id, element, hasInstance, closeSocket, maps })
   }
 
   function unmountTerminal(id: string, forget: boolean) {
-    resizeObserverMap.get(id)?.disconnect()
-    resizeObserverMap.delete(id)
-    closeSocket(id, { updateStatus: false, reconnect: false, terminate: true })
-    xtermMap.get(id)?.dispose()
-    xtermMap.delete(id)
-    elementMap.delete(id)
-    if (forget) {
-      forgetTerminalRuntime(runtimeMap, id)
-    }
+    unmountTerminalInstance({ id, forget, closeSocket, maps })
   }
 
   function closeSocket(


### PR DESCRIPTION
## Summary
- extract terminal mount and unmount lifecycle handling into a dedicated chat helper
- restore the shared `lib/features/**/*.svelte.{ts,js}` hard budget from 350 back to 325
- document the tightened budget in the frontend README so the guardrail and docs stay aligned

## Why
`featureStateModule` had been widened to 350 lines as a temporary escape hatch for oversized frontend state modules. The remaining blocker was `terminal-manager.svelte.ts`, so this change replaces that broad bypass with a maintainable split and lets the shared budget return to its stricter limit.

## Impact
- the terminal manager keeps the same runtime behavior while delegating DOM mount lifecycle concerns to a focused helper
- future feature state modules no longer inherit the broader 350-line allowance
- frontend budget policy and implementation stay consistent again

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm install --frozen-lockfile`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH ./node_modules/.bin/vitest run src/lib/features/chat/terminal-manager.test.ts --reporter=dot`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run build`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run format:check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check:security-overrides`

## Notes
- `pnpm run check` reports one pre-existing Svelte warning in `src/lib/features/settings/components/security-settings-human-auth-disabled-setup-draft-form.svelte` and no errors.
- `pnpm run lint:structure` still prints the repo's existing soft-budget warning backlog, but there are no hard-budget violations after this change.
- Ref ASE-507.
