### PR TITLE
fix(web): pin devalue to 5.8.1 for GHSA-77vg-94rm-hx3p

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -91,6 +91,7 @@
   "pnpm": {
     "overrides": {
       "cookie": "0.7.2",
+      "devalue": "5.8.1",
       "dompurify": "3.4.0",
       "lodash-es": "4.18.1",
       "uuid": "14.0.0"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cookie: 0.7.2
+  devalue: 5.8.1
   dompurify: 3.4.0
   lodash-es: 4.18.1
   uuid: 14.0.0
@@ -795,20 +796,6 @@ packages:
       {
         integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==,
       }
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution:
-      {
-        integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==,
-      }
-    engines: { node: 20 || >=22 }
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution:
-      {
-        integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==,
-      }
-    engines: { node: 20 || >=22 }
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution:
@@ -2976,10 +2963,10 @@ packages:
       }
     engines: { node: '>=8' }
 
-  devalue@5.6.4:
+  devalue@5.8.1:
     resolution:
       {
-        integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==,
+        integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==,
       }
 
   devlop@1.1.0:
@@ -6536,12 +6523,6 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.19
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6856,7 +6837,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -7850,7 +7831,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -9825,7 +9806,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       esrap: 2.2.4
       is-reference: 3.0.3


### PR DESCRIPTION
## What changed
- add a `pnpm.overrides` pin for `devalue` at `5.8.1`
- refresh `web/pnpm-lock.yaml` so the Svelte runtime dependency graph resolves the patched `devalue` release

## Why
Dependabot flagged `devalue` versions before `5.8.1` for a sparse-array deserialization denial-of-service issue (`GHSA-77vg-94rm-hx3p` / `CVE-2026-42570`). The frontend lockfile previously resolved `devalue` to `5.6.4` through the Svelte toolchain.

I first verified whether a broader Svelte/Kit upgrade was the cleanest remediation path. Updating `@sveltejs/kit` and `svelte` to patched dependency ranges made the advisory disappear, but it also introduced Playwright regressions in this repo. This PR keeps the app versions stable and applies the narrowest lockfile-safe fix by pinning `devalue` directly.

## Impact
- removes the vulnerable `devalue@5.6.4` resolution from the web lockfile
- keeps the existing Svelte and SvelteKit versions unchanged
- limits the code change to dependency metadata only

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm why devalue`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm run ci`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec playwright test tests/e2e/mobile/interactions.spec.ts tests/e2e/mobile/public-overlays.spec.ts --project=phone-360x800-compact --project=tablet-768x1024-portrait --grep 'Tickets mobile interaction flow remains usable|mobile search can open the ticket drawer from the top bar' --reporter=dot --quiet`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec playwright test tests/e2e/mobile/interactions.spec.ts tests/e2e/mobile/public-overlays.spec.ts --project=phone-360x800-compact --project=tablet-768x1024-portrait --reporter=dot --quiet` on a detached `origin/main` worktree to confirm the remaining full-suite mobile Playwright timeouts are pre-existing/flaky in this environment
