### PR TITLE
bug: Claude Code execution failures surface opaque 'empty error_during_execution' message

### DIFF
--- a/internal/chat/project_conversation_stream_projection.go
+++ b/internal/chat/project_conversation_stream_projection.go
@@ -488,7 +488,17 @@ func (s *ProjectConversationService) consumeTurn(
 		case "error":
 			payload, ok := event.Payload.(errorPayload)
 			if ok {
-				s.recordConversationTrace(ctx, live, run, "error", map[string]any{"message": payload.Message}, "runtime")
+				tracePayload := map[string]any{"message": payload.Message}
+				broadcastPayload := map[string]any{"message": payload.Message}
+				if payload.Raw != nil {
+					tracePayload["raw"] = payload.Raw
+					broadcastPayload["raw"] = payload.Raw
+				}
+				if payload.Details != "" {
+					tracePayload["details"] = payload.Details
+					broadcastPayload["details"] = payload.Details
+				}
+				s.recordConversationTrace(ctx, live, run, "error", tracePayload, "runtime")
 				anchor := liveRuntimeSessionAnchor(live, SessionID(conversationID.String()))
 				_, _ = s.core.entries.CompleteTurn(ctx, turn.ID, domain.TurnStatusFailed, optionalNonEmptyString(anchor.LastTurnID))
 				_, _ = s.core.conversations.UpdateConversationAnchors(
@@ -499,10 +509,8 @@ func (s *ProjectConversationService) consumeTurn(
 				)
 				s.recordConversationStep(ctx, live, run, domain.RuntimeStateReady, domain.RunStatusFailed, "turn_failed", payload.Message, optionalNonEmptyString(anchor.ProviderThreadID), nil, payload.Message)
 				s.broadcastConversationEvent(conversation, StreamEvent{
-					Event: "error",
-					Payload: map[string]any{
-						"message": payload.Message,
-					},
+					Event:   "error",
+					Payload: broadcastPayload,
 				})
 			}
 		case "interrupted":

--- a/internal/chat/runtime_claude.go
+++ b/internal/chat/runtime_claude.go
@@ -276,8 +276,11 @@ func (r *ClaudeRuntime) bridgeSession(
 				continue
 			}
 			events <- StreamEvent{
-				Event:   "error",
-				Payload: errorPayload{Message: provider.SummarizeClaudeProcessError(err)},
+				Event: "error",
+				Payload: errorPayload{
+					Message: provider.SummarizeClaudeProcessError(err),
+					Details: err.Error(),
+				},
 			}
 		case event, ok := <-eventCh:
 			if !ok {
@@ -423,8 +426,15 @@ func mapClaudeEvent(
 		return []StreamEvent{{Event: "message", Payload: payload}}
 	case provider.ClaudeCodeEventKindResult:
 		if isClaudeResultError(event) {
-			message, _ := provider.ClaudeCodeTurnFailure(event)
-			return []StreamEvent{{Event: "error", Payload: errorPayload{Message: message}}}
+			message, additionalDetails := provider.ClaudeCodeTurnFailure(event)
+			payload := errorPayload{Message: message}
+			if raw := decodeRawJSON(event.Raw); raw != nil {
+				payload.Raw = raw
+			}
+			if additionalDetails != "" {
+				payload.Details = additionalDetails
+			}
+			return []StreamEvent{{Event: "error", Payload: payload}}
 		}
 		costUSD := cloneCostUSD(event.TotalCostUSD)
 		if event.UsageInfo != nil {

--- a/internal/chat/runtime_claude.go
+++ b/internal/chat/runtime_claude.go
@@ -277,7 +277,7 @@ func (r *ClaudeRuntime) bridgeSession(
 			}
 			events <- StreamEvent{
 				Event:   "error",
-				Payload: errorPayload{Message: err.Error()},
+				Payload: errorPayload{Message: provider.SummarizeClaudeProcessError(err)},
 			}
 		case event, ok := <-eventCh:
 			if !ok {

--- a/internal/chat/runtime_semantics_test.go
+++ b/internal/chat/runtime_semantics_test.go
@@ -655,6 +655,12 @@ func TestMapClaudeEventPromotesClaudeResultErrorsIntoErrorEvents(t *testing.T) {
 	if payload.Message != "Claude couldn't finish this reply. Try sending your message again." {
 		t.Fatalf("error payload = %#v, want user-facing summary", payload)
 	}
+	if payload.Raw == nil {
+		t.Fatalf("error payload raw = %#v, want decoded result payload", payload)
+	}
+	if payload.Details == "" || !strings.Contains(payload.Details, "error_during_execution") {
+		t.Fatalf("error payload details = %q, want encoded raw JSON with subtype", payload.Details)
+	}
 }
 
 func TestMapClaudeEventMapsInterruptedClaudeExecutionErrorsToUserFacingMessage(t *testing.T) {

--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -135,6 +135,10 @@ type sessionPayload struct {
 
 type errorPayload struct {
 	Message string `json:"message"`
+	// Raw is the decoded Claude result payload when the failure came from a stream result event.
+	Raw any `json:"raw,omitempty"`
+	// Details holds encoded result JSON or a technical process-error string for expanded diagnostics.
+	Details string `json:"details,omitempty"`
 }
 
 type sessionPolicy struct {

--- a/internal/provider/claudecode_protocol.go
+++ b/internal/provider/claudecode_protocol.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 )
 
@@ -166,17 +168,62 @@ func ClaudeCodeTurnFailure(event ClaudeCodeEvent) (string, string) {
 		}
 	}
 	payloadMap := asClaudeCodeMap(rawPayload)
-	if message != "" {
+	subtype := strings.TrimSpace(event.Subtype)
+	if message != "" && !shouldReplaceClaudeCodeResultMessage(message, event) {
 		return message, additionalDetails
 	}
 
-	if summary := summarizeClaudeCodeFailure(strings.TrimSpace(event.Subtype), payloadMap); summary != "" {
+	if summary := summarizeClaudeCodeFailure(subtype, payloadMap); summary != "" {
 		return summary, additionalDetails
 	}
 	if additionalDetails != "" {
 		return "Claude couldn't finish this reply. Try sending your message again.", additionalDetails
 	}
 	return "Claude couldn't finish this reply. Try sending your message again.", ""
+}
+
+const claudeCodeGenericRetryMessage = "Claude couldn't finish this reply. Try sending your message again."
+
+func SummarizeClaudeProcessError(err error) string {
+	if err == nil {
+		return claudeCodeGenericRetryMessage
+	}
+	lowered := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(lowered, "claude code process exited"):
+		return "Claude stopped unexpectedly. Try sending your message again."
+	case strings.Contains(lowered, "claude code stderr:"):
+		return "Claude reported a problem while running. Try sending your message again, or check the session logs for details."
+	case errors.Is(err, context.DeadlineExceeded),
+		strings.Contains(lowered, "context deadline exceeded"),
+		strings.Contains(lowered, "timeout"):
+		return "Claude took too long to respond. Try sending your message again."
+	case strings.Contains(lowered, "connection refused"),
+		strings.Contains(lowered, "econnrefused"),
+		strings.Contains(lowered, "i/o timeout"),
+		strings.Contains(lowered, "network"):
+		return "Couldn't reach Claude. Check your network connection and try again."
+	case strings.Contains(lowered, "401"),
+		strings.Contains(lowered, "authentication"),
+		strings.Contains(lowered, "unauthorized"):
+		return "Claude authentication failed. Check your API credentials and try again."
+	default:
+		return claudeCodeGenericRetryMessage
+	}
+}
+
+func shouldReplaceClaudeCodeResultMessage(message string, event ClaudeCodeEvent) bool {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return true
+	}
+	lowered := strings.ToLower(trimmed)
+	if strings.Contains(lowered, "error_during_execution") ||
+		strings.Contains(lowered, "empty error") ||
+		strings.Contains(lowered, "reported an empty") {
+		return true
+	}
+	return false
 }
 
 type claudeCodeEDEDiagnostic struct {

--- a/internal/provider/claudecode_protocol_test.go
+++ b/internal/provider/claudecode_protocol_test.go
@@ -1,7 +1,10 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -93,5 +96,69 @@ func TestClaudeCodeTurnFailureMapsMissingResumeSessionToUserFacingMessage(t *tes
 	}
 	if !strings.Contains(details, `"thread not found: claude-session-stale"`) {
 		t.Fatalf("details = %q, want encoded raw payload", details)
+	}
+}
+
+func TestSummarizeClaudeProcessErrorMapsProcessExit(t *testing.T) {
+	msg := SummarizeClaudeProcessError(fmt.Errorf("claude code process exited: %w", errors.New("signal killed")))
+	if strings.Contains(msg, "claude code process exited") {
+		t.Fatalf("message = %q, should not echo internal error", msg)
+	}
+	if !strings.Contains(msg, "unexpectedly") || !strings.Contains(msg, "Try sending") {
+		t.Fatalf("message = %q, want friendly retry guidance", msg)
+	}
+}
+
+func TestSummarizeClaudeProcessErrorMapsStderr(t *testing.T) {
+	msg := SummarizeClaudeProcessError(errors.New("claude code stderr: secret diagnostic line"))
+	if strings.Contains(msg, "secret diagnostic") {
+		t.Fatalf("message = %q, should not echo stderr", msg)
+	}
+	if !strings.Contains(msg, "Try sending") {
+		t.Fatalf("message = %q, want retry guidance", msg)
+	}
+}
+
+func TestSummarizeClaudeProcessErrorMapsTimeoutAndConnectivity(t *testing.T) {
+	if got := SummarizeClaudeProcessError(context.DeadlineExceeded); !strings.Contains(got, "too long") {
+		t.Fatalf("deadline message = %q", got)
+	}
+	if got := SummarizeClaudeProcessError(errors.New("dial tcp: connection refused")); !strings.Contains(got, "reach Claude") {
+		t.Fatalf("connection refused message = %q", got)
+	}
+	if got := SummarizeClaudeProcessError(errors.New("HTTP 401")); !strings.Contains(got, "authentication") {
+		t.Fatalf("401 message = %q", got)
+	}
+	if got := SummarizeClaudeProcessError(errors.New("something odd")); got != claudeCodeGenericRetryMessage {
+		t.Fatalf("default message = %q", got)
+	}
+}
+
+func TestClaudeCodeTurnFailureReplacesLegacyResultJargon(t *testing.T) {
+	message, details := ClaudeCodeTurnFailure(ClaudeCodeEvent{
+		Kind:    ClaudeCodeEventKindResult,
+		Subtype: "error_during_execution",
+		Result:  "error_during_execution",
+		Raw:     json.RawMessage(`{"type":"result","subtype":"error_during_execution","result":"error_during_execution"}`),
+	})
+	if strings.Contains(message, "error_during_execution") {
+		t.Fatalf("message = %q, should hide internal jargon", message)
+	}
+	if message != claudeCodeGenericRetryMessage {
+		t.Fatalf("message = %q, want generic retry", message)
+	}
+	if !strings.Contains(details, `"subtype":"error_during_execution"`) {
+		t.Fatalf("details = %q, want raw payload preserved", details)
+	}
+}
+
+func TestClaudeCodeTurnFailureReplacesReportedEmptyErrorPhrase(t *testing.T) {
+	message, _ := ClaudeCodeTurnFailure(ClaudeCodeEvent{
+		Kind:    ClaudeCodeEventKindResult,
+		Subtype: "error",
+		Result:  "Claude reported an empty error response. Try sending your message again.",
+	})
+	if message != "Claude reported an error before this reply finished. Try sending your message again." {
+		t.Fatalf("message = %q, want subtype error summary", message)
 	}
 }

--- a/web/src/lib/api/chat.ts
+++ b/web/src/lib/api/chat.ts
@@ -33,6 +33,8 @@ export type ChatSessionPayload = {
 
 export type ChatErrorPayload = {
   message: string
+  raw?: unknown
+  details?: unknown
 }
 
 export type ChatDiffLineOp = 'context' | 'add' | 'remove'
@@ -2143,9 +2145,16 @@ function parseDonePayload(payload: unknown): ChatDonePayload {
 
 function parseErrorPayload(payload: unknown): ChatErrorPayload {
   const object = parseRequiredObject(payload)
-  return {
+  const parsed: ChatErrorPayload = {
     message: readRequiredString(object, 'message'),
   }
+  if ('raw' in object) {
+    parsed.raw = object.raw
+  }
+  if ('details' in object) {
+    parsed.details = object.details
+  }
+  return parsed
 }
 
 function parseProjectConversation(value: unknown): ProjectConversation {

--- a/web/src/lib/features/chat/project-conversation-stream.test.ts
+++ b/web/src/lib/features/chat/project-conversation-stream.test.ts
@@ -111,6 +111,42 @@ describe('handleProjectConversationStreamEvent', () => {
     expect(handlers.onError).toHaveBeenCalledWith('codex chat turn failed')
   })
 
+  it('maps Claude result errors from raw payload instead of legacy message', () => {
+    const handlers = createHandlers()
+
+    handleProjectConversationStreamEvent(
+      {
+        kind: 'error',
+        payload: {
+          message: 'Claude Code reported an empty error_during_execution result.',
+          raw: {
+            type: 'result',
+            is_error: true,
+            subtype: 'error_during_execution',
+            terminal_reason: 'aborted_streaming',
+            errors: [
+              '[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use',
+              'Error: Request was aborted.',
+            ],
+          },
+        },
+      },
+      handlers,
+    )
+
+    expect(handlers.appendTaskStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusType: 'error',
+        detail:
+          "Claude couldn't finish this reply because the session was interrupted. Try sending your message again.",
+        raw: expect.objectContaining({ subtype: 'error_during_execution' }),
+      }),
+    )
+    expect(handlers.onError).toHaveBeenCalledWith(
+      "Claude couldn't finish this reply because the session was interrupted. Try sending your message again.",
+    )
+  })
+
   it('preserves structured task status payload details for rendering', () => {
     const handlers = createHandlers()
 

--- a/web/src/lib/features/chat/project-conversation-stream.ts
+++ b/web/src/lib/features/chat/project-conversation-stream.ts
@@ -1,5 +1,10 @@
 import type { ProjectConversationStreamEvent } from '$lib/api/chat'
 import {
+  asRecord,
+  buildTaskDetail,
+  mapLegacyClaudeFailureOutput,
+} from './project-conversation-transcript-parser-helpers'
+import {
   createProjectConversationDiffEntriesFromUnifiedDiff,
   isDiffPayload,
   isTextPayload,
@@ -190,11 +195,18 @@ export function handleProjectConversationStreamEvent(
   }
 
   handlers.finalizeAssistantEntry()
+  const errorPayload = event.payload
+  const rawRecord = asRecord(errorPayload.raw) ?? asRecord(errorPayload.details)
+  const detail =
+    buildTaskDetail(rawRecord) ||
+    mapLegacyClaudeFailureOutput(errorPayload.message) ||
+    errorPayload.message
   handlers.appendTaskStatus({
     statusType: 'error',
     title: chatT('chat.status.turnFailed'),
-    detail: event.payload.message,
+    detail,
+    raw: rawRecord ?? undefined,
   })
   handlers.setPending(false)
-  handlers.onError(event.payload.message)
+  handlers.onError(detail)
 }

--- a/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.test.ts
+++ b/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  claudeFailureDetailFromPayload,
+  describeClaudeResultFailure,
+  mapLegacyClaudeFailureOutput,
+} from './project-conversation-transcript-parser-helpers'
+
+const GENERIC =
+  "Claude couldn't finish this reply. Try sending your message again."
+
+describe('claudeFailureDetailFromPayload', () => {
+  it('maps bare error_during_execution to generic retry guidance', () => {
+    const detail = claudeFailureDetailFromPayload({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+    })
+    expect(detail).toBe(GENERIC)
+    expect(detail).not.toContain('error_during_execution')
+  })
+
+  it('maps interrupted execution to session interrupted guidance', () => {
+    const detail = claudeFailureDetailFromPayload({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      terminal_reason: 'aborted_streaming',
+      errors: [
+        '[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use',
+        'Error: Request was aborted.',
+      ],
+    })
+    expect(detail).toBe(
+      "Claude couldn't finish this reply because the session was interrupted. Try sending your message again.",
+    )
+  })
+
+  it('maps missing resume session to resume guidance', () => {
+    const detail = claudeFailureDetailFromPayload({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      errors: ['thread not found: claude-session-stale'],
+    })
+    expect(detail).toBe(
+      "Claude couldn't resume the previous session. Try sending your message again, or start a new conversation if it keeps failing.",
+    )
+  })
+
+  it('maps error subtype to pre-finish error guidance', () => {
+    const detail = claudeFailureDetailFromPayload({
+      type: 'result',
+      subtype: 'error',
+      is_error: true,
+    })
+    expect(detail).toBe(
+      'Claude reported an error before this reply finished. Try sending your message again.',
+    )
+  })
+
+  it('maps empty subtype with payload keys to generic retry guidance', () => {
+    const detail = claudeFailureDetailFromPayload({
+      type: 'result',
+      is_error: true,
+      session_id: 'claude-session-1',
+    })
+    expect(detail).toBe(GENERIC)
+  })
+
+  it('returns undefined when payload is not a Claude error result', () => {
+    expect(
+      claudeFailureDetailFromPayload({
+        type: 'result',
+        subtype: 'success',
+      }),
+    ).toBeUndefined()
+    expect(claudeFailureDetailFromPayload(null)).toBeUndefined()
+  })
+
+  it('describeClaudeResultFailure matches claudeFailureDetailFromPayload', () => {
+    const raw = {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+    }
+    expect(describeClaudeResultFailure(raw)).toBe(claudeFailureDetailFromPayload(raw))
+  })
+})
+
+describe('mapLegacyClaudeFailureOutput', () => {
+  it('maps legacy empty error_during_execution output without exposing subtype', () => {
+    const mapped = mapLegacyClaudeFailureOutput(
+      'Claude Code reported an empty error_during_execution result.',
+    )
+    expect(mapped).toBe(GENERIC)
+    expect(mapped).not.toContain('error_during_execution')
+  })
+
+  it('returns undefined for unknown output', () => {
+    expect(mapLegacyClaudeFailureOutput('some other failure')).toBeUndefined()
+  })
+})

--- a/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.ts
@@ -189,6 +189,9 @@ function describeStatus(raw: Record<string, unknown> | null) {
 const CLAUDE_GENERIC_RETRY_MESSAGE =
   "Claude couldn't finish this reply. Try sending your message again."
 
+// User-facing Claude result failure strings must stay aligned with
+// internal/provider/claudecode_protocol.go summarizeClaudeCodeFailure.
+
 const LEGACY_CLAUDE_FAILURE_OUTPUTS: Record<string, string> = {
   'Claude Code reported an empty error_during_execution result.': CLAUDE_GENERIC_RETRY_MESSAGE,
 }

--- a/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.ts
+++ b/web/src/lib/features/chat/project-conversation-transcript-parser-helpers.ts
@@ -186,12 +186,23 @@ function describeStatus(raw: Record<string, unknown> | null) {
   return status ? `Status: ${status}` : undefined
 }
 
-function describeClaudeResultFailure(raw: Record<string, unknown> | null) {
+const CLAUDE_GENERIC_RETRY_MESSAGE =
+  "Claude couldn't finish this reply. Try sending your message again."
+
+const LEGACY_CLAUDE_FAILURE_OUTPUTS: Record<string, string> = {
+  'Claude Code reported an empty error_during_execution result.': CLAUDE_GENERIC_RETRY_MESSAGE,
+}
+
+export function describeClaudeResultFailure(raw: Record<string, unknown> | null) {
+  return claudeFailureDetailFromPayload(raw)
+}
+
+export function claudeFailureDetailFromPayload(raw: Record<string, unknown> | null) {
   if (readString(raw, 'type') !== 'result' || !readBoolean(raw, 'is_error')) {
     return undefined
   }
 
-  const subtype = readString(raw, 'subtype')
+  const subtype = readString(raw, 'subtype') ?? ''
   const errors = readStringList(raw, 'errors')
   const terminalReason = readString(raw, 'terminal_reason')
 
@@ -209,14 +220,25 @@ function describeClaudeResultFailure(raw: Record<string, unknown> | null) {
       ) {
         return "Claude couldn't finish this reply because the session stopped unexpectedly. Try sending your message again."
       }
-      return "Claude couldn't finish this reply. Try sending your message again."
+      return CLAUDE_GENERIC_RETRY_MESSAGE
     case 'error':
       return 'Claude reported an error before this reply finished. Try sending your message again.'
+    case '':
+      if (raw && Object.keys(raw).length > 0) {
+        return CLAUDE_GENERIC_RETRY_MESSAGE
+      }
+      return undefined
     default:
-      return subtype
-        ? 'Claude returned an empty error response. Try sending your message again.'
-        : undefined
+      return 'Claude returned an empty error response. Try sending your message again.'
   }
+}
+
+export function mapLegacyClaudeFailureOutput(output: string): string | undefined {
+  const trimmed = output.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  return LEGACY_CLAUDE_FAILURE_OUTPUTS[trimmed]
 }
 
 function isClaudeInterruptedExecutionFailure(terminalReason: string | undefined, errors: string[]) {

--- a/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-claude.test.ts
@@ -137,4 +137,55 @@ describe('ticket run transcript reducer Claude traces', () => {
       at: '2026-04-01T10:06:13Z',
     })
   })
+
+  it('maps opaque legacy output using full Claude result payload', () => {
+    let state = setTicketRunList(createEmptyTicketRunTranscriptState(), [latestRun])
+
+    state = applyTicketRunStreamFrame(state, {
+      event: 'ticket.run.trace',
+      data: JSON.stringify({
+        entry: {
+          id: 'trace-error-legacy',
+          agent_run_id: latestRun.id,
+          ticket_id: 'ticket-1',
+          sequence: 5,
+          provider: 'claude',
+          kind: 'error',
+          stream: 'task',
+          output: 'Claude Code reported an empty error_during_execution result.',
+          payload: {
+            type: 'result',
+            subtype: 'error_during_execution',
+            is_error: true,
+            terminal_reason: 'aborted_streaming',
+            errors: [
+              '[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use',
+              'Error: Request was aborted.',
+            ],
+          },
+          created_at: '2026-04-01T10:06:14Z',
+        },
+      }),
+    })
+
+    expect(state.blocks).toContainEqual({
+      kind: 'task_status',
+      id: 'status:trace-error-legacy',
+      statusType: 'error',
+      title: 'Turn failed',
+      detail:
+        "Claude couldn't finish this reply because the session was interrupted. Try sending your message again.",
+      raw: {
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        terminal_reason: 'aborted_streaming',
+        errors: [
+          '[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use',
+          'Error: Request was aborted.',
+        ],
+      },
+      at: '2026-04-01T10:06:14Z',
+    })
+  })
 })

--- a/web/src/lib/features/ticket-detail/run-transcript-trace.ts
+++ b/web/src/lib/features/ticket-detail/run-transcript-trace.ts
@@ -3,6 +3,7 @@ import {
   buildProviderStateDetail,
   buildReasoningDetail,
   buildTaskDetail,
+  mapLegacyClaudeFailureOutput,
   readBoolean,
   parseUnifiedDiffPayloads,
   readString,
@@ -176,7 +177,11 @@ function buildTaskStatusBlock(
     id: `status:${entry.id}`,
     statusType,
     title,
-    detail: buildTaskDetail(asRecord(entry.payload)) || entry.output || undefined,
+    detail:
+      buildTaskDetail(asRecord(entry.payload)) ||
+      mapLegacyClaudeFailureOutput(entry.output) ||
+      entry.output ||
+      undefined,
     raw: Object.keys(entry.payload).length > 0 ? entry.payload : undefined,
     at: entry.createdAt,
   }


### PR DESCRIPTION
## Summary

Improves Claude Code failure UX for [#710](https://github.com/PacificStudio/openase/issues/710): primary copy is plain language with retry guidance; internal terms like `error_during_execution` stay in expanded diagnostics only.

## Changes (3 commits on branch)

### Backend (`internal/provider`, `internal/chat`)
- **`SummarizeClaudeProcessError`**: maps harness/process failures (timeout, exit code, connectivity, empty stderr) to user-facing messages with suggested next steps.
- **`ClaudeCodeTurnFailure` / `summarizeClaudeCodeFailure`**: legacy empty `error_during_execution` results get friendly primary text; raw JSON preserved in `AdditionalDetails`.
- **Chat runtime & stream**: error events and broadcasts forward `raw` / `details` so UI can show expandable diagnostics (reviewer feedback).

### Frontend (`web/`)
- **`describeClaudeResultFailure`** aligned with Go categories; legacy persisted `output` strings mapped when payload is missing.
- **Transcript / task status**: `buildTaskDetail` prefers payload-based friendly detail over opaque stored output.
- **Tests**: provider, runtime semantics, parser helpers, transcript/replay fixtures assert primary UX does not show the old empty `error_during_execution` message.

## Verification
- `go test ./internal/provider -count=1` — pass
- Vitest on Claude UX / transcript tests — pass
- Full `go test ./internal/chat` may need non-root for embedded Postgres in CI-like env (noted in build handoff).

## Branch
Pushed: `berserk/40611ae7-f6c6-4859-a606-efeae1760a79` @ `7b438d5c`.

## Commit

7b438d5c628a3442e7f41fa87580788c92acc7e1

## Branch

berserk/40611ae7-f6c6-4859-a606-efeae1760a79

Fixes #710

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PacificStudio/codesmith/openase/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785173133&installation_id=133051282&pr_number=844&repository=PacificStudio%2Fopenase&return_to=https%3A%2F%2Fgithub.com%2FPacificStudio%2Fopenase%2Fpull%2F844&signature=8302fbab086dfd4ce36b5c85e4aeeabb16b3f798e38972528536b18f3943ddee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->