### PR TITLE
fix: upgrade mermaid for security alert 66

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
       "cookie": "0.7.2",
       "dompurify": "3.4.0",
       "lodash-es": "4.18.1",
+      "mermaid": "11.15.0",
       "uuid": "14.0.0"
     }
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   cookie: 0.7.2
   dompurify: 3.4.0
   lodash-es: 4.18.1
+  mermaid: 11.15.0
   uuid: 14.0.0
 
 importers:
@@ -929,10 +930,10 @@ packages:
     peerDependencies:
       svelte: '>=3 <5'
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.1.1':
     resolution:
       {
-        integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==,
+        integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==,
       }
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -3089,6 +3090,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  es-toolkit@1.46.1:
+    resolution:
+      {
+        integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==,
+      }
+
   esbuild@0.27.7:
     resolution:
       {
@@ -4343,10 +4350,10 @@ packages:
         integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
-  mermaid@11.13.0:
+  mermaid@11.15.0:
     resolution:
       {
-        integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==,
+        integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==,
       }
 
   micromark-core-commonmark@2.0.3:
@@ -6630,9 +6637,9 @@ snapshots:
       nanoid: 5.1.7
       svelte: 5.54.0
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.1.1':
     dependencies:
-      langium: 4.2.1
+      '@chevrotain/types': 11.1.2
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -6824,7 +6831,7 @@ snapshots:
     dependencies:
       '@shikijs/langs': 3.23.0
       '@shikijs/themes': 3.23.0
-      mermaid: 11.13.0
+      mermaid: 11.15.0
       rehype-katex: 7.0.1
       remark-cjk-friendly: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-cjk-friendly-gfm-strikethrough: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
@@ -7965,6 +7972,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.46.1: {}
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -8875,11 +8884,11 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mermaid@11.13.0:
+  mermaid@11.15.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.1
+      '@mermaid-js/parser': 1.1.1
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
@@ -8890,9 +8899,9 @@ snapshots:
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
       dompurify: 3.4.0
+      es-toolkit: 1.46.1
       katex: 0.16.44
       khroma: 2.1.0
-      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -9712,7 +9721,7 @@ snapshots:
       esm-env: 1.2.2
       katex: 0.16.44
       marked: 16.4.2
-      mermaid: 11.13.0
+      mermaid: 11.15.0
       rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -10,6 +10,10 @@ const requiredOverrides = {
     requiredVersion: '4.18.1',
     staleVersion: '4.17.23',
   },
+  mermaid: {
+    requiredVersion: '11.15.0',
+    staleVersion: '11.13.0',
+  },
   uuid: {
     requiredVersion: '14.0.0',
     staleVersion: '11.1.0',


### PR DESCRIPTION
## What changed
- pin `pnpm.overrides.mermaid` to `11.15.0` in `web/package.json`
- regenerate `web/pnpm-lock.yaml` so `streamdown-svelte` and `@streamdown-svelte/plugin-core` resolve the patched Mermaid release
- extend `web/scripts/check-security-overrides.mjs` so CI keeps the Mermaid override in place

## Why
Dependabot reported `GHSA-87f9-hvmw-gh4p` / `CVE-2026-41159` against Mermaid versions up to `11.14.0`. The frontend renders Mermaid diagrams through `streamdown-svelte`, so the lockfile needed to move that transitive runtime dependency onto `11.15.0` and keep it pinned.

## Validation
- `pnpm run check:security-overrides`
- `pnpm run lint:deps`
- `pnpm why mermaid`
- `pnpm exec vitest run src/lib/features/markdown/markdown-content.test.ts`
- `pnpm run build`
