### PR TITLE
fix(web): pin mermaid security upgrade

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
       "cookie": "0.7.2",
       "dompurify": "3.4.0",
       "lodash-es": "4.18.1",
+      "mermaid": "11.15.0",
       "uuid": "14.0.0"
     }
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   cookie: 0.7.2
   dompurify: 3.4.0
   lodash-es: 4.18.1
+  mermaid: 11.15.0
   uuid: 14.0.0
 
 importers:
@@ -929,10 +930,10 @@ packages:
     peerDependencies:
       svelte: '>=3 <5'
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.1.1':
     resolution:
       {
-        integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==,
+        integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==,
       }
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -3111,6 +3112,12 @@ packages:
       }
     engines: { node: '>=12' }
 
+  es-toolkit@1.46.1:
+    resolution:
+      {
+        integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==,
+      }
+
   eslint-import-context@0.1.9:
     resolution:
       {
@@ -4343,10 +4350,10 @@ packages:
         integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
-  mermaid@11.13.0:
+  mermaid@11.15.0:
     resolution:
       {
-        integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==,
+        integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==,
       }
 
   micromark-core-commonmark@2.0.3:
@@ -6630,9 +6637,9 @@ snapshots:
       nanoid: 5.1.7
       svelte: 5.54.0
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.1.1':
     dependencies:
-      langium: 4.2.1
+      '@chevrotain/types': 11.1.2
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -6824,7 +6831,7 @@ snapshots:
     dependencies:
       '@shikijs/langs': 3.23.0
       '@shikijs/themes': 3.23.0
-      mermaid: 11.13.0
+      mermaid: 11.15.0
       rehype-katex: 7.0.1
       remark-cjk-friendly: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-cjk-friendly-gfm-strikethrough: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
@@ -7998,6 +8005,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  es-toolkit@1.46.1: {}
+
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.13.6
@@ -8875,11 +8884,11 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mermaid@11.13.0:
+  mermaid@11.15.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.1
+      '@mermaid-js/parser': 1.1.1
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
@@ -8890,9 +8899,9 @@ snapshots:
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
       dompurify: 3.4.0
+      es-toolkit: 1.46.1
       katex: 0.16.44
       khroma: 2.1.0
-      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -9712,7 +9721,7 @@ snapshots:
       esm-env: 1.2.2
       katex: 0.16.44
       marked: 16.4.2
-      mermaid: 11.13.0
+      mermaid: 11.15.0
       rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -8,11 +8,15 @@ const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml')
 const requiredOverrides = {
   'lodash-es': {
     requiredVersion: '4.18.1',
-    staleVersion: '4.17.23',
+    staleVersions: ['4.17.23'],
   },
   uuid: {
     requiredVersion: '14.0.0',
-    staleVersion: '11.1.0',
+    staleVersions: ['11.1.0'],
+  },
+  mermaid: {
+    requiredVersion: '11.15.0',
+    stalePattern: /mermaid(?::|@)\s*11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?\b|mermaid@11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?:/m,
   },
 }
 
@@ -22,7 +26,7 @@ const lockfile = fs.readFileSync(lockfilePath, 'utf8')
 const problems = []
 
 for (const [packageName, config] of Object.entries(requiredOverrides)) {
-  const { requiredVersion, staleVersion } = config
+  const { requiredVersion, stalePattern } = config
   const packageOverride = packageOverrides[packageName]
   if (packageOverride !== requiredVersion) {
     problems.push(
@@ -38,12 +42,19 @@ for (const [packageName, config] of Object.entries(requiredOverrides)) {
     problems.push(`pnpm-lock.yaml must record the ${packageName} override at ${requiredVersion}`)
   }
 
-  const staleVersionPattern = new RegExp(
-    `${escapeRegExp(packageName)}(?::|@)\\s*${escapeRegExp(staleVersion)}\\b|${escapeRegExp(packageName)}@${escapeRegExp(staleVersion)}:`,
-    'm',
-  )
-  if (staleVersionPattern.test(lockfile)) {
-    problems.push(`pnpm-lock.yaml still references stale ${packageName} ${staleVersion} entries`)
+  const staleVersions = config.staleVersions ?? []
+  for (const staleVersion of staleVersions) {
+    const staleVersionPattern = new RegExp(
+      `${escapeRegExp(packageName)}(?::|@)\\s*${escapeRegExp(staleVersion)}\\b|${escapeRegExp(packageName)}@${escapeRegExp(staleVersion)}:`,
+      'm',
+    )
+    if (staleVersionPattern.test(lockfile)) {
+      problems.push(`pnpm-lock.yaml still references stale ${packageName} ${staleVersion} entries`)
+    }
+  }
+
+  if (stalePattern?.test(lockfile)) {
+    problems.push(`pnpm-lock.yaml still references vulnerable ${packageName} entries`)
   }
 
   const resolvedVersionPattern = new RegExp(

--- a/web/scripts/check-security-overrides.mjs
+++ b/web/scripts/check-security-overrides.mjs
@@ -16,7 +16,8 @@ const requiredOverrides = {
   },
   mermaid: {
     requiredVersion: '11.15.0',
-    stalePattern: /mermaid(?::|@)\s*11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?\b|mermaid@11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?:/m,
+    stalePattern:
+      /mermaid(?::|@)\s*11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?\b|mermaid@11\.(?:[0-9]|1[0-4])(?:\.[0-9A-Za-z.-]+)?:/m,
   },
 }
 


### PR DESCRIPTION
## Summary
- pin `mermaid` to `11.15.0` in `web/package.json` via `pnpm.overrides`
- refresh `web/pnpm-lock.yaml` so `streamdown-svelte` resolves the patched Mermaid parser/runtime chain
- extend `web/scripts/check-security-overrides.mjs` so future lockfile regressions fail if vulnerable Mermaid 11.0.0-11.14.x entries reappear

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm audit --prod --json`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check:security-overrides`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:deps`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/markdown/markdown-content.test.ts`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm build`

## Notes
- `pnpm audit --prod --json` no longer reports any Mermaid advisories after the override; the remaining moderate advisory is unrelated `postcss@8.5.9` from the existing dependency graph.
- An exploratory `pnpm test -- src/lib/features/markdown/markdown-content.test.ts` unexpectedly expanded to the repository's broader Vitest suite and surfaced many pre-existing unrelated failures; the targeted `vitest run src/lib/features/markdown/markdown-content.test.ts` passed.
