### PR TITLE
ASE-587: refresh GPT-5.5 pricing metadata

### DIFF
--- a/docs/zh/provider-reasoning-effort-matrix.md
+++ b/docs/zh/provider-reasoning-effort-matrix.md
@@ -23,6 +23,7 @@ OpenASE 当前内建模型目录显式建模了以下 reasoning effort 能力：
 
 | Model | Supported efforts | Default |
 | --- | --- | --- |
+| `gpt-5.5` | `low`, `medium`, `high`, `xhigh` | `medium` |
 | `gpt-5.4` | `low`, `medium`, `high`, `xhigh` | `medium` |
 | `gpt-5.4-mini` | `low`, `medium`, `high`, `xhigh` | `medium` |
 | `gpt-5.3-codex` | `low`, `medium`, `high`, `xhigh` | `medium` |

--- a/internal/domain/catalog/provider_model_pricing.go
+++ b/internal/domain/catalog/provider_model_pricing.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	builtinPricingVerifiedAt       = "2026-04-01"
-	builtinOpenAIPricingVerifiedAt = "2026-04-29"
+	builtinOpenAIPricingVerifiedAt = "2026-05-16"
 )
 
 var builtinAgentProviderPricingConfigs = map[AgentProviderAdapterType]map[string]pricing.ProviderModelPricingConfig{

--- a/web/src/lib/features/agents/provider-pricing.test.ts
+++ b/web/src/lib/features/agents/provider-pricing.test.ts
@@ -20,7 +20,7 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
           provider: 'openai',
           model_id: 'gpt-5.5',
           source_url: 'https://openai.com/api/pricing/',
-          source_verified_at: '2026-04-29',
+          source_verified_at: '2026-05-16',
           rates: {
             input_per_token: 0.000005,
             output_per_token: 0.00003,
@@ -28,7 +28,7 @@ const providerModelCatalogFixture: AgentProviderModelCatalogEntry[] = [
           },
           notes: [],
           tiers: [],
-          version: '2026-04-29',
+          version: '2026-05-16',
         },
       },
     ],


### PR DESCRIPTION
## What changed
- refreshed the built-in GPT-5.5 OpenAI pricing verification date to `2026-05-16` after re-checking the official API pricing page
- updated the provider pricing frontend fixture so the surfaced metadata stays aligned with backend pricing provenance
- added `gpt-5.5` to the Codex reasoning-effort matrix documentation

## Why
`gpt-5.5` was already wired into the product, but the verified-at metadata and supporting docs lagged behind the latest official pricing verification.

## Validation
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/domain/catalog`
- `PATH=$HOME/.local/go1.26.1/bin:$PATH go test ./internal/httpapi -run TestAgentCatalogRouteErrorMappingsAndHelpers`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH pnpm exec vitest run src/lib/features/agents/provider-pricing.test.ts`

## Ticket
- ASE-587
