### PR TITLE
refactor(web): tighten state module budget

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,7 +92,7 @@ These budgets are enforced by `pnpm run lint:structure` and mirrored in ESLint w
 | `routes/**/+page.svelte`            | 150        | 250                  |
 | `routes/**/+layout.svelte`          | 180        | 300                  |
 | `lib/features/**/*.test.{ts,js}`    | 300        | 650                  |
-| `lib/features/**/*.svelte.{ts,js}`  | 250        | 350                  |
+| `lib/features/**/*.svelte.{ts,js}`  | 250        | 325                  |
 | `lib/features/**/*.svelte`          | 200        | 350                  |
 | `lib/features/**/*.{ts,js}`         | 200        | 325                  |
 | `lib/testing/**/*.{ts,js}`          | 350        | 650                  |

--- a/web/file-budgets.config.mjs
+++ b/web/file-budgets.config.mjs
@@ -57,7 +57,7 @@ export const fileBudgetCategories = [
     key: 'featureStateModule',
     name: 'Feature state modules',
     softLimit: 250,
-    hardLimit: 350,
+    hardLimit: 325,
     match: isFeatureStateModule,
     eslintFiles: ['src/lib/features/**/*.svelte.{ts,js}'],
   }),

--- a/web/src/lib/features/chat/terminal-manager-instance-state.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager-instance-state.svelte.ts
@@ -1,0 +1,97 @@
+import type { TerminalInstance } from './terminal-manager-types'
+
+export function createTerminalManagerInstanceState() {
+  let instances = $state<TerminalInstance[]>([])
+  let activeId = $state('')
+  let panelOpen = $state(false)
+
+  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
+    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
+  }
+
+  function getActiveInstance(): TerminalInstance | undefined {
+    return instances.find((inst) => inst.id === activeId)
+  }
+
+  function hasInstance(id: string) {
+    return instances.some((inst) => inst.id === id)
+  }
+
+  function createInstance(createId: () => string) {
+    const id = createId()
+    const index = instances.length + 1
+    instances = [
+      ...instances,
+      {
+        id,
+        label: `Terminal ${index}`,
+        status: 'idle',
+        statusMessage: 'Connecting...',
+        sessionID: '',
+      },
+    ]
+    activeId = id
+    return id
+  }
+
+  function removeInstance(id: string) {
+    const closingIndex = instances.findIndex((inst) => inst.id === id)
+    instances = instances.filter((inst) => inst.id !== id)
+    if (activeId === id) {
+      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
+      activeId = nextActive?.id ?? ''
+    }
+    if (instances.length === 0) {
+      panelOpen = false
+    }
+  }
+
+  function openPanel(seedInstance: () => void) {
+    panelOpen = true
+    if (instances.length === 0) {
+      seedInstance()
+    }
+  }
+
+  function togglePanel(seedInstance: () => void) {
+    if (panelOpen) {
+      panelOpen = false
+      return
+    }
+    openPanel(seedInstance)
+  }
+
+  function closePanel() {
+    panelOpen = false
+  }
+
+  function reset() {
+    instances = []
+    activeId = ''
+    panelOpen = false
+  }
+
+  return {
+    get instances() {
+      return instances
+    },
+    get activeId() {
+      return activeId
+    },
+    set activeId(id: string) {
+      activeId = id
+    },
+    get panelOpen() {
+      return panelOpen
+    },
+    updateInstance,
+    getActiveInstance,
+    hasInstance,
+    createInstance,
+    removeInstance,
+    openPanel,
+    togglePanel,
+    closePanel,
+    reset,
+  }
+}

--- a/web/src/lib/features/chat/terminal-manager.svelte.ts
+++ b/web/src/lib/features/chat/terminal-manager.svelte.ts
@@ -3,6 +3,7 @@ import {
   mountProjectConversationTerminal,
 } from './project-conversation-terminal-panel-helpers'
 import { createTerminalConnectionHelpers } from './terminal-manager-connection'
+import { createTerminalManagerInstanceState } from './terminal-manager-instance-state.svelte'
 import {
   TERMINAL_RECONNECT_ATTEMPT_LIMIT,
   clearTerminalReconnectTimer,
@@ -11,19 +12,13 @@ import {
   generateTerminalManagerID,
   nextTerminalReconnectDelay,
 } from './terminal-manager-runtime'
-import type {
-  MountedTerminal,
-  TerminalInstance,
-  TerminalInstanceRuntime,
-} from './terminal-manager-types'
+import type { MountedTerminal, TerminalInstanceRuntime } from './terminal-manager-types'
 
 export function createTerminalManager(input: {
   getConversationId: () => string
   getWorkspacePath: () => string
 }) {
-  let instances = $state<TerminalInstance[]>([])
-  let activeId = $state<string>('')
-  let panelOpen = $state(false)
+  const instanceState = createTerminalManagerInstanceState()
 
   // Internal state per instance (not reactive, keyed by id)
   const xtermMap = new Map<string, MountedTerminal>()
@@ -32,27 +27,15 @@ export function createTerminalManager(input: {
   const resizeObserverMap = new Map<string, ResizeObserver>()
   const runtimeMap = new Map<string, TerminalInstanceRuntime>()
 
-  function updateInstance(id: string, updates: Partial<TerminalInstance>) {
-    instances = instances.map((inst) => (inst.id === id ? { ...inst, ...updates } : inst))
-  }
-
-  function getActiveInstance(): TerminalInstance | undefined {
-    return instances.find((i) => i.id === activeId)
-  }
-
-  function hasInstance(id: string) {
-    return instances.some((inst) => inst.id === id)
-  }
-
   const { attachSocket, matchesConnectionState, resolveTerminalSession, setConnectingStatus } =
     createTerminalConnectionHelpers({
       getConversationId: input.getConversationId,
-      hasInstance,
-      listInstances: () => instances,
+      hasInstance: instanceState.hasInstance,
+      listInstances: () => instanceState.instances,
       runtimeMap,
       socketMap,
       scheduleReconnect,
-      updateInstance,
+      updateInstance: instanceState.updateInstance,
     })
 
   async function mountTerminal(id: string, element: HTMLDivElement) {
@@ -82,7 +65,7 @@ export function createTerminalManager(input: {
     })
 
     if (
-      !hasInstance(id) ||
+      !instanceState.hasInstance(id) ||
       runtimeMap.get(id)?.mountRevision !== mountRevision ||
       elementMap.get(id) !== element
     ) {
@@ -145,7 +128,11 @@ export function createTerminalManager(input: {
       runtime.session = null
     }
     if (options.updateStatus) {
-      updateInstance(id, { status: 'closed', statusMessage: 'Terminal closed.', sessionID: '' })
+      instanceState.updateInstance(id, {
+        status: 'closed',
+        statusMessage: 'Terminal closed.',
+        sessionID: '',
+      })
     }
   }
 
@@ -155,7 +142,7 @@ export function createTerminalManager(input: {
       !runtime ||
       !runtime.reconnectEnabled ||
       !runtime.session ||
-      !hasInstance(id) ||
+      !instanceState.hasInstance(id) ||
       !xtermMap.has(id)
     ) {
       return
@@ -163,7 +150,7 @@ export function createTerminalManager(input: {
 
     if (runtime.reconnectAttempts >= TERMINAL_RECONNECT_ATTEMPT_LIMIT) {
       runtime.reconnectEnabled = false
-      updateInstance(id, {
+      instanceState.updateInstance(id, {
         status: 'error',
         statusMessage: 'Terminal disconnected. Reconnect attempts exhausted.',
         sessionID: '',
@@ -173,14 +160,14 @@ export function createTerminalManager(input: {
 
     runtime.reconnectAttempts += 1
     const delay = nextTerminalReconnectDelay(runtime.reconnectAttempts)
-    updateInstance(id, {
+    instanceState.updateInstance(id, {
       status: 'connecting',
       statusMessage: `Reconnecting shell in ${label}...`,
       sessionID: '',
     })
     runtime.reconnectTimer = setTimeout(() => {
       runtime.reconnectTimer = null
-      if (!runtime.reconnectEnabled || !hasInstance(id) || !xtermMap.has(id)) {
+      if (!runtime.reconnectEnabled || !instanceState.hasInstance(id) || !xtermMap.has(id)) {
         return
       }
       void connectTerminal(id, true)
@@ -192,7 +179,7 @@ export function createTerminalManager(input: {
     const workspacePath = input.getWorkspacePath()
     const runtime = ensureTerminalRuntime(runtimeMap, id)
     const entry = xtermMap.get(id)
-    if (!conversationId || !entry || !hasInstance(id)) return
+    if (!conversationId || !entry || !instanceState.hasInstance(id)) return
 
     closeSocket(id, { updateStatus: false, reconnect: false, terminate: false })
     runtime.connectRevision += 1
@@ -202,7 +189,7 @@ export function createTerminalManager(input: {
     entry.fitAddon.fit()
 
     const label = workspacePath || 'workspace root'
-    updateInstance(id, { label })
+    instanceState.updateInstance(id, { label })
     setConnectingStatus(id, label, isReconnect)
 
     const session = await resolveTerminalSession({
@@ -222,7 +209,7 @@ export function createTerminalManager(input: {
     }
 
     runtime.session = session
-    updateInstance(id, { sessionID: session.id })
+    instanceState.updateInstance(id, { sessionID: session.id })
     attachSocket({
       id,
       session,
@@ -233,62 +220,36 @@ export function createTerminalManager(input: {
     })
   }
 
-  function createInstance(): string {
-    const id = generateTerminalManagerID()
-    const index = instances.length + 1
-    instances = [
-      ...instances,
-      {
-        id,
-        label: `Terminal ${index}`,
-        status: 'idle',
-        statusMessage: 'Connecting...',
-        sessionID: '',
-      },
-    ]
-    activeId = id
-    return id
+  function createInstance() {
+    return instanceState.createInstance(generateTerminalManagerID)
   }
 
   function removeInstance(id: string) {
-    const closingIndex = instances.findIndex((inst) => inst.id === id)
     unmountTerminal(id, true)
-    instances = instances.filter((i) => i.id !== id)
-    if (activeId === id) {
-      const nextActive = instances[closingIndex] ?? instances[Math.max(closingIndex - 1, 0)]
-      activeId = nextActive?.id ?? ''
-    }
-    if (instances.length === 0) {
-      panelOpen = false
-    }
+    instanceState.removeInstance(id)
   }
 
   function openPanel() {
-    panelOpen = true
-    if (instances.length === 0) {
+    instanceState.openPanel(() => {
       createInstance()
-    }
+    })
   }
 
   function togglePanel() {
-    if (panelOpen) {
-      panelOpen = false
-    } else {
-      openPanel()
-    }
+    instanceState.togglePanel(() => {
+      createInstance()
+    })
   }
 
   function closePanel() {
-    panelOpen = false
+    instanceState.closePanel()
   }
 
   function disposeAll() {
-    for (const inst of instances) {
+    for (const inst of instanceState.instances) {
       unmountTerminal(inst.id, true)
     }
-    instances = []
-    activeId = ''
-    panelOpen = false
+    instanceState.reset()
   }
 
   /** Refits all visible terminals (call after panel resize). */
@@ -300,18 +261,18 @@ export function createTerminalManager(input: {
 
   return {
     get instances() {
-      return instances
+      return instanceState.instances
     },
     get activeId() {
-      return activeId
+      return instanceState.activeId
     },
     set activeId(id: string) {
-      activeId = id
+      instanceState.activeId = id
     },
     get panelOpen() {
-      return panelOpen
+      return instanceState.panelOpen
     },
-    getActiveInstance,
+    getActiveInstance: instanceState.getActiveInstance,
     mountTerminal,
     connectTerminal,
     createInstance,


### PR DESCRIPTION
## Summary
- tighten the shared `lib/features/**/*.svelte.{ts,js}` hard budget from 350 to 325
- extract terminal manager instance/panel state into a dedicated `.svelte.ts` module so the terminal manager no longer relies on the wider temporary budget slack
- document the stricter state-module ceiling in the frontend README

## Validation
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:structure`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run lint:eslint`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run check`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/chat/terminal-manager.test.ts --reporter=dot`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci` *(all non-E2E steps passed; one local mobile Playwright run flaked in `public-overlays.spec.ts` / `smoke-layout.spec.ts`, and both failures passed on isolated reruns below)*
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec playwright test tests/e2e/mobile/public-overlays.spec.ts --project=phone-360x800-compact --reporter=line`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec playwright test tests/e2e/mobile/public-overlays.spec.ts --project=tablet-768x1024-portrait --reporter=line`
- `cd web && PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec playwright test tests/e2e/mobile/smoke-layout.spec.ts --project=tablet-1024x768-landscape --grep 'Agents mobile smoke keeps key controls reachable' --reporter=line`

## Ticket
- ASE-565
