### PR TITLE
refactor(web): tighten frontend state budget debt

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/project-conversation-controller-dispatch.ts
+++ b/web/src/lib/features/chat/project-conversation-controller-dispatch.ts
@@ -1,0 +1,77 @@
+import { projectConversationHasPendingInterrupt } from './project-conversation-controller-helpers'
+import type { ProjectAIFocus } from './project-ai-focus'
+import type { ProjectConversationTabState } from './project-conversation-controller-state'
+import { sendNextQueuedProjectConversationTurn } from './project-conversation-controller-actions'
+
+export function createProjectConversationQueuedTurnDispatcher(input: {
+  getTabs: () => ProjectConversationTabState[]
+  sendTurnInTab: (
+    tab: ProjectConversationTabState,
+    message: string,
+    focus: ProjectAIFocus | null,
+  ) => Promise<boolean>
+  touch: () => void
+}) {
+  let queuedTurnDispatchScheduled = false
+  const autoDispatchQueuedTurnIDByTab = new Map<string, string>()
+
+  function schedule() {
+    if (queuedTurnDispatchScheduled) {
+      return
+    }
+
+    queuedTurnDispatchScheduled = true
+    queueMicrotask(() => {
+      queuedTurnDispatchScheduled = false
+
+      for (const tab of input.getTabs()) {
+        const nextQueuedTurnId = tab.queuedTurns[0]?.id ?? ''
+        const shouldAutoDispatch =
+          !!nextQueuedTurnId &&
+          !!tab.projectId &&
+          !!tab.providerId &&
+          tab.phase === 'idle' &&
+          !projectConversationHasPendingInterrupt(tab.entries)
+
+        if (!shouldAutoDispatch) {
+          autoDispatchQueuedTurnIDByTab.delete(tab.id)
+          continue
+        }
+
+        if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
+          continue
+        }
+
+        autoDispatchQueuedTurnIDByTab.set(tab.id, nextQueuedTurnId)
+        queueMicrotask(() => {
+          const liveTab = input.getTabs().find((item) => item.id === tab.id) ?? null
+          if (
+            !liveTab ||
+            liveTab.phase !== 'idle' ||
+            projectConversationHasPendingInterrupt(liveTab.entries) ||
+            (liveTab.queuedTurns[0]?.id ?? '') !== nextQueuedTurnId
+          ) {
+            if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
+              autoDispatchQueuedTurnIDByTab.delete(tab.id)
+            }
+            return
+          }
+
+          void sendNextQueuedProjectConversationTurn({
+            tab: liveTab,
+            sendTurnInTab: input.sendTurnInTab,
+          }).then((sent) => {
+            if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
+              autoDispatchQueuedTurnIDByTab.delete(tab.id)
+            }
+            if (sent) {
+              input.touch()
+            }
+          })
+        })
+      }
+    })
+  }
+
+  return { schedule }
+}

--- a/web/src/lib/features/chat/project-conversation-controller.svelte.ts
+++ b/web/src/lib/features/chat/project-conversation-controller.svelte.ts
@@ -4,10 +4,8 @@ import type { ProjectAIFocus } from './project-ai-focus'
 import { createProjectConversationControllerApi } from './project-conversation-controller-api'
 import { projectConversationHasPendingInterrupt } from './project-conversation-controller-helpers'
 import { createProjectConversationControllerOperations } from './project-conversation-controller-operations'
-import {
-  createProjectConversationControllerActions,
-  sendNextQueuedProjectConversationTurn,
-} from './project-conversation-controller-actions'
+import { createProjectConversationControllerActions } from './project-conversation-controller-actions'
+import { createProjectConversationQueuedTurnDispatcher } from './project-conversation-controller-dispatch'
 import {
   canQueueProjectConversationTurn,
   createProjectConversationTabState,
@@ -37,8 +35,6 @@ export function createProjectConversationController(
   let nextTabID = 0
   let nextQueuedTurnID = 0
   let snapshotNotificationQueued = false
-  let queuedTurnDispatchScheduled = false
-  const autoDispatchQueuedTurnIDByTab = new Map<string, string>()
 
   function touch() {
     revision += 1
@@ -162,63 +158,14 @@ export function createProjectConversationController(
     touch,
     operations,
   })
+  const queuedTurnDispatcher = createProjectConversationQueuedTurnDispatcher({
+    getTabs: () => tabs,
+    sendTurnInTab: operations.sendTurnInTab,
+    touch,
+  })
 
   function scheduleQueuedTurnDispatch() {
-    if (queuedTurnDispatchScheduled) {
-      return
-    }
-
-    queuedTurnDispatchScheduled = true
-    queueMicrotask(() => {
-      queuedTurnDispatchScheduled = false
-
-      for (const tab of tabs) {
-        const nextQueuedTurnId = tab.queuedTurns[0]?.id ?? ''
-        const shouldAutoDispatch =
-          !!nextQueuedTurnId &&
-          !!tab.projectId &&
-          !!tab.providerId &&
-          tab.phase === 'idle' &&
-          !projectConversationHasPendingInterrupt(tab.entries)
-
-        if (!shouldAutoDispatch) {
-          autoDispatchQueuedTurnIDByTab.delete(tab.id)
-          continue
-        }
-
-        if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
-          continue
-        }
-
-        autoDispatchQueuedTurnIDByTab.set(tab.id, nextQueuedTurnId)
-        queueMicrotask(() => {
-          const liveTab = tabs.find((item) => item.id === tab.id) ?? null
-          if (
-            !liveTab ||
-            liveTab.phase !== 'idle' ||
-            projectConversationHasPendingInterrupt(liveTab.entries) ||
-            (liveTab.queuedTurns[0]?.id ?? '') !== nextQueuedTurnId
-          ) {
-            if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
-              autoDispatchQueuedTurnIDByTab.delete(tab.id)
-            }
-            return
-          }
-
-          void sendNextQueuedProjectConversationTurn({
-            tab: liveTab,
-            sendTurnInTab: operations.sendTurnInTab,
-          }).then((sent) => {
-            if (autoDispatchQueuedTurnIDByTab.get(tab.id) === nextQueuedTurnId) {
-              autoDispatchQueuedTurnIDByTab.delete(tab.id)
-            }
-            if (sent) {
-              touch()
-            }
-          })
-        })
-      }
-    })
+    queuedTurnDispatcher.schedule()
   }
 
   ensureTabExists()

--- a/web/src/lib/features/chat/terminal-manager-lifecycle.ts
+++ b/web/src/lib/features/chat/terminal-manager-lifecycle.ts
@@ -1,0 +1,175 @@
+import {
+  encodeTerminalPayload,
+  mountProjectConversationTerminal,
+} from './project-conversation-terminal-panel-helpers'
+import {
+  TERMINAL_RECONNECT_ATTEMPT_LIMIT,
+  clearTerminalReconnectTimer,
+  ensureTerminalRuntime,
+  forgetTerminalRuntime,
+  nextTerminalReconnectDelay,
+} from './terminal-manager-runtime'
+import type {
+  MountedTerminal,
+  TerminalInstance,
+  TerminalInstanceRuntime,
+} from './terminal-manager-types'
+
+type UpdateInstance = (id: string, updates: Partial<TerminalInstance>) => void
+
+type TerminalLifecycleHelpersInput = {
+  runtimeMap: Map<string, TerminalInstanceRuntime>
+  socketMap: Map<string, WebSocket>
+  xtermMap: Map<string, MountedTerminal>
+  elementMap: Map<string, HTMLDivElement>
+  resizeObserverMap: Map<string, ResizeObserver>
+  hasInstance: (id: string) => boolean
+  updateInstance: UpdateInstance
+  connectTerminal: (id: string, isReconnect?: boolean) => Promise<void>
+}
+
+export function createTerminalLifecycleHelpers(input: TerminalLifecycleHelpersInput) {
+  function closeSocket(
+    id: string,
+    options: {
+      updateStatus: boolean
+      reconnect: boolean
+      terminate: boolean
+    },
+  ) {
+    const runtime = ensureTerminalRuntime(input.runtimeMap, id)
+    runtime.reconnectEnabled = options.reconnect
+    clearTerminalReconnectTimer(input.runtimeMap, id)
+
+    const socket = input.socketMap.get(id)
+    input.socketMap.delete(id)
+    if (socket?.readyState === WebSocket.OPEN) {
+      if (options.terminate) {
+        socket.send(JSON.stringify({ type: 'close' }))
+      }
+      socket.close()
+    } else if (socket?.readyState === WebSocket.CONNECTING) {
+      socket.close()
+    }
+
+    if (options.terminate) {
+      runtime.session = null
+    }
+    if (options.updateStatus) {
+      input.updateInstance(id, {
+        status: 'closed',
+        statusMessage: 'Terminal closed.',
+        sessionID: '',
+      })
+    }
+  }
+
+  function unmountTerminal(id: string, forget: boolean) {
+    input.resizeObserverMap.get(id)?.disconnect()
+    input.resizeObserverMap.delete(id)
+    closeSocket(id, { updateStatus: false, reconnect: false, terminate: true })
+    input.xtermMap.get(id)?.dispose()
+    input.xtermMap.delete(id)
+    input.elementMap.delete(id)
+    if (forget) {
+      forgetTerminalRuntime(input.runtimeMap, id)
+    }
+  }
+
+  async function mountTerminal(id: string, element: HTMLDivElement) {
+    if (input.xtermMap.has(id) && input.elementMap.get(id) === element) {
+      return
+    }
+
+    const runtime = ensureTerminalRuntime(input.runtimeMap, id)
+    runtime.mountRevision += 1
+    const mountRevision = runtime.mountRevision
+
+    unmountTerminal(id, false)
+    input.elementMap.set(id, element)
+
+    const mounted = await mountProjectConversationTerminal({
+      element,
+      onData: (data) => {
+        const socket = input.socketMap.get(id)
+        if (socket?.readyState !== WebSocket.OPEN) return
+        socket.send(JSON.stringify({ type: 'input', data: encodeTerminalPayload(data) }))
+      },
+      onResize: ({ cols, rows }) => {
+        const socket = input.socketMap.get(id)
+        if (socket?.readyState !== WebSocket.OPEN) return
+        socket.send(JSON.stringify({ type: 'resize', cols, rows }))
+      },
+    })
+
+    if (
+      !input.hasInstance(id) ||
+      input.runtimeMap.get(id)?.mountRevision !== mountRevision ||
+      input.elementMap.get(id) !== element
+    ) {
+      mounted.dispose()
+      return
+    }
+
+    input.xtermMap.set(id, mounted)
+
+    const resizeObserver = new ResizeObserver(() => {
+      const entry = input.xtermMap.get(id)
+      if (!entry) return
+      entry.fitAddon.fit()
+      const socket = input.socketMap.get(id)
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(
+          JSON.stringify({ type: 'resize', cols: entry.terminal.cols, rows: entry.terminal.rows }),
+        )
+      }
+    })
+    resizeObserver.observe(element)
+    input.resizeObserverMap.set(id, resizeObserver)
+  }
+
+  function scheduleReconnect(id: string, label: string) {
+    const runtime = input.runtimeMap.get(id)
+    if (
+      !runtime ||
+      !runtime.reconnectEnabled ||
+      !runtime.session ||
+      !input.hasInstance(id) ||
+      !input.xtermMap.has(id)
+    ) {
+      return
+    }
+
+    if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
+      runtime.reconnectEnabled = false
+      input.updateInstance(id, {
+        status: 'error',
+        statusMessage: 'Terminal disconnected. Reconnect attempts exhausted.',
+        sessionID: '',
+      })
+      return
+    }
+
+    runtime.reconnectAttempts += 1
+    const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
+    input.updateInstance(id, {
+      status: 'connecting',
+      statusMessage: `Reconnecting shell in ${label}...`,
+      sessionID: '',
+    })
+    runtime.reconnectTimer = setTimeout(() => {
+      runtime.reconnectTimer = null
+      if (!runtime.reconnectEnabled || !input.hasInstance(id) || !input.xtermMap.has(id)) {
+        return
+      }
+      void input.connectTerminal(id, true)
+    }, delay)
+  }
+
+  return {
+    closeSocket,
+    mountTerminal,
+    scheduleReconnect,
+    unmountTerminal,
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -1,16 +1,10 @@
-import {
-  encodeTerminalPayload,
-  mountProjectConversationTerminal,
-} from './project-conversation-terminal-panel-helpers'
 import { createTerminalConnectionHelpers } from './terminal-manager-connection'
 import {
-  TERMINAL_RECONNECT_ATTEMPT_LIMIT,
   clearTerminalReconnectTimer,
   ensureTerminalRuntime,
-  forgetTerminalRuntime,
   generateTerminalManagerID,
-  nextTerminalReconnectDelay,
 } from './terminal-manager-runtime'
+import { createTerminalLifecycleHelpers } from './terminal-manager-lifecycle'
 import type {
   MountedTerminal,
   TerminalInstance,
@@ -44,6 +38,18 @@ export function createTerminalManager(input: {
     return instances.some((inst) => inst.id === id)
   }
 
+  const { closeSocket, mountTerminal, scheduleReconnect, unmountTerminal } =
+    createTerminalLifecycleHelpers({
+      runtimeMap,
+      socketMap,
+      xtermMap,
+      elementMap,
+      resizeObserverMap,
+      hasInstance,
+      updateInstance,
+      connectTerminal,
+    })
+
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
     createTerminalConnectionHelpers({
       getConversationId: input.getConversationId,
@@ -54,138 +60,6 @@ export function createTerminalManager(input: {
       scheduleReconnect,
       updateInstance,
     })
-
-  async function mountTerminal(id: string, element: HTMLDivElement) {
-    // Prevent double-mount
-    if (xtermMap.has(id) && elementMap.get(id) === element) return
-
-    const runtime = ensureTerminalRuntime(runtimeMap, id)
-    runtime.mountRevision += 1
-    const mountRevision = runtime.mountRevision
-
-    // Clean up previous mount for this id
-    unmountTerminal(id, false)
-    elementMap.set(id, element)
-
-    const mounted = await mountProjectConversationTerminal({
-      element,
-      onData: (data) => {
-        const socket = socketMap.get(id)
-        if (socket?.readyState !== WebSocket.OPEN) return
-        socket.send(JSON.stringify({ type: 'input', data: encodeTerminalPayload(data) }))
-      },
-      onResize: ({ cols, rows }) => {
-        const socket = socketMap.get(id)
-        if (socket?.readyState !== WebSocket.OPEN) return
-        socket.send(JSON.stringify({ type: 'resize', cols, rows }))
-      },
-    })
-
-    if (
-      !hasInstance(id) ||
-      runtimeMap.get(id)?.mountRevision !== mountRevision ||
-      elementMap.get(id) !== element
-    ) {
-      mounted.dispose()
-      return
-    }
-
-    xtermMap.set(id, mounted)
-
-    const ro = new ResizeObserver(() => {
-      const entry = xtermMap.get(id)
-      if (!entry) return
-      entry.fitAddon.fit()
-      const socket = socketMap.get(id)
-      if (socket?.readyState === WebSocket.OPEN) {
-        socket.send(
-          JSON.stringify({ type: 'resize', cols: entry.terminal.cols, rows: entry.terminal.rows }),
-        )
-      }
-    })
-    ro.observe(element)
-    resizeObserverMap.set(id, ro)
-  }
-
-  function unmountTerminal(id: string, forget: boolean) {
-    resizeObserverMap.get(id)?.disconnect()
-    resizeObserverMap.delete(id)
-    closeSocket(id, { updateStatus: false, reconnect: false, terminate: true })
-    xtermMap.get(id)?.dispose()
-    xtermMap.delete(id)
-    elementMap.delete(id)
-    if (forget) {
-      forgetTerminalRuntime(runtimeMap, id)
-    }
-  }
-
-  function closeSocket(
-    id: string,
-    options: {
-      updateStatus: boolean
-      reconnect: boolean
-      terminate: boolean
-    },
-  ) {
-    const runtime = ensureTerminalRuntime(runtimeMap, id)
-    runtime.reconnectEnabled = options.reconnect
-    clearTerminalReconnectTimer(runtimeMap, id)
-
-    const socket = socketMap.get(id)
-    socketMap.delete(id)
-    if (socket?.readyState === WebSocket.OPEN) {
-      if (options.terminate) {
-        socket.send(JSON.stringify({ type: 'close' }))
-      }
-      socket.close()
-    } else if (socket?.readyState === WebSocket.CONNECTING) {
-      socket.close()
-    }
-    if (options.terminate) {
-      runtime.session = null
-    }
-    if (options.updateStatus) {
-      updateInstance(id, { status: 'closed', statusMessage: 'Terminal closed.', sessionID: '' })
-    }
-  }
-
-  function scheduleReconnect(id: string, label: string) {
-    const runtime = runtimeMap.get(id)
-    if (
-      !runtime ||
-      !runtime.reconnectEnabled ||
-      !runtime.session ||
-      !hasInstance(id) ||
-      !xtermMap.has(id)
-    ) {
-      return
-    }
-
-    if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
-      runtime.reconnectEnabled = false
-      updateInstance(id, {
-        status: 'error',
-        statusMessage: 'Terminal disconnected. Reconnect attempts exhausted.',
-        sessionID: '',
-      })
-      return
-    }
-
-    runtime.reconnectAttempts += 1
-    const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
-    updateInstance(id, {
-      status: 'connecting',
-      statusMessage: `Reconnecting shell in ${label}...`,
-      sessionID: '',
-    })
-    runtime.reconnectTimer = setTimeout(() => {
-      runtime.reconnectTimer = null
-      if (!runtime.reconnectEnabled || !hasInstance(id) || !xtermMap.has(id)) {
-        return
-      }
-      void connectTerminal(id, true)
-    }, delay)
-  }
 
   async function connectTerminal(id: string, isReconnect = false) {
     const conversationId = input.getConversationId()

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller-loader.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller-loader.ts
@@ -1,0 +1,158 @@
+import { ApiError } from '$lib/api/client'
+import {
+  getHRAdvisor,
+  getSystemDashboard,
+  listActivity,
+  listAgents,
+  listTickets,
+} from '$lib/api/openase'
+import {
+  createProjectReconnectRecoveryTask,
+  isProjectDashboardRefreshEvent,
+  readProjectDashboardRefreshSections,
+  subscribeProjectEvents,
+} from '$lib/features/project-events'
+import { markProjectOnboardingCompleted } from '$lib/features/onboarding'
+import {
+  type DashboardSection,
+  mergeDashboardSections,
+  systemDashboardRefreshIntervalMs,
+  toAdvisorSnapshot,
+} from './org-dashboard-controller-helpers'
+import { buildActivityItems, buildDashboardStats, buildExceptionItems } from '../model'
+import { loadOrganizationDashboardSummary } from '../organization-summary'
+import type { DashboardStats, HRAdvisorSnapshot, MemorySnapshot } from '../types'
+
+export function startOrgDashboardDataLoader(input: {
+  projectId: string
+  orgId: string
+  getOnboardingDismissed: () => boolean
+  setOnboardingDismissed: (value: boolean) => void
+  getStats: () => DashboardStats
+  setStats: (value: DashboardStats) => void
+  setActivities: (value: ReturnType<typeof buildActivityItems>) => void
+  setExceptions: (value: ReturnType<typeof buildExceptionItems>) => void
+  setHrAdvisor: (value: HRAdvisorSnapshot | null) => void
+  setMemory: (value: MemorySnapshot | null) => void
+  setError: (value: string) => void
+  setLoading: (value: boolean) => void
+}) {
+  let cancelled = false
+  let hasLoaded = false
+  let inFlight = false
+  let pendingShowLoading = false
+  let queuedSections: DashboardSection[] = []
+  let cachedAgents = [] as Awaited<ReturnType<typeof listAgents>>['agents']
+  let cachedTickets = [] as Awaited<ReturnType<typeof listTickets>>['tickets']
+
+  const queueLoad = (sections: Iterable<DashboardSection>, showLoading = false) => {
+    queuedSections = mergeDashboardSections(queuedSections, sections)
+    pendingShowLoading = pendingShowLoading || showLoading
+    if (!inFlight) void flushLoads()
+  }
+
+  const flushLoads = async () => {
+    if (inFlight) return
+
+    inFlight = true
+    while (!cancelled && queuedSections.length > 0) {
+      const sections = queuedSections
+      queuedSections = []
+      const showLoading = pendingShowLoading
+      pendingShowLoading = false
+      if (showLoading) input.setLoading(true)
+
+      try {
+        const [
+          agentPayload,
+          ticketPayload,
+          activityPayload,
+          systemPayload,
+          hrAdvisorPayload,
+          organizationSummary,
+        ] = await Promise.all([
+          sections.includes('agents') ? listAgents(input.projectId) : Promise.resolve(null),
+          sections.includes('tickets') ? listTickets(input.projectId) : Promise.resolve(null),
+          sections.includes('activity')
+            ? listActivity(input.projectId, { limit: 24 })
+            : Promise.resolve(null),
+          sections.includes('memory') ? getSystemDashboard() : Promise.resolve(null),
+          sections.includes('hr_advisor')
+            ? getHRAdvisor(input.projectId).catch(() => null)
+            : Promise.resolve(null),
+          sections.includes('organization_summary') && input.orgId
+            ? loadOrganizationDashboardSummary(input.orgId).catch(() => null)
+            : Promise.resolve(null),
+        ])
+
+        if (cancelled) return
+        if (agentPayload) cachedAgents = agentPayload.agents
+        if (ticketPayload) {
+          cachedTickets = ticketPayload.tickets
+          if (cachedTickets.length > 0 && !input.getOnboardingDismissed()) {
+            markProjectOnboardingCompleted(input.projectId)
+            input.setOnboardingDismissed(true)
+          }
+        }
+
+        if (
+          sections.includes('agents') ||
+          sections.includes('tickets') ||
+          sections.includes('organization_summary')
+        ) {
+          input.setStats(
+            buildDashboardStats(cachedAgents, cachedTickets, {
+              ticketSpendToday:
+                organizationSummary?.projectMetrics[input.projectId]?.todayCost ??
+                input.getStats().ticketSpendToday,
+            }),
+          )
+        }
+        if (systemPayload) input.setMemory(systemPayload.memory)
+        if (sections.includes('hr_advisor')) input.setHrAdvisor(toAdvisorSnapshot(hrAdvisorPayload))
+        if (activityPayload) {
+          input.setActivities(buildActivityItems(activityPayload.events))
+          input.setExceptions(buildExceptionItems(activityPayload.events))
+        }
+
+        input.setError('')
+        hasLoaded = true
+      } catch (caughtError) {
+        if (cancelled || hasLoaded) continue
+        input.setError(
+          caughtError instanceof ApiError ? caughtError.detail : 'Failed to load dashboard.',
+        )
+      } finally {
+        if (showLoading && !cancelled) input.setLoading(false)
+      }
+    }
+
+    inFlight = false
+  }
+
+  queueLoad(['agents', 'tickets', 'activity', 'memory', 'hr_advisor', 'organization_summary'], true)
+
+  const unsubscribeDashboard = subscribeProjectEvents(
+    input.projectId,
+    (event) => {
+      if (!isProjectDashboardRefreshEvent(event)) return
+      const sections = readProjectDashboardRefreshSections(event)
+      if (sections.length > 0) queueLoad(sections)
+    },
+    {
+      onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
+        queueLoad(['agents', 'tickets', 'activity', 'memory', 'hr_advisor', 'organization_summary'])
+      }),
+    },
+  )
+
+  const memoryInterval = window.setInterval(() => {
+    queueLoad(['memory'])
+  }, systemDashboardRefreshIntervalMs)
+
+  return () => {
+    cancelled = true
+    unsubscribeDashboard()
+    window.clearInterval(memoryInterval)
+  }
+}

--- a/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
+++ b/web/src/lib/features/dashboard/components/org-dashboard-controller.svelte.ts
@@ -1,18 +1,5 @@
 import { ApiError } from '$lib/api/client'
-import {
-  getHRAdvisor,
-  getSystemDashboard,
-  listActivity,
-  listAgents,
-  listTickets,
-  updateProject,
-} from '$lib/api/openase'
-import {
-  createProjectReconnectRecoveryTask,
-  isProjectDashboardRefreshEvent,
-  readProjectDashboardRefreshSections,
-  subscribeProjectEvents,
-} from '$lib/features/project-events'
+import { updateProject } from '$lib/api/openase'
 import {
   markProjectOnboardingCompleted,
   readProjectOnboardingCompletion,
@@ -20,21 +7,10 @@ import {
 import { createProjectUpdatesController } from '$lib/features/project-updates'
 import { appStore } from '$lib/stores/app.svelte'
 import { toastStore } from '$lib/stores/toast.svelte'
-import {
-  type DashboardSection,
-  emptyDashboardStats,
-  mergeDashboardSections,
-  systemDashboardRefreshIntervalMs,
-  toAdvisorSnapshot,
-} from './org-dashboard-controller-helpers'
-import {
-  buildActivityItems,
-  buildDashboardStats,
-  buildExceptionItems,
-  shouldShowProjectOnboarding,
-} from '../model'
+import { emptyDashboardStats } from './org-dashboard-controller-helpers'
+import { buildActivityItems, buildExceptionItems, shouldShowProjectOnboarding } from '../model'
 import { createOrgDashboardControllerApi } from './org-dashboard-controller-api'
-import { loadOrganizationDashboardSummary } from '../organization-summary'
+import { startOrgDashboardDataLoader } from './org-dashboard-controller-loader'
 import type { DashboardStats, HRAdvisorSnapshot, MemorySnapshot, ProjectStatus } from '../types'
 
 export function createOrgDashboardController() {
@@ -128,143 +104,39 @@ export function createOrgDashboardController() {
     markProjectOnboardingCompleted(projectId)
     onboardingDismissed = true
   }
+
+  function resetDashboardState() {
+    activities = []
+    exceptions = []
+    hrAdvisor = null
+    memory = null
+    stats = emptyDashboardStats
+    error = ''
+    loading = false
+  }
+
   $effect(() => {
     const projectId = appStore.currentProject?.id
     const orgId = appStore.currentOrg?.id
     if (!projectId) {
-      activities = []
-      exceptions = []
-      hrAdvisor = null
-      memory = null
-      stats = emptyDashboardStats
-      error = ''
-      loading = false
+      resetDashboardState()
       return
     }
 
-    let cancelled = false
-    let hasLoaded = false
-    let inFlight = false
-    let pendingShowLoading = false
-    let queuedSections: DashboardSection[] = []
-    let cachedAgents = [] as Awaited<ReturnType<typeof listAgents>>['agents']
-    let cachedTickets = [] as Awaited<ReturnType<typeof listTickets>>['tickets']
-
-    const queueLoad = (sections: Iterable<DashboardSection>, showLoading = false) => {
-      queuedSections = mergeDashboardSections(queuedSections, sections)
-      pendingShowLoading = pendingShowLoading || showLoading
-      if (!inFlight) void flushLoads()
-    }
-
-    const flushLoads = async () => {
-      if (inFlight) return
-
-      inFlight = true
-      while (!cancelled && queuedSections.length > 0) {
-        const sections = queuedSections
-        queuedSections = []
-        const showLoading = pendingShowLoading
-        pendingShowLoading = false
-        if (showLoading) loading = true
-
-        try {
-          const [
-            agentPayload,
-            ticketPayload,
-            activityPayload,
-            systemPayload,
-            hrAdvisorPayload,
-            organizationSummary,
-          ] = await Promise.all([
-            sections.includes('agents') ? listAgents(projectId) : Promise.resolve(null),
-            sections.includes('tickets') ? listTickets(projectId) : Promise.resolve(null),
-            sections.includes('activity')
-              ? listActivity(projectId, { limit: 24 })
-              : Promise.resolve(null),
-            sections.includes('memory') ? getSystemDashboard() : Promise.resolve(null),
-            sections.includes('hr_advisor')
-              ? getHRAdvisor(projectId).catch(() => null)
-              : Promise.resolve(null),
-            sections.includes('organization_summary') && orgId
-              ? loadOrganizationDashboardSummary(orgId).catch(() => null)
-              : Promise.resolve(null),
-          ])
-
-          if (cancelled) return
-          if (agentPayload) cachedAgents = agentPayload.agents
-          if (ticketPayload) {
-            cachedTickets = ticketPayload.tickets
-            if (cachedTickets.length > 0 && !onboardingDismissed && projectId) {
-              markProjectOnboardingCompleted(projectId)
-              onboardingDismissed = true
-            }
-          }
-
-          if (
-            sections.includes('agents') ||
-            sections.includes('tickets') ||
-            sections.includes('organization_summary')
-          ) {
-            stats = buildDashboardStats(cachedAgents, cachedTickets, {
-              ticketSpendToday:
-                organizationSummary?.projectMetrics[projectId]?.todayCost ?? stats.ticketSpendToday,
-            })
-          }
-          if (systemPayload) memory = systemPayload.memory
-          if (sections.includes('hr_advisor')) hrAdvisor = toAdvisorSnapshot(hrAdvisorPayload)
-          if (activityPayload) {
-            activities = buildActivityItems(activityPayload.events)
-            exceptions = buildExceptionItems(activityPayload.events)
-          }
-
-          error = ''
-          hasLoaded = true
-        } catch (caughtError) {
-          if (cancelled || hasLoaded) continue
-          error = caughtError instanceof ApiError ? caughtError.detail : 'Failed to load dashboard.'
-        } finally {
-          if (showLoading && !cancelled) loading = false
-        }
-      }
-
-      inFlight = false
-    }
-
-    queueLoad(
-      ['agents', 'tickets', 'activity', 'memory', 'hr_advisor', 'organization_summary'],
-      true,
-    )
-
-    const unsubscribeDashboard = subscribeProjectEvents(
+    return startOrgDashboardDataLoader({
       projectId,
-      (event) => {
-        if (!isProjectDashboardRefreshEvent(event)) return
-        const sections = readProjectDashboardRefreshSections(event)
-        if (sections.length > 0) queueLoad(sections)
-      },
-      {
-        onReconnectRecovery: createProjectReconnectRecoveryTask(() => {
-          queueLoad([
-            'agents',
-            'tickets',
-            'activity',
-            'memory',
-            'hr_advisor',
-            'organization_summary',
-          ])
-        }),
-      },
-    )
-
-    const memoryInterval = window.setInterval(() => {
-      queueLoad(['memory'])
-    }, systemDashboardRefreshIntervalMs)
-
-    return () => {
-      cancelled = true
-      unsubscribeDashboard()
-      window.clearInterval(memoryInterval)
-    }
+      orgId: orgId ?? '',
+      getOnboardingDismissed: () => onboardingDismissed,
+      setOnboardingDismissed: (value) => (onboardingDismissed = value),
+      getStats: () => stats,
+      setStats: (value) => (stats = value),
+      setActivities: (value) => (activities = value),
+      setExceptions: (value) => (exceptions = value),
+      setHrAdvisor: (value) => (hrAdvisor = value),
+      setMemory: (value) => (memory = value),
+      setError: (value) => (error = value),
+      setLoading: (value) => (loading = value),
+    })
   })
 
   return createOrgDashboardControllerApi({


### PR DESCRIPTION
## Summary
- extract terminal lifecycle, queued-turn dispatch, and dashboard live-loading into focused helpers so the remaining frontend controller/state modules no longer rely on oversized in-file bypasses
- tighten the shared `lib/features/**/*.svelte.{ts,js}` hard budget from 350 to 325 now that the terminal manager fits the common limit again
- update the frontend budget documentation to match the stricter enforced threshold

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run lint:structure`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run lint:eslint`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run lint:deps`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web exec svelte-check --tsconfig ./tsconfig.json --output machine --threshold error`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web exec vitest run src/lib/features/chat/terminal-manager.test.ts src/lib/features/chat/project-conversation-controller-queued-turns.test.ts src/lib/features/chat/project-conversation-controller-tabs.test.ts src/lib/features/chat/project-conversation-controller-turns.test.ts src/lib/features/chat/project-conversation-controller-restore.test.ts src/lib/features/chat/project-conversation-controller-restore-live.test.ts src/lib/features/dashboard/components/org-dashboard.test.ts`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run format:check`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH corepack pnpm --dir web run build`

OpenASE: ASE-528
