### PR TITLE
Workspace reset leaks errSymlink panic when ASE-499 contains root-owned pnpm node_modules

### DIFF
--- a/internal/httpapi/ticket_api.go
+++ b/internal/httpapi/ticket_api.go
@@ -136,6 +136,10 @@ type workspaceResetConflict interface {
 	WorkspaceResetConflict() bool
 }
 
+type workspaceResetDeleteFailed interface {
+	WorkspaceResetDeleteFailed() bool
+}
+
 type ticketRepoScopeDetailResponse struct {
 	ID                  string               `json:"id"`
 	TicketID            string               `json:"ticket_id"`
@@ -541,6 +545,10 @@ func (s *Server) handleResetTicketWorkspace(c echo.Context) error {
 		var conflictErr workspaceResetConflict
 		if errors.As(err, &conflictErr) && conflictErr.WorkspaceResetConflict() {
 			return writeAPIError(c, http.StatusConflict, "WORKSPACE_RESET_CONFLICT", err.Error())
+		}
+		var deleteErr workspaceResetDeleteFailed
+		if errors.As(err, &deleteErr) && deleteErr.WorkspaceResetDeleteFailed() {
+			return writeAPIError(c, http.StatusConflict, "WORKSPACE_RESET_DELETE_FAILED", err.Error())
 		}
 		return writeTicketError(c, err)
 	}

--- a/internal/httpapi/ticket_api_workspace_reset_test.go
+++ b/internal/httpapi/ticket_api_workspace_reset_test.go
@@ -1,0 +1,185 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	entagentprovider "github.com/BetterAndBetterII/openase/ent/agentprovider"
+	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
+	entticketrepoworkspace "github.com/BetterAndBetterII/openase/ent/ticketrepoworkspace"
+	"github.com/BetterAndBetterII/openase/internal/config"
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	eventinfra "github.com/BetterAndBetterII/openase/internal/infra/event"
+	"github.com/BetterAndBetterII/openase/internal/orchestrator"
+)
+
+func TestHandleResetTicketWorkspaceDeleteFailureReturnsActionableError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can delete protected dirs; run as non-root")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	client := openTestEntClient(t)
+	server := NewServer(
+		config.ServerConfig{Port: 40024},
+		config.GitHubConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		eventinfra.NewChannelBus(),
+		newTicketService(client),
+		newTicketStatusService(client),
+		nil,
+		nil,
+		nil,
+		WithTicketWorkspaceResetter(
+			orchestrator.NewTicketWorkspaceResetService(
+				client,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+				nil,
+			),
+		),
+	)
+
+	ctx := context.Background()
+	org, err := client.Organization.Create().SetName("Acme").SetSlug("acme").Save(ctx)
+	if err != nil {
+		t.Fatalf("create organization: %v", err)
+	}
+	project, err := client.Project.Create().SetOrganizationID(org.ID).SetName("OpenASE").SetSlug("openase").Save(ctx)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	statuses, err := newTicketStatusService(client).ResetToDefaultTemplate(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("reset statuses: %v", err)
+	}
+	todoID := findStatusIDByName(t, statuses, "Todo")
+	doneID := findStatusIDByName(t, statuses, "Done")
+	machine, err := client.Machine.Create().
+		SetOrganizationID(org.ID).
+		SetName("local-devbox").
+		SetHost(catalogdomain.LocalMachineHost).
+		SetPort(0).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create machine: %v", err)
+	}
+	providerItem, err := client.AgentProvider.Create().
+		SetOrganizationID(org.ID).
+		SetMachineID(machine.ID).
+		SetName("Codex").
+		SetAdapterType(entagentprovider.AdapterTypeCodexAppServer).
+		SetCliCommand("codex").
+		SetModelName("gpt-5.4").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	agentItem, err := client.Agent.Create().
+		SetProjectID(project.ID).
+		SetProviderID(providerItem.ID).
+		SetName("coder").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	workflowItem, err := client.Workflow.Create().
+		SetProjectID(project.ID).
+		SetName("coding-workflow").
+		SetType("coding").
+		SetHarnessPath("roles/coding.md").
+		AddPickupStatusIDs(todoID).
+		AddFinishStatusIDs(doneID).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	ticketItem, err := client.Ticket.Create().
+		SetProjectID(project.ID).
+		SetIdentifier("ASE-499").
+		SetTitle("Reset blocked").
+		SetStatusID(todoID).
+		SetCreatedBy("user:test").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	runItem, err := client.AgentRun.Create().
+		SetTicketID(ticketItem.ID).
+		SetWorkflowID(workflowItem.ID).
+		SetAgentID(agentItem.ID).
+		SetProviderID(providerItem.ID).
+		SetStatus(entagentrun.StatusCompleted).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	root := filepath.Join(home, ".openase", "workspace")
+	workspaceRoot := filepath.Join(root, "acme", "openase", "ASE-499")
+	protected := filepath.Join(workspaceRoot, "openase", "web", "node_modules")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(protected, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(protected, 0o755) })
+
+	repoItem, err := client.ProjectRepo.Create().
+		SetProjectID(project.ID).
+		SetName("openase").
+		SetRepositoryURL("https://example.com/openase.git").
+		SetDefaultBranch("main").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	workspaceItem, err := client.TicketRepoWorkspace.Create().
+		SetTicketID(ticketItem.ID).
+		SetAgentRunID(runItem.ID).
+		SetRepoID(repoItem.ID).
+		SetWorkspaceRoot(workspaceRoot).
+		SetRepoPath(filepath.Join(workspaceRoot, "openase")).
+		SetBranchName("scratch").
+		SetState(entticketrepoworkspace.StateReady).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("create workspace row: %v", err)
+	}
+
+	rec := performJSONRequest(
+		t,
+		server,
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/tickets/%s/workspace/reset", ticketItem.ID),
+		"",
+	)
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "WORKSPACE_RESET_DELETE_FAILED") {
+		t.Fatalf("expected delete failed conflict, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "errSymlink") || strings.Contains(body, "PANIC=Error") {
+		t.Fatalf("response leaked internal error: %s", body)
+	}
+
+	workspaceAfter, err := client.TicketRepoWorkspace.Get(ctx, workspaceItem.ID)
+	if err != nil {
+		t.Fatalf("reload workspace: %v", err)
+	}
+	if workspaceAfter.State != entticketrepoworkspace.StateFailed {
+		t.Fatalf("expected failed state, got %+v", workspaceAfter)
+	}
+	if strings.TrimSpace(workspaceAfter.LastError) == "" {
+		t.Fatal("expected persisted LastError")
+	}
+	if strings.Contains(workspaceAfter.LastError, "errSymlink") {
+		t.Fatalf("LastError leaked internal error: %q", workspaceAfter.LastError)
+	}
+}

--- a/internal/httpapi/ticket_api_workspace_reset_test.go
+++ b/internal/httpapi/ticket_api_workspace_reset_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"

--- a/internal/infra/filesystem/safe_delete.go
+++ b/internal/infra/filesystem/safe_delete.go
@@ -1,0 +1,189 @@
+package filesystem
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrUnsafePath indicates the delete target failed symlink or boundary safety checks.
+var ErrUnsafePath = errors.New("unsafe path for deletion")
+
+// ErrDeleteFailed indicates deletion could not be completed (permissions, partial delete, etc.).
+var ErrDeleteFailed = errors.New("path deletion failed")
+
+// PathWithinRoot reports whether target is root itself or a descendant path segment under root
+// (string prefix check on cleaned paths; use after symlink resolution for enforcement).
+func PathWithinRoot(root string, target string) bool {
+	cleanRoot := filepath.Clean(root)
+	cleanTarget := filepath.Clean(target)
+	if cleanRoot == cleanTarget {
+		return true
+	}
+	return strings.HasPrefix(cleanTarget, cleanRoot+string(os.PathSeparator))
+}
+
+// RemoveTree deletes target and its contents after local safety checks.
+//
+// When boundaryRoot is non-empty, target must be a strict descendant of boundaryRoot (neither
+// may equal the other after symlink resolution). The boundary root must not be a symlink that
+// escapes its lexical path.
+//
+// Returns whether anything was deleted (false when target did not exist).
+func RemoveTree(boundaryRoot string, target string) (bool, error) {
+	cleanBoundary := filepath.Clean(strings.TrimSpace(boundaryRoot))
+	cleanTarget := filepath.Clean(strings.TrimSpace(target))
+	if cleanTarget == "" || cleanTarget == "." {
+		return false, fmt.Errorf("%w: target path must not be empty", ErrUnsafePath)
+	}
+
+	if cleanBoundary != "" && cleanBoundary != "." {
+		if cleanTarget == cleanBoundary || !PathWithinRoot(cleanBoundary, cleanTarget) {
+			return false, ErrUnsafePath
+		}
+	}
+
+	var boundaryReal string
+	if cleanBoundary != "" && cleanBoundary != "." {
+		resolved, err := resolveExistingPath(cleanBoundary)
+		if err != nil {
+			return false, fmt.Errorf("resolve deletion boundary %s: %w", cleanBoundary, err)
+		}
+		boundaryReal = resolved
+	}
+
+	info, err := os.Lstat(cleanTarget)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat deletion target %s: %w", cleanTarget, formatPathOpError(err))
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, ErrUnsafePath
+	}
+
+	targetReal, err := resolveExistingPath(cleanTarget)
+	if err != nil {
+		return false, fmt.Errorf("resolve deletion target %s: %w", cleanTarget, err)
+	}
+
+	if boundaryReal != "" {
+		if targetReal == boundaryReal || !PathWithinRoot(boundaryReal, targetReal) {
+			return false, ErrUnsafePath
+		}
+	}
+
+	if err := removeTreeAtRealPath(targetReal); err != nil {
+		return false, fmt.Errorf("%w: %v", ErrDeleteFailed, err)
+	}
+	return true, nil
+}
+
+func resolveExistingPath(path string) (string, error) {
+	real, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", formatPathOpError(err)
+	}
+	return real, nil
+}
+
+// formatPathOpError wraps path resolution/removal errors without calling Error() on
+// internal filepath sentinel values (e.g. errSymlink).
+func formatPathOpError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return fmt.Errorf("permission denied: %w", err)
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && pathErr.Err != nil {
+		if errors.Is(pathErr.Err, os.ErrPermission) {
+			return fmt.Errorf("permission denied: %w", pathErr)
+		}
+		return fmt.Errorf("%s: %w", pathErr.Op, pathErr.Err)
+	}
+	return err
+}
+
+func removeTreeAtRealPath(root string) error {
+	rootInfo, err := os.Lstat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return formatRemovePathError(root, err)
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 {
+		return ErrUnsafePath
+	}
+	if !rootInfo.IsDir() {
+		if err := os.Remove(root); err != nil {
+			return formatRemovePathError(root, err)
+		}
+		return nil
+	}
+
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return formatRemovePathError(path, walkErr)
+		}
+		if path == root {
+			return nil
+		}
+		entryInfo, err := d.Info()
+		if err != nil {
+			return formatRemovePathError(path, err)
+		}
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: symlink %s", ErrUnsafePath, path)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return formatRemovePathError(root, err)
+	}
+	for _, entry := range entries {
+		child := filepath.Join(root, entry.Name())
+		if err := removeTreeAtRealPath(child); err != nil {
+			return err
+		}
+	}
+	if err := os.Remove(root); err != nil {
+		return formatRemovePathError(root, err)
+	}
+	return nil
+}
+
+func formatRemovePathError(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrUnsafePath) || errors.Is(err, ErrDeleteFailed) {
+		return err
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return fmt.Errorf("permission denied removing %s: %w", path, err)
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		if pathErr.Err != nil && errors.Is(pathErr.Err, os.ErrPermission) {
+			return fmt.Errorf("permission denied removing %s: %w", path, pathErr)
+		}
+		if pathErr.Err != nil {
+			return fmt.Errorf("remove %s: %w", path, pathErr.Err)
+		}
+	}
+	return fmt.Errorf("remove %s: %w", path, err)
+}

--- a/internal/infra/filesystem/safe_delete.go
+++ b/internal/infra/filesystem/safe_delete.go
@@ -3,7 +3,6 @@ package filesystem
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,7 +121,10 @@ func removeTreeAtRealPath(root string) error {
 		return formatRemovePathError(root, err)
 	}
 	if rootInfo.Mode()&os.ModeSymlink != 0 {
-		return ErrUnsafePath
+		if err := os.Remove(root); err != nil {
+			return formatRemovePathError(root, err)
+		}
+		return nil
 	}
 	if !rootInfo.IsDir() {
 		if err := os.Remove(root); err != nil {
@@ -131,31 +133,18 @@ func removeTreeAtRealPath(root string) error {
 		return nil
 	}
 
-	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return formatRemovePathError(path, walkErr)
-		}
-		if path == root {
-			return nil
-		}
-		entryInfo, err := d.Info()
-		if err != nil {
-			return formatRemovePathError(path, err)
-		}
-		if entryInfo.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("%w: symlink %s", ErrUnsafePath, path)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return formatRemovePathError(root, err)
 	}
 	for _, entry := range entries {
 		child := filepath.Join(root, entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			if err := os.Remove(child); err != nil {
+				return formatRemovePathError(child, err)
+			}
+			continue
+		}
 		if err := removeTreeAtRealPath(child); err != nil {
 			return err
 		}

--- a/internal/infra/filesystem/safe_delete.go
+++ b/internal/infra/filesystem/safe_delete.go
@@ -59,7 +59,7 @@ func RemoveTree(boundaryRoot string, target string) (bool, error) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("stat deletion target %s: %w", cleanTarget, formatPathOpError(err))
+		return false, fmt.Errorf("stat deletion target %s: %w", cleanTarget, formatFSOpError("", err))
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		return false, ErrUnsafePath
@@ -85,29 +85,47 @@ func RemoveTree(boundaryRoot string, target string) (bool, error) {
 func resolveExistingPath(path string) (string, error) {
 	real, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return "", formatPathOpError(err)
+		return "", formatFSOpError("", err)
 	}
 	return real, nil
 }
 
-// formatPathOpError wraps path resolution/removal errors without calling Error() on
-// internal filepath sentinel values (e.g. errSymlink).
-func formatPathOpError(err error) error {
+// formatFSOpError wraps path resolution/removal errors without calling Error() on
+// internal filepath sentinel values (e.g. errSymlink). Pass an empty path for resolve-only errors.
+func formatFSOpError(path string, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, os.ErrNotExist) {
+	if path != "" {
+		if errors.Is(err, ErrUnsafePath) || errors.Is(err, ErrDeleteFailed) {
+			return err
+		}
+	}
+	if errors.Is(err, os.ErrNotExist) && path == "" {
 		return err
 	}
-	if errors.Is(err, os.ErrPermission) {
-		return fmt.Errorf("permission denied: %w", err)
-	}
+	trimPath := strings.TrimSpace(path)
 	var pathErr *os.PathError
 	if errors.As(err, &pathErr) && pathErr.Err != nil {
 		if errors.Is(pathErr.Err, os.ErrPermission) {
+			if trimPath != "" {
+				return fmt.Errorf("permission denied removing %s: %w", trimPath, pathErr)
+			}
 			return fmt.Errorf("permission denied: %w", pathErr)
 		}
+		if trimPath != "" {
+			return fmt.Errorf("remove %s: %w", trimPath, pathErr.Err)
+		}
 		return fmt.Errorf("%s: %w", pathErr.Op, pathErr.Err)
+	}
+	if errors.Is(err, os.ErrPermission) {
+		if trimPath != "" {
+			return fmt.Errorf("permission denied removing %s: %w", trimPath, err)
+		}
+		return fmt.Errorf("permission denied: %w", err)
+	}
+	if trimPath != "" {
+		return fmt.Errorf("remove %s: %w", trimPath, err)
 	}
 	return err
 }
@@ -118,30 +136,30 @@ func removeTreeAtRealPath(root string) error {
 		return nil
 	}
 	if err != nil {
-		return formatRemovePathError(root, err)
+		return formatFSOpError(root, err)
 	}
 	if rootInfo.Mode()&os.ModeSymlink != 0 {
 		if err := os.Remove(root); err != nil {
-			return formatRemovePathError(root, err)
+			return formatFSOpError(root, err)
 		}
 		return nil
 	}
 	if !rootInfo.IsDir() {
 		if err := os.Remove(root); err != nil {
-			return formatRemovePathError(root, err)
+			return formatFSOpError(root, err)
 		}
 		return nil
 	}
 
 	entries, err := os.ReadDir(root)
 	if err != nil {
-		return formatRemovePathError(root, err)
+		return formatFSOpError(root, err)
 	}
 	for _, entry := range entries {
 		child := filepath.Join(root, entry.Name())
 		if entry.Type()&os.ModeSymlink != 0 {
 			if err := os.Remove(child); err != nil {
-				return formatRemovePathError(child, err)
+				return formatFSOpError(child, err)
 			}
 			continue
 		}
@@ -150,29 +168,7 @@ func removeTreeAtRealPath(root string) error {
 		}
 	}
 	if err := os.Remove(root); err != nil {
-		return formatRemovePathError(root, err)
+		return formatFSOpError(root, err)
 	}
 	return nil
-}
-
-func formatRemovePathError(path string, err error) error {
-	if err == nil {
-		return nil
-	}
-	if errors.Is(err, ErrUnsafePath) || errors.Is(err, ErrDeleteFailed) {
-		return err
-	}
-	if errors.Is(err, os.ErrPermission) {
-		return fmt.Errorf("permission denied removing %s: %w", path, err)
-	}
-	var pathErr *os.PathError
-	if errors.As(err, &pathErr) {
-		if pathErr.Err != nil && errors.Is(pathErr.Err, os.ErrPermission) {
-			return fmt.Errorf("permission denied removing %s: %w", path, pathErr)
-		}
-		if pathErr.Err != nil {
-			return fmt.Errorf("remove %s: %w", path, pathErr.Err)
-		}
-	}
-	return fmt.Errorf("remove %s: %w", path, err)
 }

--- a/internal/infra/filesystem/safe_delete_pnpm_test.go
+++ b/internal/infra/filesystem/safe_delete_pnpm_test.go
@@ -1,0 +1,73 @@
+package filesystem
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoveTreePnpmStyleSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	target := filepath.Join(boundary, "org", "proj", "ASE-499", "web")
+	nodeModules := filepath.Join(target, "node_modules")
+	pnpmStore := filepath.Join(nodeModules, ".pnpm", "eslint@9.0.0", "node_modules", "eslint")
+	if err := os.MkdirAll(pnpmStore, 0o755); err != nil {
+		t.Fatalf("mkdir pnpm store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pnpmStore, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	symlink := filepath.Join(nodeModules, "eslint")
+	if err := os.Symlink(pnpmStore, symlink); err != nil {
+		t.Fatalf("symlink eslint: %v", err)
+	}
+
+	deleted, err := RemoveTree(boundary, target)
+	if err != nil {
+		t.Fatalf("RemoveTree() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target still exists: %v", err)
+	}
+}
+
+func TestRemoveTreePermissionDeniedOnSymlink(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission-denied unlink behavior differs for root; run as non-root in CI")
+	}
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	target := filepath.Join(boundary, "ticket", "web", "node_modules")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	symlink := filepath.Join(target, "eslint")
+	if err := os.Symlink(filepath.Join(root, "outside"), symlink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := os.Chmod(symlink, 0o000); err != nil {
+		t.Fatalf("chmod symlink: %v", err)
+	}
+
+	_, err := RemoveTree(boundary, filepath.Join(boundary, "ticket"))
+	if err == nil {
+		t.Fatal("RemoveTree() error = nil, want permission failure")
+	}
+	if !errors.Is(err, ErrDeleteFailed) {
+		t.Fatalf("RemoveTree() error = %v, want ErrDeleteFailed", err)
+	}
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	if strings.Contains(lower, "errsymlink") || strings.Contains(msg, "PANIC=Error") {
+		t.Fatalf("RemoveTree() leaked internal error: %q", msg)
+	}
+}

--- a/internal/infra/filesystem/safe_delete_test.go
+++ b/internal/infra/filesystem/safe_delete_test.go
@@ -1,0 +1,89 @@
+package filesystem
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveTreeWithinBoundary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	target := filepath.Join(boundary, "org", "proj", "ticket-1")
+	if err := os.MkdirAll(filepath.Join(target, "repo"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "repo", "file.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	deleted, err := RemoveTree(boundary, target)
+	if err != nil {
+		t.Fatalf("RemoveTree() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target still exists: %v", err)
+	}
+}
+
+func TestRemoveTreeRejectsBoundaryTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(boundary, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	_, err := RemoveTree(boundary, boundary)
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("RemoveTree() error = %v, want ErrUnsafePath", err)
+	}
+}
+
+func TestRemoveTreeRejectsSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	secret := filepath.Join(root, "secret")
+	target := filepath.Join(boundary, "ticket")
+	if err := os.MkdirAll(boundary, 0o750); err != nil {
+		t.Fatalf("mkdir boundary: %v", err)
+	}
+	if err := os.MkdirAll(secret, 0o750); err != nil {
+		t.Fatalf("mkdir secret: %v", err)
+	}
+	if err := os.Symlink(secret, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := RemoveTree(boundary, target)
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("RemoveTree() error = %v, want ErrUnsafePath", err)
+	}
+}
+
+func TestRemoveTreeNoBoundary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "artifact")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	deleted, err := RemoveTree("", target)
+	if err != nil {
+		t.Fatalf("RemoveTree() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+}

--- a/internal/infra/machinetransport/runtime_artifacts.go
+++ b/internal/infra/machinetransport/runtime_artifacts.go
@@ -93,7 +93,7 @@ func materializeArtifactEntries(targetRoot string, removePaths []string, entries
 		if trimmed == "" {
 			continue
 		}
-		if err := removeLocalPath(filepath.Join(root, filepath.FromSlash(trimmed))); err != nil {
+		if err := removeLocalPath(root, filepath.Join(root, filepath.FromSlash(trimmed))); err != nil {
 			return err
 		}
 	}

--- a/internal/infra/machinetransport/runtime_protocol.go
+++ b/internal/infra/machinetransport/runtime_protocol.go
@@ -655,7 +655,11 @@ func (s *runtimeProtocolServer) handleWorkspaceReset(ctx context.Context, envelo
 	if err != nil {
 		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeInvalidRequest, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
 	}
-	if err := removeLocalPath(payload.Path); err != nil {
+	boundary, err := workspaceinfra.LocalWorkspaceRoot()
+	if err != nil {
+		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeWorkspace, runtimecontract.ErrorClassMisconfiguration, fmt.Errorf("resolve local workspace root: %w", err), false, nil))
+	}
+	if err := removeLocalPath(boundary, payload.Path); err != nil {
 		return s.sendError(ctx, envelope, runtimeErrorPayload(runtimecontract.ErrorCodeWorkspace, runtimecontract.ErrorClassMisconfiguration, err, false, nil))
 	}
 	return s.sendResponse(ctx, envelope, map[string]any{"ok": true})

--- a/internal/infra/machinetransport/sync.go
+++ b/internal/infra/machinetransport/sync.go
@@ -31,7 +31,7 @@ func syncLocalArtifacts(request SyncArtifactsRequest) error {
 		if trimmed == "" {
 			continue
 		}
-		if err := removeLocalPath(filepath.Join(targetRoot, filepath.FromSlash(trimmed))); err != nil {
+		if err := removeLocalPath(targetRoot, filepath.Join(targetRoot, filepath.FromSlash(trimmed))); err != nil {
 			return err
 		}
 	}

--- a/internal/infra/machinetransport/transport.go
+++ b/internal/infra/machinetransport/transport.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +14,7 @@ import (
 	domain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
 	githubauthdomain "github.com/BetterAndBetterII/openase/internal/domain/githubauth"
 	runtimecontract "github.com/BetterAndBetterII/openase/internal/domain/websocketruntime"
+	"github.com/BetterAndBetterII/openase/internal/infra/filesystem"
 	sshinfra "github.com/BetterAndBetterII/openase/internal/infra/ssh"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
 	"github.com/BetterAndBetterII/openase/internal/logging"
@@ -1240,11 +1240,11 @@ func effectiveConnectionMode(machine domain.Machine) domain.MachineConnectionMod
 	return domain.MachineConnectionModeWSListener
 }
 
-func removeLocalPath(target string) error {
+func removeLocalPath(boundaryRoot string, target string) error {
 	if strings.TrimSpace(target) == "" {
 		return fmt.Errorf("target path must not be empty")
 	}
-	if err := os.RemoveAll(target); err != nil {
+	if _, err := filesystem.RemoveTree(boundaryRoot, target); err != nil {
 		return fmt.Errorf("remove local path %s: %w", target, err)
 	}
 	return nil

--- a/internal/orchestrator/runtime_workspace_provisioner.go
+++ b/internal/orchestrator/runtime_workspace_provisioner.go
@@ -481,12 +481,12 @@ func (p *runtimeWorkspaceProvisioner) removeWorkspaceRoot(ctx context.Context, m
 	}
 
 	if !remote {
-		boundary, err := workspaceinfra.LocalWorkspaceRoot()
+		boundary, err := resolveWorkspaceRoot(machine, false)
 		if err != nil {
-			return fmt.Errorf("resolve local workspace root: %w", err)
+			return classifyLocalWorkspaceDeleteFailure(trimmedRoot, fmt.Errorf("resolve local workspace root: %w", err))
 		}
 		if _, err := filesysteminfra.RemoveTree(boundary, trimmedRoot); err != nil {
-			return fmt.Errorf("remove local workspace %s: %w", trimmedRoot, err)
+			return classifyLocalWorkspaceDeleteFailure(trimmedRoot, fmt.Errorf("remove local workspace %s: %w", trimmedRoot, err))
 		}
 		return nil
 	}

--- a/internal/orchestrator/runtime_workspace_provisioner.go
+++ b/internal/orchestrator/runtime_workspace_provisioner.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	entagentrun "github.com/BetterAndBetterII/openase/ent/agentrun"
 	entticketrepoworkspace "github.com/BetterAndBetterII/openase/ent/ticketrepoworkspace"
 	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+	filesysteminfra "github.com/BetterAndBetterII/openase/internal/infra/filesystem"
 	machinetransport "github.com/BetterAndBetterII/openase/internal/infra/machinetransport"
 	sshinfra "github.com/BetterAndBetterII/openase/internal/infra/ssh"
 	workspaceinfra "github.com/BetterAndBetterII/openase/internal/infra/workspace"
@@ -481,7 +481,11 @@ func (p *runtimeWorkspaceProvisioner) removeWorkspaceRoot(ctx context.Context, m
 	}
 
 	if !remote {
-		if err := os.RemoveAll(trimmedRoot); err != nil {
+		boundary, err := workspaceinfra.LocalWorkspaceRoot()
+		if err != nil {
+			return fmt.Errorf("resolve local workspace root: %w", err)
+		}
+		if _, err := filesysteminfra.RemoveTree(boundary, trimmedRoot); err != nil {
 			return fmt.Errorf("remove local workspace %s: %w", trimmedRoot, err)
 		}
 		return nil

--- a/internal/orchestrator/runtime_workspace_provisioner_remove_test.go
+++ b/internal/orchestrator/runtime_workspace_provisioner_remove_test.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	catalogdomain "github.com/BetterAndBetterII/openase/internal/domain/catalog"
+)
+
+func TestRemoveWorkspaceRootLocalPnpmLayout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	ctx := context.Background()
+	provisioner := newRuntimeWorkspaceProvisioner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, time.Now)
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	workspaceRoot := filepath.Join(boundary, "test", "openase-automation", "ASE-499")
+	nodeModules := filepath.Join(workspaceRoot, "openase", "web", "node_modules")
+	store := filepath.Join(nodeModules, ".pnpm", "pkg", "node_modules", "eslint")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	link := filepath.Join(nodeModules, "eslint")
+	if err := os.Symlink(store, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	machine := catalogdomain.Machine{
+		Name:          catalogdomain.LocalMachineName,
+		Host:          catalogdomain.LocalMachineHost,
+		WorkspaceRoot: stringPointer(boundary),
+	}
+	if err := provisioner.removeWorkspaceRoot(ctx, machine, false, workspaceRoot); err != nil {
+		t.Fatalf("removeWorkspaceRoot() error = %v", err)
+	}
+	if _, err := os.Stat(workspaceRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workspace still exists: %v", err)
+	}
+}
+
+func TestRemoveWorkspaceRootLocalPermissionDeniedMessage(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can delete root-owned trees; run as non-root")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	ctx := context.Background()
+	provisioner := newRuntimeWorkspaceProvisioner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, time.Now)
+
+	root := t.TempDir()
+	boundary := filepath.Join(root, "workspace")
+	workspaceRoot := filepath.Join(boundary, "ticket")
+	protected := filepath.Join(workspaceRoot, "node_modules")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(protected, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(protected, 0o755) })
+
+	machine := catalogdomain.Machine{
+		Name:          catalogdomain.LocalMachineName,
+		Host:          catalogdomain.LocalMachineHost,
+		WorkspaceRoot: stringPointer(boundary),
+	}
+	err := provisioner.removeWorkspaceRoot(ctx, machine, false, workspaceRoot)
+	if err == nil {
+		t.Fatal("removeWorkspaceRoot() error = nil, want failure")
+	}
+	var deleteErr TicketWorkspaceResetDeleteError
+	if !errors.As(err, &deleteErr) {
+		t.Fatalf("removeWorkspaceRoot() error = %T %v, want TicketWorkspaceResetDeleteError", err, err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "errSymlink") || strings.Contains(msg, "PANIC=Error") {
+		t.Fatalf("leaked internal error: %q", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "permission") {
+		t.Fatalf("error = %q, want permission context", msg)
+	}
+}

--- a/internal/orchestrator/workspace_reset_errors.go
+++ b/internal/orchestrator/workspace_reset_errors.go
@@ -1,0 +1,104 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	filesysteminfra "github.com/BetterAndBetterII/openase/internal/infra/filesystem"
+)
+
+// TicketWorkspaceResetDeleteError is returned when local workspace cleanup fails for a user-visible reason.
+type TicketWorkspaceResetDeleteError struct {
+	WorkspaceRoot string
+	Reason        string
+}
+
+func (e TicketWorkspaceResetDeleteError) Error() string {
+	root := strings.TrimSpace(e.WorkspaceRoot)
+	reason := strings.TrimSpace(e.Reason)
+	if root == "" {
+		return reason
+	}
+	if reason == "" {
+		return fmt.Sprintf("failed to remove ticket workspace at %s", root)
+	}
+	return fmt.Sprintf("failed to remove ticket workspace at %s: %s", root, reason)
+}
+
+func (TicketWorkspaceResetDeleteError) WorkspaceResetDeleteFailed() bool {
+	return true
+}
+
+func classifyLocalWorkspaceDeleteFailure(workspaceRoot string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var typed TicketWorkspaceResetDeleteError
+	if errors.As(err, &typed) {
+		return err
+	}
+
+	reason := sanitizeWorkspaceDeleteReason(err)
+	return TicketWorkspaceResetDeleteError{
+		WorkspaceRoot: strings.TrimSpace(workspaceRoot),
+		Reason:        reason,
+	}
+}
+
+func sanitizeWorkspaceDeleteReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	var typed TicketWorkspaceResetDeleteError
+	if errors.As(err, &typed) {
+		return strings.TrimSpace(typed.Reason)
+	}
+
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "errsymlink") || strings.Contains(lower, "panic=error method") {
+		return "permission denied or unreadable path while deleting workspace contents; check ownership of package-manager directories such as node_modules"
+	}
+	if errors.Is(err, filesysteminfra.ErrUnsafePath) {
+		return "workspace path failed safety checks; refuse to delete outside the configured workspace root"
+	}
+	if errors.Is(err, filesysteminfra.ErrDeleteFailed) || errors.Is(err, os.ErrPermission) {
+		return extractActionableDeleteDetail(err)
+	}
+
+	return extractActionableDeleteDetail(err)
+}
+
+func extractActionableDeleteDetail(err error) string {
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		return "workspace deletion failed"
+	}
+	if strings.Contains(strings.ToLower(message), "permission denied") {
+		return message
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && pathErr.Path != "" {
+		op := strings.TrimSpace(pathErr.Op)
+		if op == "" {
+			op = "remove"
+		}
+		if errors.Is(pathErr.Err, os.ErrPermission) {
+			return fmt.Sprintf("permission denied on %s (%s)", pathErr.Path, op)
+		}
+		return fmt.Sprintf("%s %s: %v", op, pathErr.Path, pathErr.Err)
+	}
+	return message
+}
+
+func userVisibleWorkspaceDeleteMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	var typed TicketWorkspaceResetDeleteError
+	if errors.As(err, &typed) {
+		return typed.Error()
+	}
+	return sanitizeWorkspaceDeleteReason(err)
+}

--- a/internal/orchestrator/workspace_reset_errors.go
+++ b/internal/orchestrator/workspace_reset_errors.go
@@ -63,10 +63,6 @@ func sanitizeWorkspaceDeleteReason(err error) string {
 	if errors.Is(err, filesysteminfra.ErrUnsafePath) {
 		return "workspace path failed safety checks; refuse to delete outside the configured workspace root"
 	}
-	if errors.Is(err, filesysteminfra.ErrDeleteFailed) || errors.Is(err, os.ErrPermission) {
-		return extractActionableDeleteDetail(err)
-	}
-
 	return extractActionableDeleteDetail(err)
 }
 

--- a/internal/orchestrator/workspace_reset_errors_test.go
+++ b/internal/orchestrator/workspace_reset_errors_test.go
@@ -1,0 +1,43 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	filesysteminfra "github.com/BetterAndBetterII/openase/internal/infra/filesystem"
+)
+
+func TestSanitizeWorkspaceDeleteReasonErrSymlinkLeak(t *testing.T) {
+	t.Parallel()
+
+	leaked := fmt.Errorf(
+		"remove local workspace /tmp/ws: %%!v(PANIC=Error method: errSymlink is not user-visible)",
+	)
+	got := sanitizeWorkspaceDeleteReason(leaked)
+	if strings.Contains(strings.ToLower(got), "errsymlink") || strings.Contains(got, "PANIC=") {
+		t.Fatalf("sanitizeWorkspaceDeleteReason() = %q, want user-visible message", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "permission") {
+		t.Fatalf("sanitizeWorkspaceDeleteReason() = %q, want permission guidance", got)
+	}
+}
+
+func TestClassifyLocalWorkspaceDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	root := "/tmp/ticket-ws"
+	wrapped := fmt.Errorf("remove local workspace %s: %w", root, filesysteminfra.ErrDeleteFailed)
+	got := classifyLocalWorkspaceDeleteFailure(root, wrapped)
+	var typed TicketWorkspaceResetDeleteError
+	if !errors.As(got, &typed) {
+		t.Fatalf("classifyLocalWorkspaceDeleteFailure() = %T, want TicketWorkspaceResetDeleteError", got)
+	}
+	if typed.WorkspaceRoot != root {
+		t.Fatalf("WorkspaceRoot = %q, want %q", typed.WorkspaceRoot, root)
+	}
+	if strings.TrimSpace(typed.Reason) == "" {
+		t.Fatal("expected non-empty Reason")
+	}
+}

--- a/internal/orchestrator/workspace_reset_service.go
+++ b/internal/orchestrator/workspace_reset_service.go
@@ -169,7 +169,7 @@ func (s *TicketWorkspaceResetService) resetCleanupTarget(
 	}
 
 	if err := s.provisioner.removeWorkspaceRoot(ctx, machine, remote, target.workspaceRoot); err != nil {
-		trimmedError := strings.TrimSpace(err.Error())
+		trimmedError := userVisibleWorkspaceDeleteMessage(err)
 		if _, updateErr := s.client.TicketRepoWorkspace.Update().
 			Where(entticketrepoworkspace.IDIn(target.workspaceIDs...)).
 			SetState(entticketrepoworkspace.StateFailed).

--- a/scripts/ci/remote_runtime_container_harness.sh
+++ b/scripts/ci/remote_runtime_container_harness.sh
@@ -67,6 +67,9 @@ export OPENASE_RUN_REMOTE_RUNTIME_CONTAINER_TESTS=1
 export OPENASE_TEST_OPENASE_BINARY="$OPENASE_BINARY"
 export OPENASE_TEST_REMOTE_RUNTIME_COMPOSE_FILE="$COMPOSE_FILE"
 export OPENASE_REMOTE_RUNTIME_ARTIFACT_DIR="$ARTIFACT_DIR"
+# Compose defaults OPENASE_TEST_UID/GID to 0 when unset; pass caller IDs so bind mounts are not root-owned.
+export OPENASE_TEST_UID="${OPENASE_TEST_UID:-$(id -u)}"
+export OPENASE_TEST_GID="${OPENASE_TEST_GID:-$(id -g)}"
 
 if [ "$#" -eq 0 ]; then
   set -- listener reverse ssh


### PR DESCRIPTION
## Summary

## ASE-499 / #835: Local workspace reset opaque `errSymlink` error

### Problem
`POST .../workspace/reset` returned HTTP 500 with `remove local workspace ...: %!v(PANIC=Error method: errSymlink is not user-visible)` when the workspace contained root-owned, non-writable pnpm `node_modules` (symlinks under `.pnpm`). Bare `os.RemoveAll` on Go 1.26.x could surface internal `errSymlink` text instead of a permission/path message.

### Changes
1. **`internal/infra/filesystem/safe_delete.go`** — `RemoveTree` walks the tree, unlinks symlink entries explicitly (pnpm-style trees), and returns normal `permission denied` / path errors.
2. **`runtime_workspace_provisioner.removeWorkspaceRoot`** — uses `filesystem.RemoveTree` after workspace root resolution (replaces `os.RemoveAll`).
3. **`workspace_reset_errors.go` + `workspace_reset_service`** — `TicketWorkspaceResetDeleteError`, sanitization of panic/internal strings, stable user-visible `LastError` text.
4. **`ticket_api.handleResetTicketWorkspace`** — workspace delete failures → **409** `WORKSPACE_RESET_DELETE_FAILED` with actionable message (conflicts remain `WORKSPACE_RESET_CONFLICT`).
5. **Tests** — `safe_delete_pnpm_test.go`, `runtime_workspace_provisioner_remove_test.go`, `workspace_reset_errors_test.go`, `ticket_api_workspace_reset_test.go`.
6. **`scripts/ci/remote_runtime_container_harness.sh`** — exports `OPENASE_TEST_UID`/`GID` to reduce root-owned workspace artifacts in remote CI.

### Verification
- `go build ./...` and `go test ./internal/infra/filesystem/ -count=1` pass in the agent container.
- Orchestrator/HTTP tests that use embedded Postgres are skipped/fail as **root** here (`initdb`); run locally:
  `./scripts/ci/with_clean_openase_test_env.sh go test ./internal/orchestrator/ -run 'TestRemoveWorkspaceRoot|TestSanitize|TestClassify|TestTicketWorkspaceReset' -count=1`
  and `go test ./internal/httpapi/ -run TestHandleResetTicketWorkspaceDeleteFailure -count=1`

### Commit
`c2e5961f` on branch `berserk/60e134e0-6ebf-4f8b-b5c1-b2a95025bc07` (pushed to `origin`).

## Commit

c2e5961f

## Branch

berserk/60e134e0-6ebf-4f8b-b5c1-b2a95025bc07

Fixes #835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PacificStudio/codesmith/openase/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785174933&installation_id=133051282&pr_number=846&repository=PacificStudio%2Fopenase&return_to=https%3A%2F%2Fgithub.com%2FPacificStudio%2Fopenase%2Fpull%2F846&signature=aebc92a5c5279581285677601c07d7bc50f5107d92da1bb77fc5f68c9fa70de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->